### PR TITLE
fix: release notes in dark mode

### DIFF
--- a/.github/workflows/update-chnagelog.yml
+++ b/.github/workflows/update-chnagelog.yml
@@ -20,7 +20,25 @@ jobs:
           commit_summary_template: "chore: update changelog for %s"
           header: |
             <style>
-                h1:first-of-type { display: none; }
-                .my-5 { margin: unset !important; }
+              h1:first-of-type {
+                  display: none;
+              }
+              .my-5 {
+                  margin: unset !important;
+              }
+              
+              @media (prefers-color-scheme: dark) {
+                  body {
+                      color-scheme: dark;
+                      color: white;
+                      background: transparent;
+                  }
+                  a, :link {
+                      color: #419cff;
+                  }
+                  a:active, link:active {
+                      color: #ff1919;
+                  }
+              }
             </style>
             


### PR DESCRIPTION
it's just https://github.com/sparkle-project/Sparkle/blob/2.x/Resources/ReleaseNotesColorStyle.css with a little more specific selectors to overwrite jekyll style

closes https://github.com/ejbills/DockDoor/issues/123