### PR TITLE
fix: Chrome PWA's

### DIFF
--- a/DockDoor.xcodeproj/project.pbxproj
+++ b/DockDoor.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		0531F8D22C3CC04600327808 /* AppearanceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0531F8D12C3CC04600327808 /* AppearanceView.swift */; };
+		0596C2C32C3E060D00DCABEF /* PrivateApis.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0596C2C22C3E060D00DCABEF /* PrivateApis.swift */; };
 		3A105FD62C1BED660015EC66 /* BlurView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A105FD52C1BED660015EC66 /* BlurView.swift */; };
 		3A105FD92C1C049E0015EC66 /* dockStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A105FD82C1C049E0015EC66 /* dockStyle.swift */; };
 		3A105FDD2C1C0EE20015EC66 /* DynStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A105FDC2C1C0EE20015EC66 /* DynStack.swift */; };
@@ -48,6 +49,7 @@
 /* Begin PBXFileReference section */
 		0531F8D12C3CC04600327808 /* AppearanceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppearanceView.swift; sourceTree = "<group>"; };
 		0531F8E22C3CC0E200327808 /* AppearanceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppearanceView.swift; path = DockDoor/Views/Settings/AppearanceView.swift; sourceTree = "<group>"; };
+		0596C2C22C3E060D00DCABEF /* PrivateApis.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivateApis.swift; sourceTree = "<group>"; };
 		3A105FD52C1BED660015EC66 /* BlurView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlurView.swift; sourceTree = "<group>"; };
 		3A105FD82C1C049E0015EC66 /* dockStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = dockStyle.swift; sourceTree = "<group>"; };
 		3A105FDC2C1C0EE20015EC66 /* DynStack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynStack.swift; sourceTree = "<group>"; };
@@ -167,6 +169,7 @@
 		BB157B772C0E32EF00997315 /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
+				0596C2C22C3E060D00DCABEF /* PrivateApis.swift */,
 				BB2567C52C10C5F000C0C93E /* DockUtils.swift */,
 				BB157B782C0E330100997315 /* WindowUtil.swift */,
 				BB157B7A2C0E343000997315 /* SystemPreferencesHelper.swift */,
@@ -326,6 +329,7 @@
 				BBA153F82C11604400119C02 /* HoverWindow.swift in Sources */,
 				BBA153FC2C12356100119C02 /* main.swift in Sources */,
 				BBF6C6242C1B4B4400BF1D40 /* KeybindHelper.swift in Sources */,
+				0596C2C32C3E060D00DCABEF /* PrivateApis.swift in Sources */,
 				3A105FDD2C1C0EE20015EC66 /* DynStack.swift in Sources */,
 				BB4ED9092C3CD97400BBDD16 /* Traffic Light Buttons.swift in Sources */,
 				C119BDF22C2AFA7600E06E18 /* WindowSwitcher.swift in Sources */,

--- a/DockDoor/Utilities/PrivateApis.swift
+++ b/DockDoor/Utilities/PrivateApis.swift
@@ -1,0 +1,13 @@
+//
+//  PrivateApis.swift
+//  DockDoor
+//
+//  Created by ShlomoCode on 10/07/2024.
+//
+
+import Cocoa
+
+// returns the CGWindowID of the provided AXUIElement
+// * macOS 10.10+
+@_silgen_name("_AXUIElementGetWindow") @discardableResult
+func _AXUIElementGetWindow(_ axUiElement: AXUIElement, _ wid: inout CGWindowID) -> AXError

--- a/DockDoor/Utilities/WindowUtil.swift
+++ b/DockDoor/Utilities/WindowUtil.swift
@@ -116,6 +116,12 @@ final class WindowUtil {
     /// Finds a window by its name in the provided AXUIElement windows.
     static func findWindow(matchingWindow window: SCWindow, in axWindows: [AXUIElement]) -> AXUIElement? {
         for axWindow in axWindows {
+            var cgWindowId: CGWindowID = 0
+            let windowIDStatus = _AXUIElementGetWindow(axWindow, &cgWindowId)
+            if windowIDStatus == .success && window.windowID == cgWindowId {
+                return axWindow
+            }
+            
             var axTitle: CFTypeRef?
             AXUIElementCopyAttributeValue(axWindow, kAXTitleAttribute as CFString, &axTitle)
             let axTitleString = (axTitle as? String) ?? ""


### PR DESCRIPTION
findWindow (find windowRef (AX Window) by `SCWindow`) using `_AXUIElementGetWindow` closes https://github.com/ejbills/DockDoor/issues/75