### PR TITLE
fix: release notes loading

### DIFF
--- a/appcast.xml
+++ b/appcast.xml
@@ -5,7 +5,7 @@
         <item>
             <title>1.1.1</title>
             <pubDate>Wed, 10 Jul 2024 18:25:45 -0700</pubDate>
-            <sparkle:fullReleaseNotesLink>https://dockdoor.kepler.cafe/CHANGELOG.html</sparkle:fullReleaseNotesLink>
+            <sparkle:releaseNotesLink>https://dockdoor.kepler.cafe/CHANGELOG.html</sparkle:releaseNotesLink>
             <sparkle:version>1.1.1</sparkle:version>
             <sparkle:shortVersionString>1.1.1</sparkle:shortVersionString>
             <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>


### PR DESCRIPTION
![CleanShot 2024-07-11 at 05 22 30@2x](https://github.com/ejbills/DockDoor/assets/78599753/48ceb02e-e349-4a84-8839-c17c8839c551)

I think this is because of the [change](https://github.com/ejbills/DockDoor/commit/8e5a929e59f1f12cdb78ce898003c3be1effc73e#diff-a83b2ea9fe264ad87bb237369388273b0ef302202bb1f3e678012edfe85aa4aeR8) from `releaseNotesLink` to `fullReleaseNotesLink`

https://sparkle-project.org/documentation/publishing/#:~:text=Sparkle%20may%20let%20the%20user%20open%20this%20link%20in%20their%20web%20browser We want Sparkle to display the report in its built-in browser, not send a link to the browser.