### PR TITLE
fix: preview image radius

### DIFF
--- a/DockDoor/Views/Hover Window/WindowPreview.swift
+++ b/DockDoor/Views/Hover Window/WindowPreview.swift
@@ -97,7 +97,7 @@ struct WindowPreview: View {
             VStack(spacing: 0) {
                 windowContent(isMinimized: windowInfo.isMinimized, isHidden: windowInfo.isHidden, isSelected: selected)
                     .overlay { Color.white.opacity(isHoveringOverTabMenu ? 0.1 : 0) }
-                    .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+                    .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
                     .shadow(radius: selected || isHoveringOverTabMenu ? 0 : 3)
                     .background {
                         RoundedRectangle(cornerRadius: 6, style: .continuous)


### PR DESCRIPTION
Before:
When using a dark theme in System Settings, there are white corners around the preview image
![CleanShot 2024-07-07 at 05 21 35@2x](https://github.com/ejbills/DockDoor/assets/78599753/4498b3b0-4133-4b0e-8cee-9afdc2aff877)
![CleanShot 2024-07-07 at 05 21 39@2x](https://github.com/ejbills/DockDoor/assets/78599753/5c8087a3-908e-4998-9e1f-fbe7c01e96c8)
After:
![CleanShot 2024-07-07 at 05 18 19@2x](https://github.com/ejbills/DockDoor/assets/78599753/54c50e4d-8359-411b-8b65-009b2cb564f0)
![CleanShot 2024-07-07 at 05 20 19@2x](https://github.com/ejbills/DockDoor/assets/78599753/576f7f7a-5e6a-4a29-b1bc-e79145f8afd5)
