### PR TITLE
feat: center Dock Tile Preview horizontally/vertically to icon

### DIFF
--- a/DockDoor/Utilities/DockObserver.swift
+++ b/DockDoor/Utilities/DockObserver.swift
@@ -167,6 +167,77 @@ final class DockObserver {
         }
     }
     
+    func getDockIconFrameAtLocation(_ mouseLocation: CGPoint) -> CGRect? {
+        guard let dockAppProcessIdentifier else {
+            print("Dock app process identifier is nil")
+            return nil
+        }
+        
+        let axDockApp = AXUIElementCreateApplication(dockAppProcessIdentifier)
+        
+        var dockItems: CFTypeRef?
+        let dockItemsResult = AXUIElementCopyAttributeValue(axDockApp, kAXChildrenAttribute as CFString, &dockItems)
+        
+        guard dockItemsResult == .success, let items = dockItems as? [AXUIElement] else {
+            print("Failed to get dock items: \(dockItemsResult.rawValue)")
+            return nil
+        }
+        
+        let axList = items.first { element in
+            var role: CFTypeRef?
+            let roleResult = AXUIElementCopyAttributeValue(element, kAXRoleAttribute as CFString, &role)
+            return roleResult == .success && (role as? String) == kAXListRole
+        }
+        
+        guard let list = axList else {
+            print("Failed to find the Dock list")
+            return nil
+        }
+        
+        var axChildren: CFTypeRef?
+        let childrenResult = AXUIElementCopyAttributeValue(list, kAXChildrenAttribute as CFString, &axChildren)
+        
+        guard childrenResult == .success, let children = axChildren as? [AXUIElement] else {
+            print("Failed to get children: \(childrenResult.rawValue)")
+            return nil
+        }
+        
+        // Adjust mouse location to match the coordinate system of the dock icons
+        let adjustedMouseLocation = CGPoint(
+            x: mouseLocation.x,
+            y: NSScreen.main!.frame.height - mouseLocation.y
+        )
+        
+        for element in children {
+            var positionValue: CFTypeRef?
+            var sizeValue: CFTypeRef?
+            let positionResult = AXUIElementCopyAttributeValue(element, kAXPositionAttribute as CFString, &positionValue)
+            let sizeResult = AXUIElementCopyAttributeValue(element, kAXSizeAttribute as CFString, &sizeValue)
+            
+            if positionResult == .success, sizeResult == .success {
+                let position = positionValue as! AXValue
+                let size = sizeValue as! AXValue
+                var positionPoint = CGPoint.zero
+                AXValueGetValue(position, .cgPoint, &positionPoint)
+                var sizeCGSize = CGSize.zero
+                AXValueGetValue(size, .cgSize, &sizeCGSize)
+                
+                let iconRect = CGRect(origin: positionPoint, size: sizeCGSize)
+                print("Checking icon rect: \(iconRect) with adjusted mouse location: \(adjustedMouseLocation)")
+                
+                if iconRect.contains(adjustedMouseLocation) {
+                    print("Matched icon rect: \(iconRect)")
+                    return iconRect
+                }
+            } else {
+                print("Failed to get position or size for element")
+            }
+        }
+        
+        print("No matching icon rect found")
+        return nil
+    }
+
     func getDockIconAtLocation(_ mouseLocation: CGPoint) -> String? {
         guard let dockAppProcessIdentifier else { return nil }
         

--- a/DockDoor/Utilities/DockObserver.swift
+++ b/DockDoor/Utilities/DockObserver.swift
@@ -205,7 +205,7 @@ final class DockObserver {
         // Adjust mouse location to match the coordinate system of the dock icons
         let adjustedMouseLocation = CGPoint(
             x: mouseLocation.x,
-            y: NSScreen.main!.frame.height - mouseLocation.y
+            y: (DockObserver.screenContainingPoint(mouseLocation)?.frame.height ?? NSScreen.main!.frame.height) - mouseLocation.y
         )
         
         for element in children {

--- a/DockDoor/Views/Hover Window/SharedPreviewWindowCoordinator.swift
+++ b/DockDoor/Views/Hover Window/SharedPreviewWindowCoordinator.swift
@@ -159,32 +159,33 @@ final class SharedPreviewWindowCoordinator: NSWindow {
         )
     }
     
-    // Calculate window position based on mouse location and dock position
+    // Calculate window position based on the given dock icon frame and dock position
     private func calculateWindowPosition(mouseLocation: CGPoint?, windowSize: CGSize, screen: NSScreen) -> CGPoint {
         guard let mouseLocation = mouseLocation else { return .zero }
+        guard let dockIconFrame = DockObserver.shared.getDockIconFrameAtLocation(mouseLocation) else { return .zero }
         
         let screenFrame = screen.frame
         let dockPosition = DockUtils.shared.getDockPosition()
         let dockHeight = DockUtils.shared.calculateDockHeight(screen)
         
-        var xPosition = mouseLocation.x
-        var yPosition = mouseLocation.y
+        var xPosition = dockIconFrame.midX
+        var yPosition = dockIconFrame.midY
         
         // Adjust position based on dock position
-        switch dockPosition {
-        case .bottom:
-            yPosition = screenFrame.minY + dockHeight
-            xPosition -= (windowSize.width / 2)
-        case .left:
-            xPosition = screenFrame.minX + dockHeight
-            yPosition -= (windowSize.height / 2)
-        case .right:
-            xPosition = screenFrame.maxX - dockHeight - windowSize.width
-            yPosition -= (windowSize.height / 2)
-        default:
-            xPosition -= (windowSize.width / 2)
-            yPosition -= (windowSize.height / 2)
-        }
+           switch dockPosition {
+           case .bottom:
+               yPosition = screenFrame.minY + dockHeight
+               xPosition -= (windowSize.width / 2)
+           case .left:
+               xPosition = screenFrame.minX + dockHeight
+               yPosition = screenFrame.height - yPosition - (windowSize.height / 2)
+           case .right:
+               xPosition = screenFrame.maxX - dockHeight - windowSize.width
+               yPosition = screenFrame.height - yPosition - (windowSize.height / 2)
+           default:
+               xPosition -= (windowSize.width / 2)
+               yPosition -= (windowSize.height / 2)
+           }
         
         // Ensure window stays within screen bounds
         xPosition = max(screenFrame.minX, min(xPosition, screenFrame.maxX - windowSize.width)) + (dockPosition != .bottom ? Defaults[.bufferFromDock] : 0)
@@ -192,6 +193,7 @@ final class SharedPreviewWindowCoordinator: NSWindow {
         
         return CGPoint(x: xPosition, y: yPosition)
     }
+    
     
     // Apply window frame with optional animation
     private func applyWindowFrame(_ frame: CGRect, animated: Bool) {
@@ -261,8 +263,6 @@ final class SharedPreviewWindowCoordinator: NSWindow {
             guard let self = self else { return }
             
             let screen = mouseScreen ?? NSScreen.main!
-            
-            hideFullPreviewWindow() // clean up any lingering fullscreen previews before presenting a new one
 
             // If in full window preview mode, show the full preview window and return early
             if centeredHoverWindowState == .fullWindowPreview, let windowInfo = windows.first {
@@ -277,7 +277,7 @@ final class SharedPreviewWindowCoordinator: NSWindow {
                 self.updateContentViewSizeAndPosition(mouseLocation: mouseLocation, mouseScreen: screen, animated: true,
                                                       centerOnScreen: shouldCenterOnScreen, centeredHoverWindowState: centeredHoverWindowState)
             }
-            
+                        
             self.makeKeyAndOrderFront(nil)
         }
     }

--- a/DockDoor/Views/Hover Window/SharedPreviewWindowCoordinator.swift
+++ b/DockDoor/Views/Hover Window/SharedPreviewWindowCoordinator.swift
@@ -146,7 +146,7 @@ final class SharedPreviewWindowCoordinator: NSWindow {
         fullPreviewWindow?.makeKeyAndOrderFront(nil)
     }
     
-    private func hideFullPreviewWindow() {
+    func hideFullPreviewWindow() {
         fullPreviewWindow?.orderOut(nil)
         fullPreviewWindow = nil
     }

--- a/DockDoor/Views/Hover Window/SharedPreviewWindowCoordinator.swift
+++ b/DockDoor/Views/Hover Window/SharedPreviewWindowCoordinator.swift
@@ -146,7 +146,7 @@ final class SharedPreviewWindowCoordinator: NSWindow {
         fullPreviewWindow?.makeKeyAndOrderFront(nil)
     }
     
-    func hideFullPreviewWindow() {
+    private func hideFullPreviewWindow() {
         fullPreviewWindow?.orderOut(nil)
         fullPreviewWindow = nil
     }
@@ -263,6 +263,8 @@ final class SharedPreviewWindowCoordinator: NSWindow {
             guard let self = self else { return }
             
             let screen = mouseScreen ?? NSScreen.main!
+            
+            hideFullPreviewWindow() // clean up any lingering fullscreen previews before presenting a new one
 
             // If in full window preview mode, show the full preview window and return early
             if centeredHoverWindowState == .fullWindowPreview, let windowInfo = windows.first {


### PR DESCRIPTION
This PR re-calculates the Dock Tile Preview (SharedPreviewWindowCoordinator) to be horizontally/vertically centered to the given dock icon instead of relying on the mouse position.

(As much as I tried to condense `getDockIconFrameAtLocation(_:)` and `getDockIconAtLocation(_:)` together, the frame would be incorrectly calculated, breaking alignment. Someone else feel free to examine this.)

Side note: `hideFullPreviewWindow` is currently marked as private and isn't usable outside its parent class.