### PR TITLE
fix: show menu bar icon only on app reopen, not on interact

### DIFF
--- a/DockDoor/AppDelegate.swift
+++ b/DockDoor/AppDelegate.swift
@@ -37,6 +37,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
     
     func applicationDidFinishLaunching(_ aNotification: Notification) {
+        self.setupMenuBar()
+        if !Defaults[.showMenuBarIcon] {
+            self.scheduleMenuBarIconVisibilityUpdate()
+        }
+        
         if !Defaults[.launched] {
             handleFirstTimeLaunch()
         } else {
@@ -48,15 +53,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
     
-    func applicationDidBecomeActive(_ notification: Notification) {
+    func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
         self.setupMenuBar()
-        
-        // Schedule a timer to remove the menu bar icon after 10 seconds if it's turned off
         if !Defaults[.showMenuBarIcon] {
-            DispatchQueue.main.asyncAfter(deadline: .now() + 10) {
-                self.updateMenuBarIconStatus()
-            }
+            self.scheduleMenuBarIconVisibilityUpdate()
         }
+        
+        return false
     }
     
     private func setupMenuBar() {
@@ -85,6 +88,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             menu.addItem(quitMenuItem)
             
             button.menu = menu
+        }
+    }
+    
+    private func scheduleMenuBarIconVisibilityUpdate() {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 10) {
+            self.updateMenuBarIconStatus()
         }
     }
     

--- a/DockDoor/AppDelegate.swift
+++ b/DockDoor/AppDelegate.swift
@@ -40,19 +40,21 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         if !Defaults[.launched] {
             handleFirstTimeLaunch()
         } else {
-            self.setupMenuBar()
-            
-            // Schedule a timer to remove the menu bar icon after 10 seconds if it's turned off
-            if !Defaults[.showMenuBarIcon] {
-                DispatchQueue.main.asyncAfter(deadline: .now() + 10) {
-                    self.updateMenuBarIconStatus()
-                }
-            }
-            
             dockObserver = DockObserver.shared
             appClosureObserver = AppClosureObserver.shared
             if Defaults[.enableWindowSwitcher] {
                 keybindHelper = KeybindHelper.shared
+            }
+        }
+    }
+    
+    func applicationDidBecomeActive(_ notification: Notification) {
+        self.setupMenuBar()
+        
+        // Schedule a timer to remove the menu bar icon after 10 seconds if it's turned off
+        if !Defaults[.showMenuBarIcon] {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 10) {
+                self.updateMenuBarIconStatus()
             }
         }
     }


### PR DESCRIPTION
Moved initialization from `applicationDidBecomeActive` (https://github.com/ejbills/DockDoor/pull/90) to `applicationShouldHandleReopen` to ensure the menu bar icon is only shown when the app is reopened, and not on other interactions.
Credit: https://github.com/sindresorhus/System-Color-Picker

closes https://github.com/ejbills/DockDoor/issues/95, closes https://github.com/ejbills/DockDoor/issues/76