### PR TITLE
refactor(defaults): replace numeric enums with named enums; reword keys and variables

### DIFF
--- a/DockDoor/Views/Hover Window/Traffic Light Buttons.swift
+++ b/DockDoor/Views/Hover Window/Traffic Light Buttons.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct TrafficLightButtons: View {
     let windowInfo: WindowInfo
-    let displayMode: WindowPreview.TrafficLightButtonsVisibility
+    let displayMode: TrafficLightButtonsVisibility
     let hoveringOverParentWindow: Bool
     let onAction: () -> Void
     

--- a/DockDoor/Views/Hover Window/WindowPreview.swift
+++ b/DockDoor/Views/Hover Window/WindowPreview.swift
@@ -18,50 +18,13 @@ struct WindowPreview: View {
     let bestGuessMonitor: NSScreen
     let uniformCardRadius: Bool
     
-    @Default(.windowTitleAlignment) var windowTitleAlignment
-    @Default(.showTitlesOnWindows) var showTitlesOnTiles
-    @Default(.windowTitlesDisplayMode) var tileTitlesDisplayMode
-    @Default(.trafficButtonsDisplayMode) var trafficButtonsDisplayMode
+    @Default(.windowTitlePosition) var windowTitlePosition
+    @Default(.showWindowTitle) var showWindowTitle
+    @Default(.windowTitleDisplayCondition) var windowTitleDisplayCondition
+    @Default(.trafficLightButtonsVisibility) var trafficLightButtonsVisibility
     
     @State private var isHovering = false
     @State private var isHoveringOverTabMenu = false
-    
-    enum TileTitleDisplayMode: Int, CaseIterable {
-        case always = 1
-        case windowSwitcherOnly = 2
-        case dockPreviewsOnly = 3
-        
-        var titleString: String {
-            switch self {
-            case .windowSwitcherOnly:
-                String(localized: "When Using Window Switcher")
-            case .dockPreviewsOnly:
-                String(localized: "When Showing Dock Tile Previews")
-            case .always:
-                String(localized: "Always")
-            }
-        }
-    }
-    
-    enum TrafficLightButtonsVisibility: Int, CaseIterable {
-        case dimmedOnWindowHover = 1
-        case fullOpacityOnWindowHover = 2
-        case alwaysVisible = 3
-        case never = 4
-        
-        var descriptionString: String {
-            switch self {
-            case .dimmedOnWindowHover:
-                String(localized: "On window hover; Dimmed until button hover")
-            case .fullOpacityOnWindowHover:
-                String(localized: "On window hover; Full opacity")
-            case .alwaysVisible:
-                String(localized: "Always visible; Full opacity")
-            case .never:
-                String(localized: "Never visible")
-            }
-        }
-    }
     
     private var calculatedMaxDimensions: CGSize? {
         CGSize(width: self.bestGuessMonitor.frame.width * 0.75, height: self.bestGuessMonitor.frame.height * 0.75)
@@ -152,15 +115,15 @@ struct WindowPreview: View {
                     }
                     .clipShape(uniformCardRadius ? AnyShape(RoundedRectangle(cornerRadius: 6, style: .continuous)) : AnyShape(Rectangle()))
             }
-            .overlay(alignment: windowTitleAlignment ? .bottomLeading : .bottomTrailing) {
-                if  showTitlesOnTiles && ((tileTitlesDisplayMode == 1) || (tileTitlesDisplayMode == 2 && CurrentWindow.shared.showingTabMenu) || (tileTitlesDisplayMode == 3 && !CurrentWindow.shared.showingTabMenu)) {
-                        windowTitleOverlay(selected: selected)
+            .overlay(alignment: windowTitlePosition == .bottomLeft ? .bottomLeading : .bottomTrailing) {
+                if  showWindowTitle && ((windowTitleDisplayCondition == .always) || (windowTitleDisplayCondition == .windowSwitcherOnly && CurrentWindow.shared.showingTabMenu) || (windowTitleDisplayCondition == .dockPreviewsOnly && !CurrentWindow.shared.showingTabMenu)) {
+                    windowTitleOverlay(selected: selected)
                 }
             }
             .overlay(alignment: .topLeading) {
                 if !windowInfo.isMinimized, !windowInfo.isHidden, let _ = windowInfo.closeButton {
                     TrafficLightButtons(windowInfo: windowInfo,
-                                        displayMode: TrafficLightButtonsVisibility(rawValue: trafficButtonsDisplayMode) ?? .dimmedOnWindowHover,
+                                        displayMode: trafficLightButtonsVisibility,
                                         hoveringOverParentWindow: selected || isHoveringOverTabMenu,
                                         onAction: { onTap?() })
                 }

--- a/DockDoor/Views/Settings/AppearanceSettingsView.swift
+++ b/DockDoor/Views/Settings/AppearanceSettingsView.swift
@@ -12,12 +12,12 @@ import LaunchAtLogin
 struct AppearanceSettingsView: View {
     @Default(.showAnimations) var showAnimations
     @Default(.uniformCardRadius) var uniformCardRadius
-    @Default(.hoverTitleStyle) var hoverTitleStyle
-    @Default(.windowPadding) var windowPadding
-    @Default(.windowTitleAlignment) var windowTitleAlignment
-    @Default(.showTitlesOnWindows) var showTitlesOnTiles
-    @Default(.windowTitlesDisplayMode) var tileTitlesDisplayMode
-    @Default(.trafficButtonsDisplayMode) var trafficButtonsDisplayMode
+    @Default(.windowTitleStyle) var windowTitleStyle
+    @Default(.bufferFromDock) var bufferFromDock
+    @Default(.windowTitlePosition) var windowTitlePosition
+    @Default(.showWindowTitle) var showWindowTitle
+    @Default(.windowTitleDisplayCondition) var windowTitleDisplayCondition
+    @Default(.trafficLightButtonsVisibility) var trafficLightButtonsVisibility
     
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
@@ -29,49 +29,47 @@ struct AppearanceSettingsView: View {
                 Text("Use Uniform Image Preview Radius")
             })
             
-            Slider(value: $windowPadding, in: -200...200, step: 20) {
+            Slider(value: $bufferFromDock, in: -200...200, step: 20) {
                 Text("Window Buffer (if misaligned with dock)")
             }.buttonStyle(PlainButtonStyle())
             
             SizePickerView()
             
-            Picker("Hover Window Title Style", selection: $hoverTitleStyle) {
-                ForEach(HoverView.TitleStyle.allCases, id: \.self) { style in
-                    Text(style.titleString)
+            Picker("Hover Window Title Style", selection: $windowTitleStyle) {
+                ForEach(WindowTitleStyle.allCases, id: \.self) { style in
+                    Text(style.localizedName)
                         .tag(style.rawValue)
                 }
             }
             
-            Toggle(isOn: $showTitlesOnTiles) {
+            Toggle(isOn: $showWindowTitle) {
                 Text("Show Window Titles on Previews")
             }
             
             Group {
-                Picker("Show Window Titles", selection: $tileTitlesDisplayMode) {
-                    ForEach(WindowPreview.TileTitleDisplayMode.allCases, id: \.self) { style in
-                        if style == .always {
-                            Text(style.titleString)
-                                .tag(style.rawValue)
+                Picker("Show Window Titles", selection: $windowTitleDisplayCondition) {
+                    ForEach(WindowTitleDisplayCondition.allCases, id: \.self) { condtion in
+                        if condtion == .always {
+                            Text(condtion.localizedName).tag(condtion)
                             Divider() // Separate from Window Switcher & Dock Previews
                         } else {
-                            Text(style.titleString)
-                                .tag(style.rawValue)
+                            Text(condtion.localizedName).tag(condtion)
                         }
-                        
                     }
                 }
                 
-                Picker("Window Title Alignment", selection: $windowTitleAlignment) {
-                    Text("Left").tag(true)
-                    Text("Right").tag(false)
+                Picker("Window Title Position", selection: $windowTitlePosition) {
+                    ForEach(WindowTitlePosition.allCases, id: \.self) { position in
+                        Text(position.localizedName).tag(position)
+                    }
                 }
                 .pickerStyle(SegmentedPickerStyle())
             }
-            .disabled(!showTitlesOnTiles)
+            .disabled(!showWindowTitle)
             
-            Picker("Traffic Light Buttons Visibility", selection: $trafficButtonsDisplayMode) {
-                ForEach(WindowPreview.TrafficLightButtonsVisibility.allCases, id: \.self) { visibility in
-                    Text(visibility.descriptionString)
+            Picker("Traffic Light Buttons Visibility", selection: $trafficLightButtonsVisibility) {
+                ForEach(TrafficLightButtonsVisibility.allCases, id: \.self) { visibility in
+                    Text(visibility.localizedName)
                         .tag(visibility.rawValue)
                 }
             }
@@ -83,7 +81,7 @@ struct AppearanceSettingsView: View {
 
 struct SizePickerView: View {
     @Default(.sizingMultiplier) var sizingMultiplier
-    @Default(.windowPadding) var windowPadding
+    @Default(.bufferFromDock) var bufferFromDock
     
     var body: some View {
         VStack(spacing: 20) {

--- a/DockDoor/Views/Settings/MainSettingsView.swift
+++ b/DockDoor/Views/Settings/MainSettingsView.swift
@@ -10,7 +10,7 @@ import Defaults
 import LaunchAtLogin
 
 struct MainSettingsView: View {
-    @Default(.openDelay) var openDelay
+    @Default(.hoverWindowOpenDelay) var hoverWindowOpenDelay
     @Default(.screenCaptureCacheLifespan) var screenCaptureCacheLifespan
     @Default(.showMenuBarIcon) var showMenuBarIcon
     
@@ -44,9 +44,9 @@ struct MainSettingsView: View {
             }
             
             HStack {
-                Text("Hover Window Open Delay: \(openDelay, specifier: "%.1f") seconds")
+                Text("Hover Window Open Delay: \(hoverWindowOpenDelay, specifier: "%.1f") seconds")
                 Spacer()
-                Slider(value: $openDelay, in: 0...2, step: 0.1)
+                Slider(value: $hoverWindowOpenDelay, in: 0...2, step: 0.1)
             }
             
             HStack {

--- a/DockDoor/consts.swift
+++ b/DockDoor/consts.swift
@@ -7,33 +7,106 @@
 
 import Cocoa
 import Defaults
-//import Carbon
+import Foundation
 
 let optimisticScreenSizeWidth = NSScreen.main!.frame.width
 let optimisticScreenSizeHeight = NSScreen.main!.frame.height
 
 let roughHeightCap = optimisticScreenSizeHeight / 3
 let roughWidthCap = optimisticScreenSizeWidth / 3
+
 extension Defaults.Keys {
-    static let sizingMultiplier = Key<CGFloat>("sizingMultiplier") { 3 }
-    static let windowPadding = Key<CGFloat>("windowPadding") { 0 }
-    static let openDelay = Key<CGFloat>("openDelay") { 0 }
-    static let windowTitleAlignment = Key<Bool>("windowTitleAlignment") { true } // true = left side, false = right side alignment
+    static let sizingMultiplier = Key<CGFloat>("sizingMultiplier", default: 3 )
+    static let bufferFromDock = Key<CGFloat>("bufferFromDock", default: 0 )
+    static let hoverWindowOpenDelay = Key<CGFloat>("openDelay", default: 0 )
     
-    static let screenCaptureCacheLifespan = Key<CGFloat>("screenCaptureCacheLifespan") { 60 }
-    static let uniformCardRadius = Key<Bool>("uniformCardRadius") { true }
+    static let screenCaptureCacheLifespan = Key<CGFloat>("screenCaptureCacheLifespan", default: 60 )
+    static let uniformCardRadius = Key<Bool>("uniformCardRadius", default: true )
     
-    static let showAnimations = Key<Bool>("showAnimations") { true }
-    static let enableWindowSwitcher = Key<Bool>("enableWindowSwitcher"){ true }
+    static let showAnimations = Key<Bool>("showAnimations", default: true )
+    static let enableWindowSwitcher = Key<Bool>("enableWindowSwitcher", default: true )
     static let showMenuBarIcon = Key<Bool>("showMenuBarIcon", default: true)
-    static let defaultCMDTABKeybind = Key<Bool>("defaultCMDTABKeybind") { true }
-    static let launched = Key<Bool>("launched") { false }
-    static let Int64maskCommand = Key<Int>("Int64maskCommand") { 1048840 }
-    static let Int64maskControl = Key<Int>("Int64maskControl") { 262401 }
-    static let Int64maskAlternate = Key<Int>("Int64maskAlternate") { 524576 }
+    static let defaultCMDTABKeybind = Key<Bool>("defaultCMDTABKeybind", default: true )
+    static let launched = Key<Bool>("launched", default: false )
+    static let Int64maskCommand = Key<Int>("Int64maskCommand", default: 1048840 )
+    static let Int64maskControl = Key<Int>("Int64maskControl", default: 262401 )
+    static let Int64maskAlternate = Key<Int>("Int64maskAlternate", default: 524576 )
     static let UserKeybind = Key<UserKeyBind>("UserKeybind", default: UserKeyBind(keyCode: 48, modifierFlags: Defaults[.Int64maskControl]))
-    static let hoverTitleStyle = Key<Int>("hoverTitleStyle") { 0 }
-    static let showTitlesOnWindows = Key<Bool>("showTitlesOnWindows") { true }
-    static let windowTitlesDisplayMode = Key<Int>("windowTitlesDisplayMode") { 1 }
-    static let trafficButtonsDisplayMode = Key<Int>("trafficButtonsDisplayMode") { 1 }
+    
+    static let showWindowTitle = Key<Bool>("showWindowTitle", default: true )
+    static let windowTitleDisplayCondition = Key<WindowTitleDisplayCondition>("windowTitleDisplayCondition", default: .always )
+    static let windowTitlePosition = Key<WindowTitlePosition>("windowTitlePosition", default: WindowTitlePosition.bottomLeft )
+    static let windowTitleStyle = Key<WindowTitleStyle>("windowTitleStyle", default: .default )
+    static let trafficLightButtonsVisibility = Key<TrafficLightButtonsVisibility>("trafficLightButtonsVisibility", default: .dimmedOnWindowHover )
+}
+
+enum WindowTitleDisplayCondition: String, CaseIterable, Defaults.Serializable {
+    case always = "always"
+    case dockPreviewsOnly = "dockPreviewsOnly"
+    case windowSwitcherOnly = "windowSwitcherOnly"
+    
+    var localizedName: String {
+        switch self {
+        case .always:
+            String(localized: "Always", comment: "Preview window title condition option")
+        case .dockPreviewsOnly:
+            String(localized: "When Showing Dock Tile Previews", comment: "Preview window title condition option")
+        case .windowSwitcherOnly:
+            String(localized: "When Using Window Switcher", comment: "Preview window title condition option")
+        }
+    }
+}
+
+enum WindowTitlePosition: String, CaseIterable, Defaults.Serializable {
+    case bottomLeft
+    case bottomRight
+    
+    var localizedName: String {
+        switch self {
+        case .bottomLeft:
+            String(localized: "Bottom Left", comment: "Preview window title position option")
+        case .bottomRight:
+            String(localized: "Bottom Right", comment: "Preview window title position option")
+        }
+    }
+}
+
+enum WindowTitleStyle: String, CaseIterable, Defaults.Serializable {
+    case hidden
+    case `default`
+    case embedded
+    case popover
+    
+    var localizedName: String {
+        switch self {
+        case .hidden:
+            String(localized: "Hidden", comment: "Preview title style option")
+        case .default:
+            String(localized: "Default", comment: "Preview title style option")
+        case .embedded:
+            String(localized: "Embedded", comment: "Preview title style option")
+        case .popover:
+            String(localized: "Popover", comment: "Preview title style option")
+        }
+    }
+}
+
+enum TrafficLightButtonsVisibility: String, CaseIterable, Defaults.Serializable {
+    case never
+    case dimmedOnWindowHover
+    case fullOpacityOnWindowHover
+    case alwaysVisible
+    
+    var localizedName: String {
+        switch self {
+        case .never:
+            String(localized: "Never visible", comment: "Traffic light buttons visibility option")
+        case .dimmedOnWindowHover:
+            String(localized: "On window hover; Dimmed until button hover", comment: "Traffic light buttons visibility option")
+        case .fullOpacityOnWindowHover:
+            String(localized: "On window hover; Full opacity", comment: "Traffic light buttons visibility option")
+        case .alwaysVisible:
+            String(localized: "Always visible; Full opacity", comment: "Traffic light buttons visibility option")
+        }
+    }
 }


### PR DESCRIPTION
Throws away all numeric enums; Eliminates trying to remember every time "so what does `0` mean and what does `3` mean?". Eliminates awkward code snippets like this:
```
case 1, 2: // Embed + Popover
            Text(appName)
```
```
if  showTitlesOnTiles && ((tileTitlesDisplayMode == 1) || (tileTitlesDisplayMode == 2 && CurrentWindow.shared.showingTabMenu) || (tileTitlesDisplayMode == 3 && !CurrentWindow.shared.showingTabMenu)) {
```
Now it's elegant and clear:
```
case .embedded, .popover:
            Text(appName)
```
```
if  showWindowTitle && ((windowTitleDisplayCondition == .always) || (windowTitleDisplayCondition == .windowSwitcherOnly && CurrentWindow.shared.showingTabMenu) || (windowTitleDisplayCondition == .dockPreviewsOnly && !CurrentWindow.shared.showingTabMenu)) {
```

Collects all the types related to the defaults into the `consts.swift` file as `enums`, and also contains the localized name.

Rewrites the names of the keys and variables (mainly new ones that have not yet been included in a version that has been distributed).