### PR TITLE
Feat: add full-screen toggle button to preview window

### DIFF
--- a/DockDoor/Utilities/WindowUtil.swift
+++ b/DockDoor/Utilities/WindowUtil.swift
@@ -183,6 +183,19 @@ final class WindowUtil {
         }
     }
     
+    /// Toggles the full-screen state of a window.
+    static func toggleFullScreen(windowInfo: WindowInfo) {
+        let kAXFullscreenAttribute = "AXFullScreen" as CFString
+        var isCurrentlyInFullScreen: CFTypeRef?
+        
+        let currentState = AXUIElementCopyAttributeValue(windowInfo.axElement, kAXFullscreenAttribute, &isCurrentlyInFullScreen)
+        if currentState == .success {
+            if let isFullScreen = isCurrentlyInFullScreen as? Bool {
+                AXUIElementSetAttributeValue(windowInfo.axElement, kAXFullscreenAttribute, !isFullScreen as CFBoolean)
+            }
+        }
+    }
+    
     /// Brings a window to the front and focuses it.
     static func bringWindowToFront(windowInfo: WindowInfo) {
         let raiseResult = AXUIElementPerformAction(windowInfo.axElement, kAXRaiseAction as CFString)

--- a/DockDoor/Views/HoverWindow.swift
+++ b/DockDoor/Views/HoverWindow.swift
@@ -541,6 +541,23 @@ struct WindowPreview: View {
                     .buttonStyle(.plain)
                     .font(.system(size: 13))
                     
+                    Button(action: {
+                        WindowUtil.toggleFullScreen(windowInfo: windowInfo)
+                        onTap?()
+                    }) {
+                        ZStack {
+                            Image(systemName: "circle.fill")
+                                .foregroundStyle(.secondary)
+                            Image(systemName: "arrow.up.left.and.arrow.down.right.circle")
+                        }
+                    }
+                    .buttonBorderShape(.roundedRectangle)
+                    .foregroundStyle(.green)
+                    .shadow(radius: 3)
+                    .buttonStyle(.plain)
+                    .font(.system(size: 13))
+                    
+                    
                     Spacer()
                     
                     if let windowTitle = windowInfo.window?.title, !windowTitle.isEmpty {


### PR DESCRIPTION
Currently we don't support windows in full screen so there is no need for a "toggle", but in the future we will, so I built it as a toggle and not as "enterFullScreen"

SF Symbols doesn't seem to include the exact full screen icon that apple uses, but it's very similar. I checked in alt-tab-macos and it [uses](https://github.com/lwouis/alt-tab-macos/blob/master/src/ui/generic-components/TrafficLightButton.swift#L120-L133) a custom drawing, which I'm not sure if the different license (GPL-3.0 vs MIT) allows us to copy.

Demo:

![CleanShot 2024-07-01 at 10 43 56@2x](https://github.com/ejbills/DockDoor/assets/78599753/e5f9ed8c-0614-4888-aa75-53dc58d92c20)


https://github.com/ejbills/DockDoor/assets/78599753/25654e49-080a-4bad-af49-b6a22109c805

