### PR TITLE
feat: make traffic lights button symbols colored like macOS buttons

### DIFF
--- a/DockDoor.xcodeproj/project.pbxproj
+++ b/DockDoor.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		0531F8D22C3CC04600327808 /* AppearanceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0531F8D12C3CC04600327808 /* AppearanceView.swift */; };
 		0596C2C32C3E060D00DCABEF /* PrivateApis.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0596C2C22C3E060D00DCABEF /* PrivateApis.swift */; };
+		05A25B912C3EF28E002AC594 /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05A25B902C3EF28E002AC594 /* Extensions.swift */; };
 		3A105FD62C1BED660015EC66 /* BlurView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A105FD52C1BED660015EC66 /* BlurView.swift */; };
 		3A105FD92C1C049E0015EC66 /* dockStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A105FD82C1C049E0015EC66 /* dockStyle.swift */; };
 		3A105FDD2C1C0EE20015EC66 /* DynStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A105FDC2C1C0EE20015EC66 /* DynStack.swift */; };
@@ -50,6 +51,7 @@
 		0531F8D12C3CC04600327808 /* AppearanceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppearanceView.swift; sourceTree = "<group>"; };
 		0531F8E22C3CC0E200327808 /* AppearanceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppearanceView.swift; path = DockDoor/Views/Settings/AppearanceView.swift; sourceTree = "<group>"; };
 		0596C2C22C3E060D00DCABEF /* PrivateApis.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivateApis.swift; sourceTree = "<group>"; };
+		05A25B902C3EF28E002AC594 /* Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
 		3A105FD52C1BED660015EC66 /* BlurView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlurView.swift; sourceTree = "<group>"; };
 		3A105FD82C1C049E0015EC66 /* dockStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = dockStyle.swift; sourceTree = "<group>"; };
 		3A105FDC2C1C0EE20015EC66 /* DynStack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynStack.swift; sourceTree = "<group>"; };
@@ -179,6 +181,7 @@
 				BB1CBD5C2C1BCA4F003969BC /* Misc Utils.swift */,
 				BBE7CC932C225D9700AB8F4D /* App Icon.swift */,
 				BB7CA33C2C31F1B00012E303 /* WindowClosureObservers.swift */,
+				05A25B902C3EF28E002AC594 /* Extensions.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -320,6 +323,7 @@
 				BB157B802C0E8E6700997315 /* MessageUtil.swift in Sources */,
 				3A105FD62C1BED660015EC66 /* BlurView.swift in Sources */,
 				BB1CBD5D2C1BCA4F003969BC /* Misc Utils.swift in Sources */,
+				05A25B912C3EF28E002AC594 /* Extensions.swift in Sources */,
 				3A105FD92C1C049E0015EC66 /* dockStyle.swift in Sources */,
 				BBE7CC942C225D9700AB8F4D /* App Icon.swift in Sources */,
 				BB3968022C2A6CC2004F1AB6 /* Marquee.swift in Sources */,

--- a/DockDoor/Utilities/Extensions.swift
+++ b/DockDoor/Utilities/Extensions.swift
@@ -1,0 +1,35 @@
+//
+//  Extensions.swift
+//  DockDoor
+//
+//  Created by ShlomoCode on 10/07/2024.
+//
+
+import SwiftUI
+
+extension Color {
+    init(hex: String) {
+        let hex = hex.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
+        var int: UInt64 = 0
+        Scanner(string: hex).scanHexInt64(&int)
+        let a, r, g, b: UInt64
+        switch hex.count {
+        case 3: // RGB (12-bit)
+            (a, r, g, b) = (255, (int >> 8) * 17, (int >> 4 & 0xF) * 17, (int & 0xF) * 17)
+        case 6: // RGB (24-bit)
+            (a, r, g, b) = (255, int >> 16, int >> 8 & 0xFF, int & 0xFF)
+        case 8: // ARGB (32-bit)
+            (a, r, g, b) = (int >> 24, int >> 16 & 0xFF, int >> 8 & 0xFF, int & 0xFF)
+        default:
+            (a, r, g, b) = (1, 1, 1, 0)
+        }
+
+        self.init(
+            .sRGB,
+            red: Double(r) / 255,
+            green: Double(g) / 255,
+            blue:  Double(b) / 255,
+            opacity: Double(a) / 255
+        )
+    }
+}

--- a/DockDoor/Views/Hover Window/Traffic Light Buttons.swift
+++ b/DockDoor/Views/Hover Window/Traffic Light Buttons.swift
@@ -15,10 +15,10 @@ struct TrafficLightButtons: View {
     
     var body: some View {
         HStack(spacing: 6) {
-            buttonFor(action: .quit, symbol: "power", color: .purple)
-            buttonFor(action: .close, symbol: "xmark", color: .red)
-            buttonFor(action: .minimize, symbol: "minus", color: .yellow)
-            buttonFor(action: .toggleFullScreen, symbol: "arrow.up.left.and.arrow.down.right", color: .green)
+            buttonFor(action: .quit, symbol: "power", color: Color(hex: "290133"), fillColor: .purple)
+            buttonFor(action: .close, symbol: "xmark", color: Color(hex: "7e0609"), fillColor: .red)
+            buttonFor(action: .minimize, symbol: "minus", color: Color(hex: "985712"), fillColor: .yellow)
+            buttonFor(action: .toggleFullScreen, symbol: "arrow.up.left.and.arrow.down.right", color: Color(hex: "0d650d"), fillColor: .green)
         }
         .padding(4)
         .opacity(isHovering ? 1 : 0.25)
@@ -29,7 +29,7 @@ struct TrafficLightButtons: View {
         }
     }
     
-    private func buttonFor(action: WindowAction, symbol: String, color: Color) -> some View {
+    private func buttonFor(action: WindowAction, symbol: String, color: Color, fillColor: Color) -> some View {
         Button(action: {
             performAction(action)
             onAction()
@@ -41,7 +41,7 @@ struct TrafficLightButtons: View {
             }
         }
         .buttonBorderShape(.roundedRectangle)
-        .foregroundStyle(color)
+        .foregroundStyle(color, fillColor)
         .buttonStyle(.plain)
         .font(.system(size: 13))
     }


### PR DESCRIPTION
The traffic light buttons mimic those of macOS, and macOS never changes the button's icon color:

https://github.com/ejbills/DockDoor/assets/78599753/7081164a-dba3-47ce-b2b7-87584a6af29c

I checked the colors of the macOS buttons with https://github.com/sindresorhus/System-Color-Picker and set them for our buttons. For the quit button I just used dark purple:
![CleanShot 2024-07-10 at 16 59 57@2x](https://github.com/ejbills/DockDoor/assets/78599753/f05cb6e1-ea3c-4346-97e9-b8549ff86a29)

closes https://github.com/ejbills/DockDoor/issues/132