### PR TITLE
fix: update previousTrafficLightButtonsPosition on ok

### DIFF
--- a/DockDoor/Views/Settings/AppearanceSettingsView.swift
+++ b/DockDoor/Views/Settings/AppearanceSettingsView.swift
@@ -57,6 +57,8 @@ struct AppearanceSettingsView: View {
                         completion: { result in
                             if result == .cancel {
                                 trafficLightButtonsPosition = previousTrafficLightButtonsPosition
+                            } else {
+                                previousTrafficLightButtonsPosition = newValue
                             }
                         }
                     )
@@ -131,6 +133,8 @@ struct AppearanceSettingsView: View {
                             completion: { result in
                                 if result == .cancel {
                                     windowTitlePosition = previousWindowTitlePosition
+                                } else {
+                                    previousWindowTitlePosition = newValue
                                 }
                             }
                         )


### PR DESCRIPTION
Mistakenly dropped from https://github.com/ejbills/DockDoor/pull/267