### PR TITLE
Feat: add quit app button to preview window

### DIFF
--- a/DockDoor/Utilities/WindowUtil.swift
+++ b/DockDoor/Utilities/WindowUtil.swift
@@ -240,6 +240,27 @@ final class WindowUtil {
         }
     }
     
+    /// Terminates the window's application.
+    static func quitApp(windowInfo: WindowInfo, force: Bool) {
+        guard let pid = windowInfo.window?.owningApplication?.processID else {
+            print("Application not found")
+            NSSound.beep()
+            return
+        }
+        
+        guard let app = NSRunningApplication(processIdentifier: pid) else {
+            print("No running application associated with PID \(pid)")
+            NSSound.beep()
+            return
+        }
+        
+        if force {
+            app.forceTerminate()
+        } else {
+            app.terminate()
+        }
+    }
+    
     // MARK: - Minimized Window Handling
     
     /// Retrieves minimized windows' information for a given process ID, bundle ID, and app name.

--- a/DockDoor/Views/HoverWindow.swift
+++ b/DockDoor/Views/HoverWindow.swift
@@ -511,6 +511,21 @@ struct WindowPreview: View {
             if !windowInfo.isMinimized, let closeButton = windowInfo.closeButton {
                 HStack(alignment:.top, spacing: 6) {
                     Button(action: {
+                        WindowUtil.quitApp(windowInfo: windowInfo, force: NSEvent.modifierFlags.contains(.option))
+                        onTap?()
+                    }) {
+                        ZStack {
+                            Image(systemName: "circle.fill")
+                                .foregroundStyle(.secondary)
+                            Image(systemName: "power.circle.fill")
+                        }
+                    }
+                    .buttonBorderShape(.roundedRectangle)
+                    .foregroundStyle(.purple)
+                    .buttonStyle(.plain)
+                    .font(.system(size: 13))
+                    
+                    Button(action: {
                         WindowUtil.closeWindow(closeButton: closeButton)
                         onTap?()
                     }) {


### PR DESCRIPTION
Adds a button to quit the application, as can be done by right-clicking on the application icon in the Dock
![CleanShot 2024-07-03 at 01 07 32@2x](https://github.com/ejbills/DockDoor/assets/78599753/6474660e-b163-45f3-915c-c2bf639f5c59)

Pressing normally = soft quit, pressing with alt (option) pressed = force quit. 
It imitates Apple:
![CleanShot 2024-07-03 at 01 32 37](https://github.com/ejbills/DockDoor/assets/78599753/d4df9ed7-6ab6-4f40-9121-21c3efd8e25a)