### PR TITLE
Feat: notify user that the menubar icon can be temporarily show by openning the app

### DIFF
--- a/DockDoor/Views/Settings/SettingsView.swift
+++ b/DockDoor/Views/Settings/SettingsView.swift
@@ -33,8 +33,17 @@ struct SettingsView: View {
             Toggle(isOn: $showMenuBarIcon, label: {
                 Text("Show Menu Bar Icon")
             })
-            .onChange(of: showMenuBarIcon) { _, _ in restartApplication() }
-
+            .onChange(of: showMenuBarIcon) { _, isOn in
+                if !isOn {
+                    let alert = NSAlert()
+                    alert.messageText = "Menu Bar Icon Hidden"
+                    alert.informativeText = "If you need to access the menu bar icon, launch the app to reveal it for 10 seconds."
+                    alert.alertStyle = .informational
+                    alert.runModal()
+                }
+                restartApplication()
+            }
+            
             SizePickerView()
             
             HStack {


### PR DESCRIPTION
![CleanShot 2024-06-30 at 20 13 14@2x](https://github.com/ejbills/DockDoor/assets/78599753/08ae0c8c-1b6d-4842-bd08-edbfcb8cfdfa)
