### PR TITLE
feat: open app settings by relaunch

### DIFF
--- a/DockDoor/Views/Settings/MainSettingsView.swift
+++ b/DockDoor/Views/Settings/MainSettingsView.swift
@@ -47,14 +47,15 @@ struct MainSettingsView: View {
             })
             .onChange(of: showMenuBarIcon) { _, isOn in
                 let delegate = NSApplication.shared.delegate as! AppDelegate
-                delegate.updateMenuBarIconStatus()
-                
-                if !isOn {
-                    MessageUtil.showMessage(title: String(localized: "Menu Bar Icon Hidden"), message: String(localized: "If you need to access the menu bar icon, launch the app to reveal it for 10 seconds."), completion: { result in
-                        if result == .cancel {
-                            showMenuBarIcon = true
-                        }
-                    })
+                if isOn {
+                    delegate.setupMenuBar()
+                } else {
+                    delegate.removeMenuBar()
+                    if let settingsWindow = delegate.settingsWindowController.window {
+                        // re-front the settings window after removeMenuBar's setActivationPolicy
+                        settingsWindow.makeKeyAndOrderFront(nil)
+                        NSApp.activate(ignoringOtherApps: false)
+                    }
                 }
             }
             

--- a/DockDoor/Views/Settings/MainSettingsView.swift
+++ b/DockDoor/Views/Settings/MainSettingsView.swift
@@ -51,11 +51,6 @@ struct MainSettingsView: View {
                     delegate.setupMenuBar()
                 } else {
                     delegate.removeMenuBar()
-                    if let settingsWindow = delegate.settingsWindowController.window {
-                        // re-front the settings window after removeMenuBar's setActivationPolicy
-                        settingsWindow.makeKeyAndOrderFront(nil)
-                        NSApp.activate(ignoringOtherApps: false)
-                    }
                 }
             }
             


### PR DESCRIPTION
The opening is even if the menu bar icon is enabled, because sometimes many applications are open in the menu bar and there is no way to get to the DockDoor menu, so it seems logical to me that it would always be possible to open DockDoor again to get to the settings.

closes https://github.com/ejbills/DockDoor/issues/57

*************

It is still not perfect, when the user disables "Show Menu Bar Icon" the window loses focus, and may be lost. I try to focus it back but it only brings it back forward and doesn't focus it, so it can get lost in some scenarios. In any case, the user can always simply reopen the app from the Launchpad and the settings window will open and focused again.

https://github.com/user-attachments/assets/c54792b5-653e-4a3d-9086-bcc71093827f

It happens because of this:
```swift
func removeMenuBar() {
        NSApplication.shared.setActivationPolicy(.prohibited) // hide the dock icon
```

If you have a better way to hide the dock icon even when hiding the menus icon, without losing focus, please let me know!

