### PR TITLE
Feat: set minimum width for settings window

### DIFF
--- a/DockDoor/Views/Settings/PermView.swift
+++ b/DockDoor/Views/Settings/PermView.swift
@@ -100,7 +100,8 @@ struct PermView: View {
 
             Spacer()
         }
-        .padding(20)
+        .padding([.top, .leading, .trailing], 20)
+        .frame(minWidth: 600)
     }
     
     private func openAccessibilityPreferences() {

--- a/DockDoor/Views/Settings/UpdateView.swift
+++ b/DockDoor/Views/Settings/UpdateView.swift
@@ -56,5 +56,6 @@ struct CheckForUpdatesView: View {
             Spacer()
         }
         .padding(20)
+        .frame(minWidth: 600)
     }
 }


### PR DESCRIPTION
Current situation: the window jumps between different sizes sharply, and in the last two tabs the transition back to the first tabs is cumbersome:

https://github.com/ejbills/DockDoor/assets/78599753/7ceb1b71-a319-4b35-910c-bddfdbed1d6b

Suggested in this PR - minimum 600px width:

https://github.com/ejbills/DockDoor/assets/78599753/31765a4d-3c95-4b70-8a0c-5c8efb17991e

