### PR TITLE
Feat: change showMenuBarIcon setting without restarting the app

### DIFF
--- a/DockDoor/Views/Settings/SettingsView.swift
+++ b/DockDoor/Views/Settings/SettingsView.swift
@@ -33,9 +33,16 @@ struct SettingsView: View {
             Toggle(isOn: $showMenuBarIcon, label: {
                 Text("Show Menu Bar Icon")
             })
-            .onChange(of: showMenuBarIcon) { _, isOn in 
+            .onChange(of: showMenuBarIcon) { _, isOn in
+                let delegate = NSApplication.shared.delegate as! AppDelegate
+                delegate.updateMenuBarIconStatus()
+                
                 if !isOn {
-                    MessageUtil.showMessage(title: "Menu Bar Icon Hidden", message: "If you need to access the menu bar icon, launch the app to reveal it for 10 seconds. Will take effect on next launch.", completion: { _ in })
+                    MessageUtil.showMessage(title: "Menu Bar Icon Hidden", message: "If you need to access the menu bar icon, launch the app to reveal it for 10 seconds.", completion: { result in
+                        if result == .cancel {
+                            showMenuBarIcon = true
+                        }
+                    })
                 }
             }
 


### PR DESCRIPTION
For good UX, we should apply setting changes immediately when possible