### PR TITLE
Feat: Hide the window title in the preview window if it's the same as the app name

### DIFF
--- a/DockDoor/Views/HoverWindow.swift
+++ b/DockDoor/Views/HoverWindow.swift
@@ -543,7 +543,7 @@ struct WindowPreview: View {
                     
                     Spacer()
                     
-                    if let windowTitle = windowInfo.window?.title, !windowTitle.isEmpty {
+                    if let windowTitle = windowInfo.window?.title, !windowTitle.isEmpty, windowTitle != windowInfo.appName {
                         let maxLabelWidth = calculatedSize.width - 150
                         let stringMeasurementWidth = measureString(windowTitle, fontSize: 12).width + 5
                         let width = maxLabelWidth > stringMeasurementWidth ? stringMeasurementWidth : maxLabelWidth


### PR DESCRIPTION
Motivation: The display of the window title in the preview is intended to add more information to the user, but in the case that the window title is exactly the name of the application and nothing more, it is actually an unnecessary duplication of information, which may also hide important parts of the preview.

<img src="https://github.com/ejbills/DockDoor/assets/78599753/36778c63-d7b9-46df-8d7f-8fcf9817d63a" width="250">
