### PR TITLE
fix: correct RTL layout rendering for user-defined element positions

### DIFF
--- a/DockDoor/Views/Hover Window/WindowPreview.swift
+++ b/DockDoor/Views/Hover Window/WindowPreview.swift
@@ -113,6 +113,7 @@ struct WindowPreview: View {
                 }
             }
         }
+        .environment(\.layoutDirection, .leftToRight)
         .scaleEffect(selected ? 1.015 : 1)
         .contentShape(Rectangle())
         .onHover { over in


### PR DESCRIPTION
## Describe your changes

trafficLightButtonsPosition and windowTitlePosition flipped in RTL langs because the choice is for example "top left" while swiftUI only accepts a definition of "Leading" or "Trailing", which depends on the context (RTL or LTR)

## Related issue number(s) and link(s)
closes https://github.com/ejbills/DockDoor/issues/261

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] If this change affects core functionality, I have added a description highlighting the changes
- [x] I have followed conventional commit guidelines

## Core Functionality Changes
If this PR modifies core functionality, please provide a brief description of the changes and their impact below:
