### PR TITLE
Fix openScreenRecordingPreferences

### DIFF
--- a/DockDoor/Utilities/SystemPreferencesHelper.swift
+++ b/DockDoor/Utilities/SystemPreferencesHelper.swift
@@ -13,6 +13,6 @@ class SystemPreferencesHelper {
     }
 
     static func openScreenRecordingPreferences() {
-        NSWorkspace.shared.open(URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenRecording")!)
+        NSWorkspace.shared.open(URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture")!)
     }
 }


### PR DESCRIPTION
The previous address opened the main Security page and not the Screen Recording page

Tested on macOS 14.5, it may be different in older versions, but currently the project runs on macOS 14 only