### PR TITLE
Feat: Remove unnecessary ".00" in Window Cache Lifespan

### DIFF
--- a/DockDoor/Views/Settings/SettingsView.swift
+++ b/DockDoor/Views/Settings/SettingsView.swift
@@ -56,7 +56,7 @@ struct SettingsView: View {
             }
             
             HStack {
-                Text("Window Cache Lifespan: \(screenCaptureCacheLifespan, specifier: "%.2f") seconds")
+                Text("Window Cache Lifespan: \(screenCaptureCacheLifespan, specifier: "%.0f") seconds")
                 Spacer()
                 Slider(value: $screenCaptureCacheLifespan, in: 0...60, step: 5)
             }


### PR DESCRIPTION
The number can never be decimal because the slider uses steps of 5