### PR TITLE
chore: remove autogenerated Xcode file headers

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,4 +7,4 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: SwiftFormat
-        run: swiftformat --lint --swiftversion 5.0 --header strip . --reporter github-actions-log 
+        run: swiftformat --lint . --reporter github-actions-log 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,4 +7,4 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: SwiftFormat
-        run: swiftformat --lint --swiftversion 5.0 . --reporter github-actions-log 
+        run: swiftformat --lint --swiftversion 5.0 --header strip . --reporter github-actions-log 

--- a/.swiftformat
+++ b/.swiftformat
@@ -1,0 +1,2 @@
+--swiftversion 5.0
+--header strip

--- a/DockDoor.xcodeproj/project.pbxproj
+++ b/DockDoor.xcodeproj/project.pbxproj
@@ -341,7 +341,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "cd BuildTools\nSDKROOT=(xcrun --sdk macosx --show-sdk-path)\n#swift package update #Uncomment this line temporarily to update the version used to the latest matching your BuildTools/Package.swift file\nswift run -c release swiftformat \"$SRCROOT\" --swiftversion 5.0\n";
+			shellScript = "cd BuildTools\nSDKROOT=(xcrun --sdk macosx --show-sdk-path)\n#swift package update #Uncomment this line temporarily to update the version used to the latest matching your BuildTools/Package.swift file\nswift run -c release swiftformat \"$SRCROOT\" --swiftversion 5.0 --header strip\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/DockDoor.xcodeproj/project.pbxproj
+++ b/DockDoor.xcodeproj/project.pbxproj
@@ -341,7 +341,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "cd BuildTools\nSDKROOT=(xcrun --sdk macosx --show-sdk-path)\n#swift package update #Uncomment this line temporarily to update the version used to the latest matching your BuildTools/Package.swift file\nswift run -c release swiftformat \"$SRCROOT\" --swiftversion 5.0 --header strip\n";
+			shellScript = "cd BuildTools\nSDKROOT=(xcrun --sdk macosx --show-sdk-path)\n#swift package update #Uncomment this line temporarily to update the version used to the latest matching your BuildTools/Package.swift file\nswift run -c release swiftformat \"$SRCROOT\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/DockDoor/AppDelegate.swift
+++ b/DockDoor/AppDelegate.swift
@@ -1,10 +1,3 @@
-//
-//  AppDelegate.swift
-//  DockDoor
-//
-//  Created by Ethan Bills on 6/3/24.
-//
-
 import Cocoa
 import Defaults
 import Settings

