### PR TITLE
feat: use "hidden" word for window title hidden style

### DIFF
--- a/DockDoor/Localization/Localizable.xcstrings
+++ b/DockDoor/Localization/Localizable.xcstrings
@@ -381,7 +381,7 @@
         }
       }
     },
-    "None" : {
+    "Hidden" : {
       "comment" : "Preview title style option",
       "localizations" : {
         "he" : {

--- a/DockDoor/Views/Hover Window/HoverWindow.swift
+++ b/DockDoor/Views/Hover Window/HoverWindow.swift
@@ -275,7 +275,7 @@ struct HoverView: View {
         case `default` = 0
         case embedded = 1
         case popover = 2
-        case none = -1
+        case hidden = -1
         
         var titleString: String {
             switch self {
@@ -285,8 +285,8 @@ struct HoverView: View {
                 return String(localized: "Embedded", comment: "Preview title style option")
             case .popover:
                 return String(localized: "Popover", comment: "Preview title style option")
-            case .none:
-                return String(localized: "None", comment: "Preview title style option")
+            case .hidden:
+                return String(localized: "Hidden", comment: "Preview title style option")
             }
         }
     }


### PR DESCRIPTION
"None" sounds to the user a title without formatting, when in fact it is no title at all, so "Hidden" would be more obvious.