### PR TITLE
feat: restart the app when needed instead of just quit

### DIFF
--- a/DockDoor/AppDelegate.swift
+++ b/DockDoor/AppDelegate.swift
@@ -117,6 +117,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         NSApplication.shared.terminate(nil)
     }
     
+    func restartApp() {
+        // we use -n to open a new instance, to avoid calling applicationShouldHandleReopen
+        // we use Bundle.main.bundlePath in case of multiple AltTab versions on the machine
+        Process.launchedProcess(launchPath: "/usr/bin/open", arguments: ["-n", Bundle.main.bundlePath])
+        self.quitApp()
+    }
+    
     private func handleFirstTimeLaunch() {
         let contentView = FirstTimeView()
         

--- a/DockDoor/Utilities/Misc Utils.swift
+++ b/DockDoor/Utilities/Misc Utils.swift
@@ -9,15 +9,11 @@ import Cocoa
 import Defaults
 import Carbon
 
-func quitApp() {
-    // Terminate the current application
-    NSApplication.shared.terminate(nil)
-}
-
-func restartApplication ()-> Void {
+func askUserToRestartApplication () -> Void {
     MessageUtil.showMessage(title: String(localized: "Restart required"), message: String(localized: "Please restart the application to apply your changes. Click OK to quit the app."), completion: { result in
         if result == .ok {
-            quitApp()
+            let delegate = NSApplication.shared.delegate as! AppDelegate
+            delegate.restartApp()
         }})
 }
 

--- a/DockDoor/Views/Settings/PermissionsSettingsView.swift
+++ b/DockDoor/Views/Settings/PermissionsSettingsView.swift
@@ -92,10 +92,13 @@ struct PermissionsSettingsView: View {
             }
             .buttonStyle(.bordered)
             
-            Text("Please Quit the App to Apply Changes! :)")
+            Text("Please Restart the App to Apply Changes! :)")
                 .font(.footnote)
                 .foregroundColor(.secondary)
-            Button("Quit App", action: quitApp)
+            Button("Restart App", action: {
+                let delegate = NSApplication.shared.delegate as! AppDelegate
+                delegate.restartApp()
+            })
                 .buttonStyle(.bordered)
 
             Spacer()

--- a/DockDoor/Views/Settings/WindowSwitcherSettingsView.swift
+++ b/DockDoor/Views/Settings/WindowSwitcherSettingsView.swift
@@ -31,7 +31,7 @@ struct WindowSwitcherSettingsView: View {
                 Text("Enable Window Switcher")
             }).onChange(of: enableWindowSwitcher){
                 _, newValue in
-                restartApplication()
+                askUserToRestartApplication()
             }
             // Default CMD + TAB implementation checkbox
             if Defaults[.enableWindowSwitcher] {


### PR DESCRIPTION
The alert tells the user to "restart" but in practice the app is simply killed and the user has to restart it manually. Now the app will restart itself smoothly.
It's imported from alt-tab, more to come!