### PR TITLE
feat(preview): improve app label shadow

### DIFF
--- a/DockDoor/Views/Hover Window/HoverWindow.swift
+++ b/DockDoor/Views/Hover Window/HoverWindow.swift
@@ -350,33 +350,11 @@ struct HoverView: View {
                         .fontWeight(.medium)
                         .font(.system(size: 14))
                         .padding(.horizontal, 4)
-                        .shadow(stacked: 2, radius: 6)
-                        .background(
-                            ZStack {
-                                MaterialBlurView(material: .hudWindow)
-                                    .mask(
-                                        Ellipse()
-                                            .fill(
-                                                LinearGradient(
-                                                    gradient: Gradient(
-                                                        colors: [
-                                                            Color.white.opacity(1.0),
-                                                            Color.white.opacity(0.35)
-                                                        ]
-                                                    ),
-                                                    startPoint: .top,
-                                                    endPoint: .bottom
-                                                )
-                                            )
-                                    )
-                                    .blur(radius: 5)
-                            }
-                                .frame(width: appNameLabelSize.width + 30)
-                        )
                 }
                 .padding(.horizontal, 3)
                 .padding(.vertical, 1.5)
                 .padding(EdgeInsets(top: -13, leading: 6, bottom: 0, trailing: 0))
+                .shadow(stacked: 2, radius: 6)
             }
         }
         .padding(.all, 24)


### PR DESCRIPTION
1. Fixed excessive shadow with dark theme
2. Applies the shadow to the app icon as well

![CleanShot 2024-07-07 at 00 01 18@2x](https://github.com/ejbills/DockDoor/assets/78599753/5147fbe1-cf2c-4dd1-befa-b7cbadd3204a)
![CleanShot 2024-07-07 at 00 10 58@2x](https://github.com/ejbills/DockDoor/assets/78599753/a2e8380a-cea8-4316-be4f-e5b9baae6fec)