--- a/DockDoor/Components/BlurView.swift
+++ b/DockDoor/Components/BlurView.swift
@@ -1,10 +1,3 @@
-//
-//  BlurView.swift
-//  DockDoor
-//
-//  Created by Igor Marcossi on 14/06/24.
-//
-
 import SwiftUI
 
 struct BlurView: NSViewRepresentable {

--- a/DockDoor/Components/DynStack.swift
+++ b/DockDoor/Components/DynStack.swift
@@ -1,10 +1,3 @@
-//
-//  DynStack.swift
-//  DockDoor
-//
-//  Created by Igor Marcossi on 14/06/24.
-//
-
 import SwiftUI
 
 struct DynStack<C: View>: View {

--- a/DockDoor/Components/FluidGradient.swift
+++ b/DockDoor/Components/FluidGradient.swift
@@ -1,10 +1,3 @@
-//
-//  FluidGradient.swift
-//  DockDoor
-//
-//  Created by Ethan Bills on 7/11/24.
-//
-
 import FluidGradient
 import SwiftUI
 

--- a/DockDoor/Components/HiddenModifier.swift
+++ b/DockDoor/Components/HiddenModifier.swift
@@ -1,10 +1,3 @@
-//
-//  HiddenModifier.swift
-//  OpenArtemis
-//
-//  Created by Ethan Bills on 1/1/24.
-//
-
 import SwiftUI
 
 struct HiddenModifier: ViewModifier {

--- a/DockDoor/Components/Marquee.swift
+++ b/DockDoor/Components/Marquee.swift
@@ -1,10 +1,3 @@
-//
-//  Marquee.swift
-//  NotchNook
-//
-//  Created by Igor Marcossi on 16/06/24.
-//
-
 import SmoothGradient
 import SwiftUI
 

--- a/DockDoor/Components/StackedShadow.swift
+++ b/DockDoor/Components/StackedShadow.swift
@@ -1,10 +1,3 @@
-//
-//  StackedShadow.swift
-//  DockDoor
-//
-//  Created by Ethan Bills on 6/23/24.
-//
-
 import SwiftUI
 
 struct StackedShadow: ViewModifier {

--- a/DockDoor/Extensions/ColorHex.swift
+++ b/DockDoor/Extensions/ColorHex.swift
@@ -1,10 +1,3 @@
-//
-//  ColorHex.swift
-//  DockDoor
-//
-//  Created by ShlomoCode on 10/07/2024.
-//
-
 import SwiftUI
 
 extension Color {

--- a/DockDoor/Extensions/dockStyle.swift
+++ b/DockDoor/Extensions/dockStyle.swift
@@ -1,10 +1,3 @@
-//
-//  dockStyle.swift
-//  DockDoor
-//
-//  Created by Igor Marcossi on 14/06/24.
-//
-
 import SwiftUI
 
 struct DockStyleModifier: ViewModifier {

--- a/DockDoor/Utilities/App Icon.swift
+++ b/DockDoor/Utilities/App Icon.swift
@@ -1,10 +1,3 @@
-//
-//  App Icon.swift
-//  DockDoor
-//
-//  Created by Ethan Bills on 6/18/24.
-//
-
 import AppKit
 
 enum AppIconUtil {

--- a/DockDoor/Utilities/DockObserver.swift
+++ b/DockDoor/Utilities/DockObserver.swift
@@ -1,9 +1,3 @@
-//  DockObserver.swift
-//  DockDoor
-//
-//  Created by Ethan Bills on 6/3/24.
-//
-
 import ApplicationServices
 import Cocoa
 

--- a/DockDoor/Utilities/DockUtils.swift
+++ b/DockDoor/Utilities/DockUtils.swift
@@ -1,9 +1,3 @@
-//
-//  DockUtils.swift
-//  DockDoor
-//
-//
-
 import Cocoa
 
 enum DockPosition {

--- a/DockDoor/Utilities/KeybindHelper.swift
+++ b/DockDoor/Utilities/KeybindHelper.swift
@@ -1,10 +1,3 @@
-//
-//  KeybindHelper.swift
-//  DockDoor
-//
-//  Created by Ethan Bills on 6/13/24.
-//
-
 import AppKit
 import Carbon
 import Defaults

--- a/DockDoor/Utilities/LimitedTaskGroup.swift
+++ b/DockDoor/Utilities/LimitedTaskGroup.swift
@@ -1,10 +1,3 @@
-//
-//  LimitedTaskGroup.swift
-//  DockDoor
-//
-//  Created by Ethan Bills on 7/23/24.
-//
-
 actor LimitedTaskGroup<T> {
     private var tasks: [Task<T, Error>] = []
     private let maxConcurrentTasks: Int

--- a/DockDoor/Utilities/MessageUtil.swift
+++ b/DockDoor/Utilities/MessageUtil.swift
@@ -1,10 +1,3 @@
-//
-//  MessageUtil.swift
-//  DockDoor
-//
-//  Created by Ethan Bills on 6/3/24.
-//
-
 import Cocoa
 
 enum MessageUtil {

--- a/DockDoor/Utilities/Misc Utils.swift
+++ b/DockDoor/Utilities/Misc Utils.swift
@@ -1,10 +1,3 @@
-//
-//  Misc Utils.swift
-//  DockDoor
-//
-//  Created by Ethan Bills on 6/13/24.
-//
-
 import Carbon
 import Cocoa
 import Defaults

--- a/DockDoor/Utilities/PrivateApis.swift
+++ b/DockDoor/Utilities/PrivateApis.swift
@@ -1,10 +1,3 @@
-//
-//  PrivateApis.swift
-//  DockDoor
-//
-//  Created by ShlomoCode on 10/07/2024.
-//
-
 import Cocoa
 
 // returns the CGWindowID of the provided AXUIElement

--- a/DockDoor/Utilities/SpaceWindowCacheManager.swift
+++ b/DockDoor/Utilities/SpaceWindowCacheManager.swift
@@ -1,10 +1,3 @@
-//
-//  SpaceWindowCacheManager.swift
-//  DockDoor
-//
-//  Created by Ethan Bills on 7/17/24.
-//
-
 import Cocoa
 import ScreenCaptureKit
 

--- a/DockDoor/Utilities/SystemPreferencesHelper.swift
+++ b/DockDoor/Utilities/SystemPreferencesHelper.swift
@@ -1,10 +1,3 @@
-//
-//  SystemPreferencesHelper.swift
-//  DockDoor
-//
-//  Created by Ethan Bills on 6/3/24.
-//
-
 import AppKit
 
 class SystemPreferencesHelper {

--- a/DockDoor/Utilities/WindowManipulationObservers.swift
+++ b/DockDoor/Utilities/WindowManipulationObservers.swift
@@ -1,10 +1,3 @@
-//
-//  WindowManipulationObservers.swift
-//  DockDoor
-//
-//  Created by Ethan Bills on 6/30/24.
-//
-
 import AppKit
 import ApplicationServices
 import Cocoa

--- a/DockDoor/Utilities/WindowUtil.swift
+++ b/DockDoor/Utilities/WindowUtil.swift
@@ -1,10 +1,3 @@
-//
-//  WindowUtil.swift
-//  DockDoor
-//
-//  Created by Ethan Bills on 6/3/24.
-//
-
 import ApplicationServices
 import Cocoa
 import Defaults

--- a/DockDoor/Views/FirstTimeView.swift
+++ b/DockDoor/Views/FirstTimeView.swift
@@ -1,10 +1,3 @@
-//
-//  FirstTimeView.swift
-//  DockDoor
-//
-//  Created by Ethan Bills on 6/21/24.
-//
-
 import SwiftUI
 
 struct FirstTimeView: View {

--- a/DockDoor/Views/Hover Window/FullSizePreviewView.swift
+++ b/DockDoor/Views/Hover Window/FullSizePreviewView.swift
@@ -1,10 +1,3 @@
-//
-//  FullSizePreviewView.swift
-//  DockDoor
-//
-//  Created by Ethan Bills on 7/11/24.
-//
-
 import Defaults
 import SwiftUI
 

--- a/DockDoor/Views/Hover Window/SharedPreviewWindowCoordinator.swift
+++ b/DockDoor/Views/Hover Window/SharedPreviewWindowCoordinator.swift
@@ -1,10 +1,3 @@
-//
-//  SharedPreviewWindowCoordinator.swift
-//  DockDoor
-//
-//  Created by Ethan Bills on 6/5/24.
-//
-
 import Defaults
 import FluidGradient
 import SwiftUI

--- a/DockDoor/Views/Hover Window/Traffic Light Buttons.swift
+++ b/DockDoor/Views/Hover Window/Traffic Light Buttons.swift
@@ -1,10 +1,3 @@
-//
-//  Traffic Light Buttons.swift
-//  DockDoor
-//
-//  Created by Ethan Bills on 7/8/24.
-//
-
 import SwiftUI
 
 struct TrafficLightButtons: View {

--- a/DockDoor/Views/Hover Window/WindowPreview.swift
+++ b/DockDoor/Views/Hover Window/WindowPreview.swift
@@ -1,10 +1,3 @@
-//
-//  WindowPreview.swift
-//  DockDoor
-//
-//  Created by Ethan Bills on 7/4/24.
-//
-
 import Defaults
 import SwiftUI
 

--- a/DockDoor/Views/Hover Window/WindowPreviewHoverContainer.swift
+++ b/DockDoor/Views/Hover Window/WindowPreviewHoverContainer.swift
@@ -1,10 +1,3 @@
-//
-//  WindowPreviewHoverContainer.swift
-//  DockDoor
-//
-//  Created by Ethan Bills on 7/11/24.
-//
-
 import Defaults
 import SwiftUI
 

--- a/DockDoor/Views/Settings/AppearanceSettingsView.swift
+++ b/DockDoor/Views/Settings/AppearanceSettingsView.swift
@@ -1,10 +1,3 @@
-//
-//  AppearanceSettingsView.swift
-//  DockDoor
-//
-//  Created by ShlomoCode on 09/07/2024.
-//
-
 import Defaults
 import LaunchAtLogin
 import SwiftUI

--- a/DockDoor/Views/Settings/MainSettingsView.swift
+++ b/DockDoor/Views/Settings/MainSettingsView.swift
@@ -1,10 +1,3 @@
-//
-//  MainSettingsView.swift
-//  DockDoor
-//
-//  Created by Ethan Bills on 6/13/24.
-//
-
 import Defaults
 import LaunchAtLogin
 import SwiftUI

--- a/DockDoor/Views/Settings/PermissionsSettingsView.swift
+++ b/DockDoor/Views/Settings/PermissionsSettingsView.swift
@@ -1,10 +1,3 @@
-//
-//  PermissionsSettingsView.swift
-//  DockDoor
-//
-//  Created by Ethan Bills on 6/14/24.
-//
-
 import AppKit
 import Combine
 import SwiftUI

--- a/DockDoor/Views/Settings/UpdateSettingsView.swift
+++ b/DockDoor/Views/Settings/UpdateSettingsView.swift
@@ -1,10 +1,3 @@
-//
-//  UpdateSettingsView.swift
-//  DockDoor
-//
-//  Created by Ethan Bills on 6/23/24.
-//
-
 import Sparkle
 import SwiftUI
 

--- a/DockDoor/Views/Settings/WindowSwitcherSettingsView.swift
+++ b/DockDoor/Views/Settings/WindowSwitcherSettingsView.swift
@@ -1,10 +1,3 @@
-//
-//  WindowSwitcherSettingsView.swift
-//  DockDoor
-//
-//  Created by Hasan Sultan on 6/25/24.
-//
-
 import Carbon
 import Defaults
 import SwiftUI

--- a/DockDoor/Views/Settings/settings.swift
+++ b/DockDoor/Views/Settings/settings.swift
@@ -1,10 +1,3 @@
-//
-//  settings.swift
-//  DockDoor
-//
-//  Created by Ethan Bills on 6/18/24.
-//
-
 import Cocoa
 import Settings
 import Sparkle

--- a/DockDoor/consts.swift
+++ b/DockDoor/consts.swift
@@ -1,10 +1,3 @@
-//
-//  consts.swift
-//  DockDoor
-//
-//  Created by Ethan Bills on 6/6/24.
-//
-
 import Cocoa
 import Defaults
 import Foundation

--- a/DockDoor/main.swift
+++ b/DockDoor/main.swift
@@ -1,10 +1,3 @@
-//
-//  main.swift
-//  DockDoor
-//
-//  Created by Ethan Bills on 6/6/24.
-//
-
 import AppKit
 
 let appDelegate = AppDelegate()


### PR DESCRIPTION
## Describe your changes
This PR adds a SwiftFormat rule to remove file headers automatically generated by Xcode, as they often contribute unnecessary clutter without providing intrinsic value.

These headers contain information available in the git history. Moreover, they tend to become outdated and potentially misleading over time, as they are not automatically updated when files undergo significant changes such as full rewrites or renaming. By removing these headers, we maintain cleaner, more maintainable code while relying on version control systems for historical information.

## Related issue number(s) and link(s)
No

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] If this change affects core functionality, I have added a description highlighting the changes
- [x] I have followed conventional commit guidelines

## Core Functionality Changes
If this PR modifies core functionality, please provide a brief description of the changes and their impact below:
No