### PR TITLE
Feature: Hover Window Title Style

### DIFF
--- a/DockDoor/Views/Settings/SettingsView.swift
+++ b/DockDoor/Views/Settings/SettingsView.swift
@@ -15,6 +15,7 @@ struct SettingsView: View {
     @Default(.showAnimations) var showAnimations
     @Default(.showMenuBarIcon) var showMenuBarIcon
     @Default(.uniformCardRadius) var uniformCardRadius
+    @Default(.hoverTitleStyle) var hoverTitleStyle
     
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
@@ -53,6 +54,13 @@ struct SettingsView: View {
             }
 
             SizePickerView()
+            
+            Picker("Hover Window Title Style", selection: $hoverTitleStyle) {
+                ForEach(HoverView.TitleStyle.allCases, id: \.self) { style in
+                    Text(style.titleString)
+                        .tag(style.rawValue)
+                }
+            }
             
             HStack {
                 Text("Hover Window Open Delay: \(openDelay, specifier: "%.2f") seconds")

--- a/DockDoor/consts.swift
+++ b/DockDoor/consts.swift
@@ -31,4 +31,5 @@ extension Defaults.Keys {
     static let Int64maskControl = Key<Int>("Int64maskControl") { 262401 }
     static let Int64maskAlternate = Key<Int>("Int64maskAlternate") { 524576 }
     static let UserKeybind = Key<UserKeyBind>("UserKeybind", default: UserKeyBind(keyCode: 48, modifierFlags: Defaults[.Int64maskControl]))
+    static let hoverTitleStyle = Key<Int>("hoverTitleStyle") { 0 }
 }


### PR DESCRIPTION
Adds options to configure the Hover Window Title Style.

- Adds Settings option for "Hover Window Title Style"
  - Default, Embedded, Popover, and None
- Somewhat breaks HoverView into manageable subviews

Examples:

Embedded:
<img width="295" alt="Screenshot 2024-07-08 at 7 03 46 PM" src="https://github.com/ejbills/DockDoor/assets/56522199/d47b5c48-e1c1-4a22-a746-a88ce893a3e5">

Popover:
<img width="294" alt="Screenshot 2024-07-08 at 7 04 22 PM" src="https://github.com/ejbills/DockDoor/assets/56522199/6da827d7-1376-4990-85d5-7ef7c6c73b35">
