### PR TITLE
fix: display decimals for sliders with float steps

### DIFF
--- a/DockDoor.xcodeproj/project.pbxproj
+++ b/DockDoor.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		0531F8D22C3CC04600327808 /* AppearanceSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0531F8D12C3CC04600327808 /* AppearanceSettingsView.swift */; };
 		0596C2C32C3E060D00DCABEF /* PrivateApis.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0596C2C22C3E060D00DCABEF /* PrivateApis.swift */; };
 		05C0C7182C60629C000ADAC6 /* AXUIElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05C0C7172C60629C000ADAC6 /* AXUIElement.swift */; };
+		27DC8C172CFA4DA7005F8F31 /* NumberFormatter+Convenience.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27DC8C152CFA4DA7005F8F31 /* NumberFormatter+Convenience.swift */; };
 		3A105FD62C1BED660015EC66 /* BlurView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A105FD52C1BED660015EC66 /* BlurView.swift */; };
 		3A105FD92C1C049E0015EC66 /* dockStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A105FD82C1C049E0015EC66 /* dockStyle.swift */; };
 		3A105FDD2C1C0EE20015EC66 /* DynStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A105FDC2C1C0EE20015EC66 /* DynStack.swift */; };
@@ -92,6 +93,7 @@
 		0531F8D12C3CC04600327808 /* AppearanceSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppearanceSettingsView.swift; sourceTree = "<group>"; };
 		0596C2C22C3E060D00DCABEF /* PrivateApis.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivateApis.swift; sourceTree = "<group>"; };
 		05C0C7172C60629C000ADAC6 /* AXUIElement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AXUIElement.swift; sourceTree = "<group>"; };
+		27DC8C152CFA4DA7005F8F31 /* NumberFormatter+Convenience.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NumberFormatter+Convenience.swift"; sourceTree = "<group>"; };
 		3A105FD52C1BED660015EC66 /* BlurView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlurView.swift; sourceTree = "<group>"; };
 		3A105FD82C1C049E0015EC66 /* dockStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = dockStyle.swift; sourceTree = "<group>"; };
 		3A105FDC2C1C0EE20015EC66 /* DynStack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynStack.swift; sourceTree = "<group>"; };
@@ -185,6 +187,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		27DC8C162CFA4DA7005F8F31 /* Formatters */ = {
+			isa = PBXGroup;
+			children = (
+				27DC8C152CFA4DA7005F8F31 /* NumberFormatter+Convenience.swift */,
+			);
+			path = Formatters;
+			sourceTree = "<group>";
+		};
 		3A105FD42C1BED5B0015EC66 /* Components */ = {
 			isa = PBXGroup;
 			children = (
@@ -208,6 +218,7 @@
 			isa = PBXGroup;
 			children = (
 				BB918BB42CF7613200931236 /* CGRect.swift */,
+				27DC8C162CFA4DA7005F8F31 /* Formatters */,
 				BB3D6EAF2C84E58000FFE584 /* NSScreen.swift */,
 				BBBD4AF42C8D671A0074FFCF /* NSImage.swift */,
 				3A1622B32C8C099200D318EE /* Button Styles */,
@@ -560,6 +571,7 @@
 				BB44474F2C507F950047EB92 /* LimitedTaskGroup.swift in Sources */,
 				BBBD4AF52C8D671C0074FFCF /* NSImage.swift in Sources */,
 				BB04405E2C77A87F009F1D33 /* PreferencesProtocol.swift in Sources */,
+				27DC8C172CFA4DA7005F8F31 /* NumberFormatter+Convenience.swift in Sources */,
 				3A1622C72C8D5A5C00D318EE /* EnabledActionRowView.swift in Sources */,
 				3A1622D02C8D691700D318EE /* SquiggleDivider.swift in Sources */,
 				BB157B822C0EB29E00997315 /* DockObserver.swift in Sources */,

--- a/DockDoor/Components/sliderSetting.swift
+++ b/DockDoor/Components/sliderSetting.swift
@@ -5,7 +5,8 @@ func sliderSetting<T: BinaryFloatingPoint>(
     value: Binding<T>,
     range: ClosedRange<T>,
     step: T.Stride,
-    unit: String
+    unit: String,
+    formatter: NumberFormatter = NumberFormatter.defaultFormatter
 ) -> some View where T.Stride: BinaryFloatingPoint {
     VStack(alignment: .leading, spacing: 5) {
         Text(title)
@@ -16,16 +17,9 @@ func sliderSetting<T: BinaryFloatingPoint>(
                 in: range,
                 step: step
             )
-            TextField("", text: Binding(
-                get: { String(describing: value.wrappedValue) },
-                set: { str in
-                    if let newValue = Double(str) {
-                        value.wrappedValue = T(newValue)
-                    }
-                }
-            ))
-            .textFieldStyle(RoundedBorderTextFieldStyle())
-            .frame(width: 50)
+            TextField("", value: value, formatter: formatter)
+                .textFieldStyle(RoundedBorderTextFieldStyle())
+                .frame(width: 50)
             Text(unit)
                 .font(.footnote)
         }

--- a/DockDoor/Extensions/Formatters/NumberFormatter+Convenience.swift
+++ b/DockDoor/Extensions/Formatters/NumberFormatter+Convenience.swift
@@ -1,0 +1,24 @@
+import SwiftUI
+
+extension NumberFormatter {
+    static let defaultFormatter: NumberFormatter = .init()
+    static let oneDecimalFormatter: NumberFormatter = .init(style: .decimal, minimumFractionDigits: 1, maximumFractionDigits: 1)
+    static let twoDecimalFormatter: NumberFormatter = .init(style: .decimal, minimumFractionDigits: 2, maximumFractionDigits: 2)
+}
+
+extension NumberFormatter {
+    convenience init(
+        style: NumberFormatter.Style = .none,
+        minimumFractionDigits: Int? = nil,
+        maximumFractionDigits: Int? = nil
+    ) {
+        self.init()
+        numberStyle = style
+        if let minDigits = minimumFractionDigits {
+            self.minimumFractionDigits = minDigits
+        }
+        if let maxDigits = maximumFractionDigits {
+            self.maximumFractionDigits = maxDigits
+        }
+    }
+}

--- a/DockDoor/Views/Settings/GradientColorPaletteSettingsView.swift
+++ b/DockDoor/Views/Settings/GradientColorPaletteSettingsView.swift
@@ -49,13 +49,15 @@ struct GradientColorPaletteSettingsView: View {
                       value: $storedSettings.speed,
                       range: 0.1 ... 1.0,
                       step: 0.05,
-                      unit: String(localized: "seconds"))
+                      unit: String(localized: "seconds"),
+                      formatter: NumberFormatter.twoDecimalFormatter)
 
         sliderSetting(title: String(localized: "Blur amount"),
                       value: $storedSettings.blur,
                       range: 0 ... 1.0,
                       step: 0.05,
-                      unit: String(localized: "amount"))
+                      unit: String(localized: "amount"),
+                      formatter: NumberFormatter.twoDecimalFormatter)
             .onAppear {
                 setupColorDebounce()
             }

--- a/DockDoor/Views/Settings/MainSettingsView.swift
+++ b/DockDoor/Views/Settings/MainSettingsView.swift
@@ -2,13 +2,6 @@ import Defaults
 import LaunchAtLogin
 import SwiftUI
 
-var decimalFormatter: NumberFormatter {
-    let formatter = NumberFormatter()
-    formatter.numberStyle = .decimal
-    formatter.maximumFractionDigits = 1
-    return formatter
-}
-
 struct MainSettingsView: View {
     @Default(.hoverWindowOpenDelay) var hoverWindowOpenDelay
     @Default(.screenCaptureCacheLifespan) var screenCaptureCacheLifespan
@@ -86,13 +79,15 @@ struct MainSettingsView: View {
                           value: $hoverWindowOpenDelay,
                           range: 0 ... 2,
                           step: 0.1,
-                          unit: String(localized: "seconds"))
+                          unit: String(localized: "seconds"),
+                          formatter: NumberFormatter.oneDecimalFormatter)
 
             sliderSetting(title: String(localized: "Preview Window Fade Out Duration"),
                           value: $fadeOutDuration,
                           range: 0 ... 2,
                           step: 0.1,
-                          unit: String(localized: "seconds"))
+                          unit: String(localized: "seconds"),
+                          formatter: NumberFormatter.oneDecimalFormatter)
 
             VStack(alignment: .leading) {
                 HStack {
@@ -148,7 +143,8 @@ struct MainSettingsView: View {
                           value: $tapEquivalentInterval,
                           range: 0 ... 2,
                           step: 0.1,
-                          unit: String(localized: "seconds"))
+                          unit: String(localized: "seconds"),
+                          formatter: NumberFormatter.oneDecimalFormatter)
                 .disabled(previewHoverAction == .none)
         }
         .padding(20)


### PR DESCRIPTION
## Describe your changes
- remove unused decimal formatter
- create number formatter convenience file with init extension and a couple predefined formats
- update sliderSetting to take an optional NumberFormatter and propagate to TextField
- update settings views to use defined formats as appropriate

## Related issue number(s) and link(s)
[385](https://github.com/ejbills/DockDoor/issues/385)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] If this change affects core functionality, I have added a description highlighting the changes
- [x] I have followed conventional commit guidelines

## Screenshots

https://github.com/user-attachments/assets/3755c256-0298-47e6-beb9-dccd6ad9f8f3

## Notes

I am not familiar with swift or macOS development, so don't know which of these methods is more appropriate. I'd already written my change before the [other change](https://github.com/ejbills/DockDoor/commit/ee6a46398a52b4dc056ef8b3430a1bc939743cc1) went in, and was just dealing with some branch weirdness on my repo since I usually only PR within a repo, not across forks...

Anyway, figured I'd send the PR even though there is a different fix in place, can take a look and keep or trash
