### PR TITLE
feat: enhance window switcher by focusing on second preview

### DIFF
--- a/DockDoor/Utilities/KeybindHelper.swift
+++ b/DockDoor/Utilities/KeybindHelper.swift
@@ -211,6 +211,15 @@ class KeybindHelper {
                                     currentMouseLocation: CGPoint,
                                     targetScreen: NSScreen)
     {
+        // If classic window ordering is enabled and there are at least two windows,
+        // set the initial focus on the second window preview (instead of the first).
+        //
+        // This behavior improves window switching speed and mimics the Windows OS
+        // experience, making it easier for users to switch between recent windows quickly.
+        if Defaults[.useClassicWindowOrdering], windows.count >= 2 {
+            SharedPreviewWindowCoordinator.shared.windowSwitcherCoordinator.setIndex(to: 1)
+        }
+
         let showWindow = { (mouseLocation: NSPoint?, mouseScreen: NSScreen?) in
             SharedPreviewWindowCoordinator.shared.showWindow(
                 appName: "Window Switcher",

--- a/DockDoor/Utilities/Window Management/WindowUtil.swift
+++ b/DockDoor/Utilities/Window Management/WindowUtil.swift
@@ -395,15 +395,6 @@ enum WindowUtil {
             windows = windows.filter { !$0.isHidden && !$0.isMinimized }
         }
 
-        // If classic ordering is enabled and there are at least two windows,
-        // swap the first and second windows
-        if Defaults[.useClassicWindowOrdering], windows.count >= 2 {
-            var modifiedWindows = windows
-            modifiedWindows.swapAt(0, 1)
-            return modifiedWindows
-        }
-
-        // Otherwise return natural date-based ordering
         return windows
     }
 


### PR DESCRIPTION




## Describe your changes
- When classic ordering is enabled and there are at least two windows, set the initial focus on the second window preview instead of the first.
- This improves switching speed and provides a more intuitive experience, similar to Windows OS behavior.

## Related issue number(s) and link(s)
- Fixes #455 #439 #431

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] If this change affects core functionality, I have added a description highlighting the changes
- [x] I have followed conventional commit guidelines

## Core Functionality Changes
