### PR TITLE
fix: [WindowTitleDisplayCondition] change "Always" behavior

### DIFF
--- a/DockDoor/Views/Hover Window/WindowPreview.swift
+++ b/DockDoor/Views/Hover Window/WindowPreview.swift
@@ -119,8 +119,15 @@ struct WindowPreview: View {
                     return .topTrailing
                 }
             }()) {
-                if  showWindowTitle && ((windowTitleDisplayCondition == .always) || (windowTitleDisplayCondition == .windowSwitcherOnly && ScreenCenteredFloatingWindow.shared.windowSwitcherActive) || (windowTitleDisplayCondition == .dockPreviewsOnly && !ScreenCenteredFloatingWindow.shared.windowSwitcherActive)) {
-                    windowTitleOverlay(selected: selected)
+                let shouldShowTitleOverlay = showWindowTitle && (
+                    windowTitleDisplayCondition == .always ||
+                    (windowTitleDisplayCondition == .hoverOnly) ||
+                    (windowTitleDisplayCondition == .windowSwitcherOnly && ScreenCenteredFloatingWindow.shared.windowSwitcherActive) ||
+                    (windowTitleDisplayCondition == .dockPreviewsOnly && !ScreenCenteredFloatingWindow.shared.windowSwitcherActive)
+                )
+
+                if shouldShowTitleOverlay {
+                    windowTitleOverlay(selected: windowTitleDisplayCondition == .always ? true : selected)
                 }
             }
             .overlay(alignment: .topLeading) {
@@ -220,7 +227,7 @@ struct WindowPreview: View {
 
     @ViewBuilder
     private func windowTitleOverlay(selected: Bool) -> some View {
-        if selected, let windowTitle = windowInfo.window?.title, !windowTitle.isEmpty, windowTitle != windowInfo.appName {
+        if selected, let windowTitle = windowInfo.window?.title, !windowTitle.isEmpty, (windowTitle != windowInfo.appName || (windowTitle == windowInfo.appName && ScreenCenteredFloatingWindow.shared.windowSwitcherActive && (windowTitleDisplayCondition == .always || windowTitleDisplayCondition == .windowSwitcherOnly || windowTitleDisplayCondition == .hoverOnly))) {
             let maxLabelWidth = calculatedSize.width - 50
             let stringMeasurementWidth = measureString(windowTitle, fontSize: 12).width + 5
             let width = maxLabelWidth > stringMeasurementWidth ? stringMeasurementWidth : maxLabelWidth

--- a/DockDoor/consts.swift
+++ b/DockDoor/consts.swift
@@ -44,6 +44,7 @@ extension Defaults.Keys {
 
 enum WindowTitleDisplayCondition: String, CaseIterable, Defaults.Serializable {
     case always = "always"
+    case hoverOnly = "hoverOnly"
     case dockPreviewsOnly = "dockPreviewsOnly"
     case windowSwitcherOnly = "windowSwitcherOnly"
     
@@ -51,10 +52,12 @@ enum WindowTitleDisplayCondition: String, CaseIterable, Defaults.Serializable {
         switch self {
         case .always:
             String(localized: "Always", comment: "Preview window title condition option")
+        case .hoverOnly:
+            String(localized: "When Hovering", comment: "Preview window title condition option")
         case .dockPreviewsOnly:
-            String(localized: "When Showing Dock Tile Previews", comment: "Preview window title condition option")
+            String(localized: "When Hovering Dock Tile Previews Only", comment: "Preview window title condition option")
         case .windowSwitcherOnly:
-            String(localized: "When Using Window Switcher", comment: "Preview window title condition option")
+            String(localized: "When Hovering Window Switcher Previews Only", comment: "Preview window title condition option")
         }
     }
 }


### PR DESCRIPTION
Make "Always" actually always show a window title. Additionally, when using Window Switcher-applicable settings, show the app title as the window title for clarity. See #185 for additional information.