### PR TITLE
feat: allow navigation with arrow keys, select by pressing return

### DIFF
--- a/DockDoor.xcodeproj/project.pbxproj
+++ b/DockDoor.xcodeproj/project.pbxproj
@@ -92,6 +92,7 @@
 		BBE153BE2D2126D000CD3D4A /* MaterialPill.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBE153BD2D2126C000CD3D4A /* MaterialPill.swift */; };
 		BBE153C02D21FA2700CD3D4A /* StyledGroupBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBE153BF2D21FA2300CD3D4A /* StyledGroupBox.swift */; };
 		BBE153C22D22024F00CD3D4A /* View.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBE153C12D22024E00CD3D4A /* View.swift */; };
+		BBE63DFF2DEA583C0079D2B9 /* PreviewStateCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBE63DFE2DEA58040079D2B9 /* PreviewStateCoordinator.swift */; };
 		BBE692192D17AD9E0093B4A5 /* DangerButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBE692182D17AD9C0093B4A5 /* DangerButton.swift */; };
 		BBE7CC8F2C22421900AB8F4D /* Settings in Frameworks */ = {isa = PBXBuildFile; productRef = BBE7CC8E2C22421900AB8F4D /* Settings */; };
 		BBE7CC912C22429A00AB8F4D /* settings.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBE7CC902C22429A00AB8F4D /* settings.swift */; };
@@ -187,6 +188,7 @@
 		BBE153BD2D2126C000CD3D4A /* MaterialPill.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaterialPill.swift; sourceTree = "<group>"; };
 		BBE153BF2D21FA2300CD3D4A /* StyledGroupBox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StyledGroupBox.swift; sourceTree = "<group>"; };
 		BBE153C12D22024E00CD3D4A /* View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = View.swift; sourceTree = "<group>"; };
+		BBE63DFE2DEA58040079D2B9 /* PreviewStateCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewStateCoordinator.swift; sourceTree = "<group>"; };
 		BBE692182D17AD9C0093B4A5 /* DangerButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DangerButton.swift; sourceTree = "<group>"; };
 		BBE7CC902C22429A00AB8F4D /* settings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = settings.swift; sourceTree = "<group>"; };
 		BBF383962C94A25B00B39A23 /* sliderSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = sliderSetting.swift; sourceTree = "<group>"; };
@@ -423,6 +425,7 @@
 		BB6021CE2D1E60C700D47C86 /* WindowPreview Supporting */ = {
 			isa = PBXGroup;
 			children = (
+				BBE63DFE2DEA58040079D2B9 /* PreviewStateCoordinator.swift */,
 				BB0CBE392DD8179200D55437 /* MouseEventModifier.swift */,
 				BB3D6EAD2C82E4AE00FFE584 /* WindowDismissalContainer.swift */,
 				BB6021D12D1E613100D47C86 /* Window Image Sizing Calculations.swift */,
@@ -646,6 +649,7 @@
 				BB0440602C77AD2C009F1D33 /* CodableColor.swift in Sources */,
 				BB52EDF02C5BEFE3006A64A4 /* HiddenModifier.swift in Sources */,
 				BBBAA15B2DE6998B00FF8F8F /* UpdaterState.swift in Sources */,
+				BBE63DFF2DEA583C0079D2B9 /* PreviewStateCoordinator.swift in Sources */,
 				BB15E1EC2C8F8F13002ECFB9 /* CardModifier.swift in Sources */,
 				BB44474F2C507F950047EB92 /* LimitedTaskGroup.swift in Sources */,
 				BBBD4AF52C8D671C0074FFCF /* NSImage.swift in Sources */,

--- a/DockDoor/Utilities/KeybindHelper.swift
+++ b/DockDoor/Utilities/KeybindHelper.swift
@@ -18,6 +18,7 @@ struct UserKeyBind: Codable, Defaults.Serializable {
 private class WindowSwitchingCoordinator {
     private var isProcessingSwitcher = false
 
+    @MainActor
     func handleWindowSwitching(
         previewCoordinator: SharedPreviewWindowCoordinator,
         isModifierPressed: Bool,
@@ -25,12 +26,11 @@ private class WindowSwitchingCoordinator {
     ) async {
         guard !isProcessingSwitcher else { return }
         isProcessingSwitcher = true
-
         defer { isProcessingSwitcher = false }
 
-        if await previewCoordinator.isVisible {
-            await previewCoordinator.cycleWindows(goBackwards: isShiftPressed)
-        } else {
+        if previewCoordinator.isVisible {
+            previewCoordinator.cycleWindows(goBackwards: isShiftPressed)
+        } else if isModifierPressed {
             await showHoverWindow(
                 previewCoordinator: previewCoordinator,
                 isModifierPressed: isModifierPressed
@@ -38,6 +38,7 @@ private class WindowSwitchingCoordinator {
         }
     }
 
+    @MainActor
     private func showHoverWindow(
         previewCoordinator: SharedPreviewWindowCoordinator,
         isModifierPressed: Bool
@@ -65,6 +66,7 @@ private class WindowSwitchingCoordinator {
         }
     }
 
+    @MainActor
     private func displayHoverWindow(
         previewCoordinator: SharedPreviewWindowCoordinator,
         windows: [WindowInfo],
@@ -75,7 +77,7 @@ private class WindowSwitchingCoordinator {
             previewCoordinator.windowSwitcherCoordinator.setIndex(to: 1)
         }
 
-        let showWindow = { (mouseLocation: NSPoint?, mouseScreen: NSScreen?) in
+        let showWindowLambda = { (mouseLocation: NSPoint?, mouseScreen: NSScreen?) in
             previewCoordinator.showWindow(
                 appName: "Window Switcher",
                 windows: windows,
@@ -85,25 +87,23 @@ private class WindowSwitchingCoordinator {
                 overrideDelay: true,
                 centeredHoverWindowState: .windowSwitcher,
                 onWindowTap: {
-                    previewCoordinator.hideWindow()
+                    Task { @MainActor in
+                        previewCoordinator.hideWindow()
+                    }
                 }
             )
         }
 
         switch Defaults[.windowSwitcherPlacementStrategy] {
         case .pinnedToScreen:
-            let screenCenter = NSPoint(x: targetScreen.frame.midX,
-                                       y: targetScreen.frame.midY)
-            showWindow(screenCenter, targetScreen)
-
+            let screenCenter = NSPoint(x: targetScreen.frame.midX, y: targetScreen.frame.midY)
+            showWindowLambda(screenCenter, targetScreen)
         case .screenWithLastActiveWindow:
-            showWindow(nil, nil)
-
+            showWindowLambda(nil, nil)
         case .screenWithMouse:
             let mouseScreen = NSScreen.screenContainingMouse(currentMouseLocation)
-            let convertedMouseLocation = DockObserver.nsPointFromCGPoint(currentMouseLocation,
-                                                                         forScreen: mouseScreen)
-            showWindow(convertedMouseLocation, mouseScreen)
+            let convertedMouseLocation = DockObserver.nsPointFromCGPoint(currentMouseLocation, forScreen: mouseScreen)
+            showWindowLambda(convertedMouseLocation, mouseScreen)
         }
     }
 
@@ -123,11 +123,11 @@ class KeybindHelper {
     private let dockObserver: DockObserver
     private let windowSwitchingCoordinator = WindowSwitchingCoordinator()
 
-    private var isModifierKeyPressed = false
-    private var isShiftKeyPressed = false
+    private var isSwitcherModifierKeyPressed: Bool = false
+    private var isShiftKeyPressedGeneral: Bool = false
+
     private var eventTap: CFMachPort?
     private var runLoopSource: CFRunLoopSource?
-    private var modifierValue: Int = 0
     private var monitorTimer: Timer?
     private var unmanagedEventTapUserInfo: Unmanaged<KeybindHelperUserInfo>?
 
@@ -136,11 +136,6 @@ class KeybindHelper {
         self.dockObserver = dockObserver
         setupEventTap()
         startMonitoring()
-    }
-
-    deinit {
-        cleanup()
-        print("KeybindHelper deinit")
     }
 
     func reset() {
@@ -157,9 +152,8 @@ class KeybindHelper {
     }
 
     private func resetState() {
-        isModifierKeyPressed = false
-        isShiftKeyPressed = false
-        modifierValue = 0
+        isSwitcherModifierKeyPressed = false
+        isShiftKeyPressedGeneral = false
     }
 
     private func startMonitoring() {
@@ -169,20 +163,15 @@ class KeybindHelper {
     }
 
     private func checkEventTapStatus() {
-        guard let eventTap else {
+        guard let eventTap, CGEvent.tapIsEnabled(tap: eventTap) else {
             reset()
             return
-        }
-
-        if !CGEvent.tapIsEnabled(tap: eventTap) {
-            reset()
         }
     }
 
     private static let eventCallback: CGEventTapCallBack = { proxy, type, event, refcon in
         guard let refcon else { return Unmanaged.passUnretained(event) }
-        let userInfo = Unmanaged<KeybindHelperUserInfo>.fromOpaque(refcon).takeUnretainedValue()
-        return userInfo.instance.handleEvent(proxy: proxy, type: type, event: event)
+        return Unmanaged<KeybindHelperUserInfo>.fromOpaque(refcon).takeUnretainedValue().instance.handleEvent(proxy: proxy, type: type, event: event)
     }
 
     private func setupEventTap() {
@@ -231,120 +220,141 @@ class KeybindHelper {
     }
 
     private func handleEvent(proxy: CGEventTapProxy, type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
-        let keyCode = event.getIntegerValueField(.keyboardEventKeycode)
-        let keyBoardShortcutSaved: UserKeyBind = Defaults[.UserKeybind]
-        let shiftKeyCurrentlyPressed = event.flags.contains(.maskShift)
-        var userDefinedKeyCurrentlyPressed = false
-
         switch type {
         case .flagsChanged:
-            handleFlagsChanged(event: event, userDefinedKeyCurrentlyPressed: &userDefinedKeyCurrentlyPressed)
-            handleModifierEvent(modifierKeyPressed: userDefinedKeyCurrentlyPressed,
-                                shiftKeyPressed: shiftKeyCurrentlyPressed)
+            let keyBoardShortcutSaved: UserKeyBind = Defaults[.UserKeybind]
+            let (currentSwitcherModifierIsPressed, currentShiftState) = updateModifierStatesFromFlags(event: event, keyBoardShortcutSaved: keyBoardShortcutSaved)
+
+            Task { @MainActor [weak self] in
+                self?.handleModifierEvent(currentSwitcherModifierIsPressed: currentSwitcherModifierIsPressed, currentShiftState: currentShiftState)
+            }
 
         case .keyDown:
-            let shouldConsumeKeyEvent = handleKeyDown(keyCode: keyCode,
-                                                      keyBoardShortcutSaved: keyBoardShortcutSaved)
-
-            if shouldConsumeKeyEvent {
-                return nil
+            let (shouldConsume, actionTask) = determineActionForKeyDown(event: event)
+            if let task = actionTask {
+                Task { @MainActor in
+                    await task()
+                }
             }
+            if shouldConsume { return nil }
 
         default:
             break
         }
-
         return Unmanaged.passUnretained(event)
     }
 
-    private func handleFlagsChanged(event: CGEvent, userDefinedKeyCurrentlyPressed: inout Bool) {
-        if event.flags.contains(.maskControl) {
-            modifierValue = Defaults[.Int64maskControl]
-            userDefinedKeyCurrentlyPressed = true
-        } else if event.flags.contains(.maskAlternate) {
-            modifierValue = Defaults[.Int64maskAlternate]
-            userDefinedKeyCurrentlyPressed = true
-        } else if event.flags.contains(.maskCommand) {
-            modifierValue = Defaults[.Int64maskCommand]
-            userDefinedKeyCurrentlyPressed = true
-        }
+    private func updateModifierStatesFromFlags(event: CGEvent, keyBoardShortcutSaved: UserKeyBind) -> (currentSwitcherModifierIsPressed: Bool, currentShiftState: Bool) {
+        let currentSwitcherModifierIsPressed = event.flags.rawValue & UInt64(keyBoardShortcutSaved.modifierFlags) == UInt64(keyBoardShortcutSaved.modifierFlags) && keyBoardShortcutSaved.modifierFlags != 0
+        let currentShiftState = event.flags.contains(.maskShift)
+
+        return (currentSwitcherModifierIsPressed, currentShiftState)
     }
 
-    private func handleKeyDown(keyCode: Int64, keyBoardShortcutSaved: UserKeyBind) -> Bool {
-        if previewCoordinator.isVisible, keyCode == kVK_Escape {
-            previewCoordinator.hideWindow()
-            return true
-        }
-
-        if previewCoordinator.isVisible {
-            var consumed = false
-            switch keyCode {
-            case Int64(kVK_LeftArrow):
-                previewCoordinator.navigateWithArrowKey(direction: .left)
-                consumed = true
-            case Int64(kVK_RightArrow):
-                previewCoordinator.navigateWithArrowKey(direction: .right)
-                consumed = true
-            case Int64(kVK_UpArrow):
-                previewCoordinator.navigateWithArrowKey(direction: .up)
-                consumed = true
-            case Int64(kVK_DownArrow):
-                previewCoordinator.navigateWithArrowKey(direction: .down)
-                consumed = true
-            case Int64(kVK_Return):
-                previewCoordinator.selectAndBringToFrontCurrentWindow()
-                consumed = true
-            default:
-                break
-            }
-            if consumed {
-                return true
-            }
-        }
-
-        if isModifierKeyPressed,
-           keyCode == keyBoardShortcutSaved.keyCode,
-           modifierValue == keyBoardShortcutSaved.modifierFlags
-        {
-            handleKeybindActivation()
-            return true
-        }
-
-        if previewCoordinator.isVisible,
-           !isModifierKeyPressed,
-           keyCode == keyBoardShortcutSaved.keyCode
-        {
-            handleKeybindActivation()
-            return true
-        }
-
-        return false
-    }
-
-    private func handleKeybindActivation() {
-        Task { @MainActor in
-            await windowSwitchingCoordinator.handleWindowSwitching(
-                previewCoordinator: previewCoordinator,
-                isModifierPressed: isModifierKeyPressed,
-                isShiftPressed: isShiftKeyPressed
-            )
-        }
-    }
-
-    private func handleModifierEvent(modifierKeyPressed: Bool, shiftKeyPressed: Bool) {
-        let oldModifierState = isModifierKeyPressed
-        isModifierKeyPressed = modifierKeyPressed
-        isShiftKeyPressed = shiftKeyPressed
+    @MainActor
+    private func handleModifierEvent(currentSwitcherModifierIsPressed: Bool, currentShiftState: Bool) {
+        let oldSwitcherModifierState = isSwitcherModifierKeyPressed
+        isSwitcherModifierKeyPressed = currentSwitcherModifierIsPressed
+        isShiftKeyPressedGeneral = currentShiftState
 
         if !Defaults[.preventSwitcherHide] {
-            if oldModifierState, !isModifierKeyPressed {
-                DispatchQueue.main.async { [weak self] in
-                    guard let self else { return }
-                    if previewCoordinator.isVisible {
-                        previewCoordinator.selectAndBringToFrontCurrentWindow()
+            if oldSwitcherModifierState, !isSwitcherModifierKeyPressed {
+                Task { @MainActor in
+                    if self.previewCoordinator.isVisible, self.previewCoordinator.windowSwitcherCoordinator.windowSwitcherActive {
+                        self.previewCoordinator.selectAndBringToFrontCurrentWindow()
                     }
                 }
             }
         }
+    }
+
+    private func determineActionForKeyDown(event: CGEvent) -> (shouldConsume: Bool, actionTask: (() async -> Void)?) {
+        let keyCode = event.getIntegerValueField(.keyboardEventKeycode)
+        let flags = event.flags
+        let keyBoardShortcutSaved: UserKeyBind = Defaults[.UserKeybind]
+        let previewIsCurrentlyVisible = previewCoordinator.isVisible
+
+        if previewIsCurrentlyVisible {
+            if keyCode == kVK_Escape {
+                return (true, { await self.previewCoordinator.hideWindow() })
+            }
+
+            if flags.contains(.maskCommand), previewCoordinator.windowSwitcherCoordinator.currIndex >= 0 {
+                switch keyCode {
+                case Int64(kVK_ANSI_W):
+                    return (true, { await self.previewCoordinator.performActionOnCurrentWindow(action: .close) })
+                case Int64(kVK_ANSI_Q):
+                    return (true, { await self.previewCoordinator.performActionOnCurrentWindow(action: .quit) })
+                case Int64(kVK_ANSI_M):
+                    return (true, { await self.previewCoordinator.performActionOnCurrentWindow(action: .minimize) })
+                default:
+                    break
+                }
+            }
+        }
+
+        let isExactSwitcherShortcutPressed = (isSwitcherModifierKeyPressed && keyCode == keyBoardShortcutSaved.keyCode) ||
+            (!isSwitcherModifierKeyPressed && keyBoardShortcutSaved.modifierFlags == 0 && keyCode == keyBoardShortcutSaved.keyCode)
+
+        if isExactSwitcherShortcutPressed {
+            return (true, { await self.handleKeybindActivation() })
+        }
+
+        if previewIsCurrentlyVisible {
+            if keyCode == kVK_Tab {
+                return (true, { await self.previewCoordinator.cycleWindows(goBackwards: flags.contains(.maskShift)) })
+            }
+            switch keyCode {
+            case Int64(kVK_LeftArrow), Int64(kVK_RightArrow), Int64(kVK_UpArrow), Int64(kVK_DownArrow):
+                let dir: ArrowDirection = switch keyCode {
+                case Int64(kVK_LeftArrow):
+                    .left
+                case Int64(kVK_RightArrow):
+                    .right
+                case Int64(kVK_UpArrow):
+                    .up
+                default:
+                    .down
+                }
+                return (true, { await self.previewCoordinator.navigateWithArrowKey(direction: dir) })
+            case Int64(kVK_Return):
+                if previewCoordinator.windowSwitcherCoordinator.currIndex >= 0 {
+                    return (true, { await self.previewCoordinator.selectAndBringToFrontCurrentWindow() })
+                }
+            default:
+                break
+            }
+        }
+
+        if previewIsCurrentlyVisible,
+           previewCoordinator.windowSwitcherCoordinator.windowSwitcherActive,
+           keyCode == keyBoardShortcutSaved.keyCode,
+           !isSwitcherModifierKeyPressed,
+           keyBoardShortcutSaved.modifierFlags != 0,
+           !flags.hasSuperfluousModifiers(ignoring: [.maskShift, .maskAlphaShift, .maskNumericPad])
+        {
+            return (true, { await self.handleKeybindActivation() })
+        }
+
+        return (false, nil)
+    }
+
+    @MainActor
+    private func handleKeybindActivation() {
+        Task { @MainActor in
+            await windowSwitchingCoordinator.handleWindowSwitching(
+                previewCoordinator: previewCoordinator,
+                isModifierPressed: self.isSwitcherModifierKeyPressed,
+                isShiftPressed: self.isShiftKeyPressedGeneral
+            )
+        }
+    }
+}
+
+extension CGEventFlags {
+    func hasSuperfluousModifiers(ignoring: CGEventFlags = []) -> Bool {
+        let significantModifiers: CGEventFlags = [.maskControl, .maskAlternate, .maskCommand]
+        let relevantToCheck = significantModifiers.subtracting(ignoring)
+        return !intersection(relevantToCheck).isEmpty
     }
 }

--- a/DockDoor/Utilities/Misc Utils.swift
+++ b/DockDoor/Utilities/Misc Utils.swift
@@ -62,7 +62,6 @@ enum KeyCodeConverter {
         case 36:
             return "↩︎" // Return symbol
         default:
-
             let source = TISCopyCurrentKeyboardInputSource().takeUnretainedValue()
             let layoutData = TISGetInputSourceProperty(source, kTISPropertyUnicodeKeyLayoutData)
 

--- a/DockDoor/Utilities/Window Management/WindowManipulationObservers.swift
+++ b/DockDoor/Utilities/Window Management/WindowManipulationObservers.swift
@@ -69,6 +69,7 @@ class WindowManipulationObservers {
         handleNewWindow(for: app.processIdentifier)
     }
 
+    @MainActor
     @objc private func appDidTerminate(_ notification: Notification) {
         guard let app = notification.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication else {
             return

--- a/DockDoor/Views/Hover Window/WindowPreview Supporting/Flow Container Calculations.swift
+++ b/DockDoor/Views/Hover Window/WindowPreview Supporting/Flow Container Calculations.swift
@@ -3,8 +3,13 @@ import Defaults
 
 // Handles calculating rows and columns for flow container
 extension WindowPreviewHoverContainer {
-    func calculateOptimalLayout(windowDimensions: [Int: WindowDimensions], isHorizontal: Bool, wrap: Int) -> (stackCount: Int, windowsPerStack: [Range<Int>]) {
-        let activeWindowCount = windowStates.count
+    func calculateOptimalLayout(
+        windowDimensions: [Int: WindowDimensions],
+        isHorizontal: Bool,
+        wrap: Int,
+        maxDimensionForLayout: CGPoint
+    ) -> (stackCount: Int, windowsPerStack: [Range<Int>]) {
+        let activeWindowCount = previewStateCoordinator.windows.count
 
         guard activeWindowCount > 0 else {
             return (1, [0 ..< 0])
@@ -19,7 +24,7 @@ extension WindowPreviewHoverContainer {
 
         // Additional padding based on mode
         let additionalPadding: CGFloat = {
-            if windowSwitcherCoordinator.windowSwitcherActive {
+            if previewStateCoordinator.windowSwitcherActive {
                 return 50
             } else if showAppTitleData {
                 switch appNameStyle {
@@ -37,143 +42,100 @@ extension WindowPreviewHoverContainer {
         if isHorizontal {
             let maxWidth = visibleFrame.width - totalHorizontalPadding
             let maxHeight = visibleFrame.height - totalVerticalPadding
-            let rowHeight = maxWindowDimension.y + itemSpacing
-            let availableHeight = maxHeight - itemSpacing
 
-            // Calculate maximum allowed rows
-            let calculatedMaxRows = max(1, Int(floor(availableHeight / rowHeight)))
+            // Calculate actual window height from window dimensions instead of using maxDimensionForLayout
+            var actualMaxWindowHeight: CGFloat = 0
+            for windowIndex in 0 ..< activeWindowCount {
+                let height = windowDimensions[windowIndex]?.size.height ?? maxDimensionForLayout.y
+                actualMaxWindowHeight = max(actualMaxWindowHeight, height)
+            }
+
+            // First row: actualMaxWindowHeight
+            // Subsequent rows: itemSpacing + actualMaxWindowHeight each
+            let calculatedMaxRows: Int
+            if actualMaxWindowHeight > maxHeight {
+                calculatedMaxRows = 1 // Can't even fit one row properly
+            } else {
+                let remainingHeight = maxHeight - actualMaxWindowHeight
+                let additionalRows = Int(floor(remainingHeight / (actualMaxWindowHeight + itemSpacing)))
+                calculatedMaxRows = 1 + additionalRows
+            }
+
             let userMaxRows = wrap
             let effectiveMaxRows = userMaxRows > 0 ? min(Int(userMaxRows), calculatedMaxRows) : calculatedMaxRows
 
-            // Calculate optimal number of rows based on window widths and available space
+            // Calculate total width needed for all windows
             var totalWidthNeeded: CGFloat = 0
-            var maxWindowWidth: CGFloat = 0
-
             for windowIndex in 0 ..< activeWindowCount {
                 let width = windowDimensions[windowIndex]?.size.width ?? 0
-                totalWidthNeeded += width + (totalWidthNeeded > 0 ? itemSpacing : 0)
-                maxWindowWidth = max(maxWindowWidth, width)
+                totalWidthNeeded += width + (windowIndex > 0 ? itemSpacing : 0)
             }
 
-            let avgWindowsPerRow = max(2, CGFloat(activeWindowCount) / CGFloat(effectiveMaxRows))
-            let optimalRows = max(min(effectiveMaxRows,
-                                      Int(ceil(totalWidthNeeded / maxWidth))),
-                                  Int(ceil(CGFloat(activeWindowCount) / avgWindowsPerRow)))
-
-            let targetWindowsPerRow = Int(floor(CGFloat(activeWindowCount) / CGFloat(optimalRows)))
-
-            var rows: [[Int]] = [[]]
-            var currentRowWidth: CGFloat = 0
-            var currentRowIndex = 0
-            var currentRowCount = 0
-
-            for windowIndex in 0 ..< activeWindowCount {
-                let windowWidth = windowDimensions[windowIndex]?.size.width ?? 0
-                let newWidth = currentRowWidth + windowWidth + (currentRowWidth > 0 ? itemSpacing : 0)
-
-                let isLastRow = currentRowIndex == effectiveMaxRows - 1
-                let shouldStartNewRow = newWidth > maxWidth || (!isLastRow && currentRowCount >= targetWindowsPerRow)
-
-                if shouldStartNewRow {
-                    if currentRowIndex + 1 >= effectiveMaxRows {
-                        return redistributeEvenly(windowCount: activeWindowCount, divisions: effectiveMaxRows)
-                    }
-
-                    currentRowIndex += 1
-                    rows.append([])
-                    currentRowWidth = windowWidth
-                    currentRowCount = 1
-                } else {
-                    currentRowWidth = newWidth
-                    currentRowCount += 1
-                }
-
-                rows[currentRowIndex].append(windowIndex)
+            // Determine optimal number of rows
+            let optimalRows: Int
+            if totalWidthNeeded <= maxWidth {
+                // All windows fit in one row
+                optimalRows = 1
+            } else {
+                // Calculate how many rows we need based on available space
+                let minRowsNeeded = Int(ceil(totalWidthNeeded / maxWidth))
+                optimalRows = max(1, min(effectiveMaxRows, minRowsNeeded))
             }
 
-            var ranges: [Range<Int>] = []
-            var startIndex = 0
+            // Use even distribution for better balance
+            return redistributeEvenly(windowCount: activeWindowCount, divisions: optimalRows)
 
-            for row in rows {
-                if !row.isEmpty {
-                    ranges.append(startIndex ..< (startIndex + row.count))
-                    startIndex += row.count
-                }
-            }
-
-            return (ranges.count, ranges)
-
-        } else {
+        } else { // Vertical Flow
             let maxHeight = visibleFrame.height - totalVerticalPadding
             let maxWidth = visibleFrame.width - totalHorizontalPadding
-            let columnWidth = maxWindowDimension.x + itemSpacing
-            let availableWidth = maxWidth - itemSpacing
 
-            let calculatedMaxColumns = max(1, Int(floor(availableWidth / columnWidth)))
+            // Calculate actual window width from window dimensions instead of using maxDimensionForLayout
+            var actualMaxWindowWidth: CGFloat = 0
+            for windowIndex in 0 ..< activeWindowCount {
+                let width = windowDimensions[windowIndex]?.size.width ?? maxDimensionForLayout.x
+                actualMaxWindowWidth = max(actualMaxWindowWidth, width)
+            }
+
+            let calculatedMaxColumns: Int
+            if actualMaxWindowWidth > maxWidth {
+                calculatedMaxColumns = 1 // Can't even fit one column properly
+            } else {
+                let remainingWidth = maxWidth - actualMaxWindowWidth
+                let additionalColumns = Int(floor(remainingWidth / (actualMaxWindowWidth + itemSpacing)))
+                calculatedMaxColumns = 1 + additionalColumns
+            }
+
             let userMaxColumns = wrap
             let effectiveMaxColumns = userMaxColumns > 0 ? min(Int(userMaxColumns), calculatedMaxColumns) : calculatedMaxColumns
 
+            // Calculate total height needed for all windows
             var totalHeightNeeded: CGFloat = 0
-            var maxWindowHeight: CGFloat = 0
-
             for windowIndex in 0 ..< activeWindowCount {
                 let height = windowDimensions[windowIndex]?.size.height ?? 0
-                totalHeightNeeded += height + (totalHeightNeeded > 0 ? itemSpacing : 0)
-                maxWindowHeight = max(maxWindowHeight, height)
+                totalHeightNeeded += height + (windowIndex > 0 ? itemSpacing : 0)
             }
 
-            let avgWindowsPerColumn = max(2, CGFloat(activeWindowCount) / CGFloat(effectiveMaxColumns))
-            let optimalColumns = max(min(effectiveMaxColumns,
-                                         Int(ceil(totalHeightNeeded / maxHeight))),
-                                     Int(ceil(CGFloat(activeWindowCount) / avgWindowsPerColumn)))
-
-            let targetWindowsPerColumn = Int(floor(CGFloat(activeWindowCount) / CGFloat(optimalColumns)))
-
-            var columns: [[Int]] = [[]]
-            var columnHeights: [CGFloat] = [0]
-            var currentColumnIndex = 0
-            var currentColumnCount = 0
-
-            for windowIndex in 0 ..< activeWindowCount {
-                let windowHeight = windowDimensions[windowIndex]?.size.height ?? 0
-                let newHeight = columnHeights[currentColumnIndex] + windowHeight + (columnHeights[currentColumnIndex] > 0 ? itemSpacing : 0)
-
-                let isLastColumn = currentColumnIndex == effectiveMaxColumns - 1
-                let shouldStartNewColumn = newHeight > maxHeight || (!isLastColumn && currentColumnCount >= targetWindowsPerColumn)
-
-                if shouldStartNewColumn {
-                    if currentColumnIndex + 1 >= effectiveMaxColumns {
-                        return redistributeEvenly(windowCount: activeWindowCount, divisions: effectiveMaxColumns)
-                    }
-
-                    currentColumnIndex += 1
-                    columns.append([])
-                    columnHeights.append(0)
-                    columnHeights[currentColumnIndex] = windowHeight
-                    currentColumnCount = 1
-                } else {
-                    columnHeights[currentColumnIndex] = newHeight
-                    currentColumnCount += 1
-                }
-
-                columns[currentColumnIndex].append(windowIndex)
+            // Determine optimal number of columns
+            let optimalColumns: Int
+            if totalHeightNeeded <= maxHeight {
+                // All windows fit in one column
+                optimalColumns = 1
+            } else {
+                // Calculate how many columns we need based on available space
+                let minColumnsNeeded = Int(ceil(totalHeightNeeded / maxHeight))
+                optimalColumns = max(1, min(effectiveMaxColumns, minColumnsNeeded))
             }
 
-            var ranges: [Range<Int>] = []
-            var startIndex = 0
-
-            for column in columns {
-                if !column.isEmpty {
-                    ranges.append(startIndex ..< (startIndex + column.count))
-                    startIndex += column.count
-                }
-            }
-
-            return (ranges.count, ranges)
+            // Use even distribution for better balance
+            return redistributeEvenly(windowCount: activeWindowCount, divisions: optimalColumns)
         }
     }
 
     private func redistributeEvenly(windowCount: Int, divisions: Int) -> (stackCount: Int, windowsPerStack: [Range<Int>]) {
+        guard divisions > 0 else { // Prevent division by zero
+            if windowCount > 0 { return (1, [0 ..< windowCount]) }
+            return (0, [])
+        }
         let baseCount = windowCount / divisions
         let remainder = windowCount % divisions
 
@@ -189,7 +151,11 @@ extension WindowPreviewHoverContainer {
                 startIndex += count
             }
         }
+        // If no ranges were created but there are windows (e.g. windowCount < divisions, baseCount is 0 for some), ensure all windows are covered.
+        if ranges.isEmpty, windowCount > 0 {
+            return (1, [0 ..< windowCount])
+        }
 
-        return (ranges.count, ranges)
+        return (ranges.count > 0 ? ranges.count : 1, ranges)
     }
 }

--- a/DockDoor/Views/Hover Window/WindowPreview Supporting/PreviewStateCoordinator.swift
+++ b/DockDoor/Views/Hover Window/WindowPreview Supporting/PreviewStateCoordinator.swift
@@ -1,0 +1,96 @@
+import Defaults
+import SwiftUI
+
+class PreviewStateCoordinator: ObservableObject {
+    @Published var currIndex: Int = 0
+    @Published var windowSwitcherActive: Bool = false
+    @Published var fullWindowPreviewActive: Bool = false
+    @Published var windows: [WindowInfo] = []
+
+    @Published var overallMaxPreviewDimension: CGPoint = .zero
+    @Published var windowDimensionsMap: [Int: WindowPreviewHoverContainer.WindowDimensions] = [:]
+
+    enum WindowState {
+        case windowSwitcher
+        case fullWindowPreview
+        case both
+    }
+
+    func setShowing(_ state: WindowState? = .both, toState: Bool) {
+        switch state {
+        case .windowSwitcher:
+            windowSwitcherActive = toState
+        case .fullWindowPreview:
+            fullWindowPreviewActive = toState
+        case .both:
+            windowSwitcherActive = toState
+            fullWindowPreviewActive = toState
+        case .none:
+            return
+        }
+    }
+
+    func setIndex(to: Int) {
+        currIndex = to
+    }
+
+    func setWindows(_ newWindows: [WindowInfo], dockPosition: DockPosition, bestGuessMonitor: NSScreen, isMockPreviewActive: Bool = false) {
+        let filteredWindows = newWindows.filter { windowInfo in
+            let isDockDoorApp = windowInfo.app.localizedName?.contains("DockDoor") ?? false
+            if isDockDoorApp {
+                // If it's DockDoor, only include it if its settings are visible
+                return (NSApp.delegate as? AppDelegate)?.settingsWindowController.window?.isVisible ?? false
+            }
+            // If it's not DockDoor, always include it
+            return true
+        }
+
+        windows = filteredWindows
+
+        if currIndex >= windows.count {
+            currIndex = max(0, windows.count - 1)
+        }
+        recomputeAndPublishDimensions(dockPosition: dockPosition, bestGuessMonitor: bestGuessMonitor, isMockPreviewActive: isMockPreviewActive)
+    }
+
+    func updateWindow(at index: Int, with newInfo: WindowInfo, dockPosition: DockPosition, bestGuessMonitor: NSScreen, isMockPreviewActive: Bool = false) {
+        guard index >= 0, index < windows.count else { return }
+        windows[index] = newInfo
+    }
+
+    func removeWindow(at index: Int, dockPosition: DockPosition, bestGuessMonitor: NSScreen, isMockPreviewActive: Bool = false) {
+        guard index >= 0, index < windows.count else { return }
+        windows.remove(at: index)
+        if currIndex >= windows.count {
+            currIndex = max(0, windows.count - 1)
+        }
+        if windows.isEmpty { SharedPreviewWindowCoordinator.activeInstance?.hideWindow() }
+    }
+
+    func removeAllWindows(dockPosition: DockPosition, bestGuessMonitor: NSScreen, isMockPreviewActive: Bool = false) {
+        windows.removeAll()
+        currIndex = 0
+        SharedPreviewWindowCoordinator.activeInstance?.hideWindow()
+    }
+
+    private func recomputeAndPublishDimensions(dockPosition: DockPosition, bestGuessMonitor: NSScreen, isMockPreviewActive: Bool = false) {
+        let panelSize = getWindowSize()
+
+        let newOverallMaxDimension = WindowPreviewHoverContainer.calculateOverallMaxDimensions(
+            windows: windows,
+            dockPosition: dockPosition,
+            isWindowSwitcherActive: windowSwitcherActive,
+            isMockPreviewActive: isMockPreviewActive,
+            sharedPanelWindowSize: panelSize
+        )
+
+        let newDimensionsMap = WindowPreviewHoverContainer.precomputeWindowDimensions(
+            windows: windows,
+            overallMaxDimensions: newOverallMaxDimension,
+            bestGuessMonitor: bestGuessMonitor
+        )
+
+        overallMaxPreviewDimension = newOverallMaxDimension
+        windowDimensionsMap = newDimensionsMap
+    }
+}

--- a/DockDoor/Views/Hover Window/WindowPreview Supporting/PreviewStateCoordinator.swift
+++ b/DockDoor/Views/Hover Window/WindowPreview Supporting/PreviewStateCoordinator.swift
@@ -1,8 +1,9 @@
 import Defaults
 import SwiftUI
 
+// Manages window element states and presentation of window switcher (and associated cycling
 class PreviewStateCoordinator: ObservableObject {
-    @Published var currIndex: Int = 0
+    @Published var currIndex: Int = -1
     @Published var windowSwitcherActive: Bool = false
     @Published var fullWindowPreviewActive: Bool = false
     @Published var windows: [WindowInfo] = []
@@ -16,7 +17,9 @@ class PreviewStateCoordinator: ObservableObject {
         case both
     }
 
+    @MainActor
     func setShowing(_ state: WindowState? = .both, toState: Bool) {
+        let oldSwitcherState = windowSwitcherActive
         switch state {
         case .windowSwitcher:
             windowSwitcherActive = toState
@@ -28,51 +31,122 @@ class PreviewStateCoordinator: ObservableObject {
         case .none:
             return
         }
-    }
 
-    func setIndex(to: Int) {
-        currIndex = to
-    }
-
-    func setWindows(_ newWindows: [WindowInfo], dockPosition: DockPosition, bestGuessMonitor: NSScreen, isMockPreviewActive: Bool = false) {
-        let filteredWindows = newWindows.filter { windowInfo in
-            let isDockDoorApp = windowInfo.app.localizedName?.contains("DockDoor") ?? false
-            if isDockDoorApp {
-                // If it's DockDoor, only include it if its settings are visible
-                return (NSApp.delegate as? AppDelegate)?.settingsWindowController.window?.isVisible ?? false
+        if windowSwitcherActive {
+            if !oldSwitcherState || currIndex < 0 { // If just activated or was unselected
+                if Defaults[.useClassicWindowOrdering], windows.count >= 2 {
+                    currIndex = 1
+                } else if !windows.isEmpty {
+                    currIndex = 0
+                } else {
+                    currIndex = -1 // No windows to select
+                }
             }
-            // If it's not DockDoor, always include it
-            return true
+        } else {
+            currIndex = -1 // Dock previews have no initial selection
         }
+    }
 
-        windows = filteredWindows
+    @MainActor
+    func setIndex(to: Int) {
+        // If window switcher is active, currIndex must be valid if windows exist
+        if windowSwitcherActive {
+            if !windows.isEmpty {
+                currIndex = max(0, min(to, windows.count - 1))
+            } else {
+                currIndex = -1
+            }
+        } else {
+            if to >= 0, to < windows.count {
+                currIndex = to
+            } else {
+                currIndex = -1 // Allow unselecting or invalid index becomes -1
+            }
+        }
+    }
 
-        if currIndex >= windows.count {
-            currIndex = max(0, windows.count - 1)
+    @MainActor
+    func setWindows(_ newWindows: [WindowInfo], dockPosition: DockPosition, bestGuessMonitor: NSScreen, isMockPreviewActive: Bool = false) {
+        windows = newWindows
+
+        if windowSwitcherActive {
+            if currIndex >= windows.count || (currIndex < 0 && !windows.isEmpty) {
+                if Defaults[.useClassicWindowOrdering], windows.count >= 2 {
+                    currIndex = 1
+                } else if !windows.isEmpty {
+                    currIndex = 0
+                } else {
+                    currIndex = -1
+                }
+            } else if windows.isEmpty { // If list became empty
+                currIndex = -1
+            }
+        } else {
+            // For dock previews, always reset to no initial selection when windows are set/reset
+            currIndex = -1
         }
         recomputeAndPublishDimensions(dockPosition: dockPosition, bestGuessMonitor: bestGuessMonitor, isMockPreviewActive: isMockPreviewActive)
     }
 
-    func updateWindow(at index: Int, with newInfo: WindowInfo, dockPosition: DockPosition, bestGuessMonitor: NSScreen, isMockPreviewActive: Bool = false) {
+    @MainActor
+    func updateWindow(at index: Int, with newInfo: WindowInfo) {
         guard index >= 0, index < windows.count else { return }
         windows[index] = newInfo
     }
 
-    func removeWindow(at index: Int, dockPosition: DockPosition, bestGuessMonitor: NSScreen, isMockPreviewActive: Bool = false) {
-        guard index >= 0, index < windows.count else { return }
-        windows.remove(at: index)
-        if currIndex >= windows.count {
-            currIndex = max(0, windows.count - 1)
+    @MainActor
+    func removeWindow(at indexToRemove: Int) {
+        guard indexToRemove >= 0, indexToRemove < windows.count else { return }
+
+        let oldCurrIndex = currIndex
+
+        windows.remove(at: indexToRemove)
+        windowDimensionsMap.removeValue(forKey: indexToRemove)
+        var newDimensionsMap: [Int: WindowPreviewHoverContainer.WindowDimensions] = [:]
+        for (key, value) in windowDimensionsMap {
+            if key < indexToRemove {
+                newDimensionsMap[key] = value
+            } else {
+                newDimensionsMap[key - 1] = value
+            }
         }
-        if windows.isEmpty { SharedPreviewWindowCoordinator.activeInstance?.hideWindow() }
+        windowDimensionsMap = newDimensionsMap
+
+        let newWindowsCount = windows.count
+
+        if newWindowsCount == 0 {
+            currIndex = -1
+            SharedPreviewWindowCoordinator.activeInstance?.hideWindow()
+            return
+        }
+
+        if oldCurrIndex == indexToRemove {
+            currIndex = min(indexToRemove, newWindowsCount - 1)
+        } else if oldCurrIndex > indexToRemove {
+            currIndex = oldCurrIndex - 1
+        }
+
+        if windowSwitcherActive {
+            if currIndex < 0, newWindowsCount > 0 {
+                currIndex = 0
+            } else if currIndex >= newWindowsCount {
+                currIndex = newWindowsCount - 1
+            }
+        } else {
+            if currIndex >= newWindowsCount {
+                currIndex = newWindowsCount - 1
+            }
+        }
     }
 
-    func removeAllWindows(dockPosition: DockPosition, bestGuessMonitor: NSScreen, isMockPreviewActive: Bool = false) {
+    @MainActor
+    func removeAllWindows() {
         windows.removeAll()
-        currIndex = 0
+        currIndex = -1 // Reset to no selection
         SharedPreviewWindowCoordinator.activeInstance?.hideWindow()
     }
 
+    @MainActor
     private func recomputeAndPublishDimensions(dockPosition: DockPosition, bestGuessMonitor: NSScreen, isMockPreviewActive: Bool = false) {
         let panelSize = getWindowSize()
 

--- a/DockDoor/Views/Hover Window/WindowPreview Supporting/Window Image Sizing Calculations.swift
+++ b/DockDoor/Views/Hover Window/WindowPreview Supporting/Window Image Sizing Calculations.swift
@@ -7,45 +7,113 @@ extension WindowPreviewHoverContainer {
         let maxDimensions: CGSize
     }
 
-    func precomputeWindowDimensions() -> [Int: WindowDimensions] {
+    static func calculateOverallMaxDimensions(
+        windows: [WindowInfo],
+        dockPosition: DockPosition,
+        isWindowSwitcherActive: Bool,
+        isMockPreviewActive: Bool,
+        sharedPanelWindowSize: CGSize
+    ) -> CGPoint {
+        let thickness = isMockPreviewActive ? 200 : sharedPanelWindowSize.height
+        var maxWidth: CGFloat = 300 // Default/min
+        var maxHeight: CGFloat = 300 // Default/min
+
+        let orientationIsHorizontal = dockPosition == .bottom || isWindowSwitcherActive
+        let maxAspectRatio: CGFloat = 1.5
+
+        for window in windows {
+            if let cgImage = window.image {
+                let cgSize = CGSize(width: cgImage.width, height: cgImage.height)
+                if orientationIsHorizontal {
+                    let rawWidthBasedOnHeight = (cgSize.width * thickness) / cgSize.height
+                    let widthBasedOnHeight = min(rawWidthBasedOnHeight, thickness * maxAspectRatio)
+                    maxWidth = max(maxWidth, widthBasedOnHeight)
+                    maxHeight = thickness
+                } else {
+                    let rawHeightBasedOnWidth = (cgSize.height * thickness) / cgSize.width
+                    let heightBasedOnWidth = min(rawHeightBasedOnWidth, thickness * maxAspectRatio)
+                    maxHeight = max(maxHeight, heightBasedOnWidth)
+                    maxWidth = thickness
+                }
+            }
+        }
+        return CGPoint(x: max(1, maxWidth), y: max(1, maxHeight)) // Ensure positive dimensions
+    }
+
+    static func precomputeWindowDimensions(
+        windows: [WindowInfo],
+        overallMaxDimensions: CGPoint,
+        bestGuessMonitor: NSScreen
+    ) -> [Int: WindowDimensions] {
         var dimensionsMap: [Int: WindowDimensions] = [:]
-        let maxAllowedWidth = maxWindowDimension.x
-        let maxAllowedHeight = maxWindowDimension.y
-        let calculatedMaxDimensions = CGSize(
+
+        let maxAllowedWidth = overallMaxDimensions.x
+        let maxAllowedHeight = overallMaxDimensions.y
+
+        let cardMaxFrameDimensions = CGSize(
             width: bestGuessMonitor.frame.width * 0.75,
             height: bestGuessMonitor.frame.height * 0.75
         )
 
-        for (index, windowInfo) in windowStates.enumerated() {
+        for (index, windowInfo) in windows.enumerated() {
             guard let cgImage = windowInfo.image else {
-                dimensionsMap[index] = WindowDimensions(size: .zero, maxDimensions: calculatedMaxDimensions)
+                dimensionsMap[index] = WindowDimensions(size: .zero, maxDimensions: cardMaxFrameDimensions)
                 continue
             }
 
             let cgSize = CGSize(width: cgImage.width, height: cgImage.height)
-            let aspectRatio = cgSize.width / cgSize.height
+            // Avoid division by zero if height is 0
+            let aspectRatio = cgSize.height > 0 ? cgSize.width / cgSize.height : 1.0
 
-            var targetWidth = maxAllowedWidth
-            var targetHeight = targetWidth / aspectRatio
+            var targetWidth: CGFloat
+            var targetHeight: CGFloat
+
+            // This logic determines how each individual preview image is scaled *within* the bounds
+            // defined by overallMaxDimensions.
+            // If overallMaxDimensions.x is the width for horizontal items, use that.
+            // If overallMaxDimensions.y is the height for horizontal items, use that.
+
+            // If the overall container's orientation is horizontal (dock bottom or switcher mode),
+            // then 'overallMaxDimensions.y' (which is 'thickness') dictates the height of each preview,
+            // and 'overallMaxDimensions.x' is the max width *one* preview can take if it's very wide.
+            // The 'precomputeWindowDimensions' in the previous version used 'maxWindowDimension.x' and 'maxWindowDimension.y'
+            // where maxWindowDimension itself was already adjusted for orientation (one side was 'thickness').
+
+            targetWidth = maxAllowedWidth
+            targetHeight = targetWidth / aspectRatio
 
             if targetHeight > maxAllowedHeight {
                 targetHeight = maxAllowedHeight
                 targetWidth = aspectRatio * targetHeight
             }
 
+            if targetWidth > maxAllowedWidth {
+                targetWidth = maxAllowedWidth
+                targetHeight = targetWidth / (aspectRatio > 0 ? aspectRatio : 1.0)
+            }
+
             dimensionsMap[index] = WindowDimensions(
-                size: CGSize(width: targetWidth, height: targetHeight),
-                maxDimensions: calculatedMaxDimensions
+                size: CGSize(width: max(1, targetWidth), height: max(1, targetHeight)), // Ensure positive
+                maxDimensions: cardMaxFrameDimensions
             )
         }
-
         return dimensionsMap
     }
 
     // Helper method to get dimensions for a specific window
     func getDimensions(for index: Int, dimensionsMap: [Int: WindowDimensions]) -> WindowDimensions {
-        dimensionsMap[index] ?? WindowDimensions(
-            size: .zero,
+        guard index >= 0, index < previewStateCoordinator.windows.count else {
+            return WindowDimensions(
+                size: CGSize(width: 100, height: 100),
+                maxDimensions: CGSize(
+                    width: bestGuessMonitor.frame.width * 0.75,
+                    height: bestGuessMonitor.frame.height * 0.75
+                )
+            )
+        }
+
+        return dimensionsMap[index] ?? WindowDimensions(
+            size: CGSize(width: 100, height: 100),
             maxDimensions: CGSize(
                 width: bestGuessMonitor.frame.width * 0.75,
                 height: bestGuessMonitor.frame.height * 0.75

--- a/DockDoor/Views/Hover Window/WindowPreview.swift
+++ b/DockDoor/Views/Hover Window/WindowPreview.swift
@@ -45,7 +45,7 @@ struct WindowPreview: View {
                 Image(decorative: cgImage, scale: 1.0)
                     .resizable()
                     .aspectRatio(contentMode: .fit)
-                    .markHidden(isHidden: inactive || windowSwitcherActive && !isSelected && dimInSwitcherUntilSelected)
+                    .markHidden(isHidden: inactive || (windowSwitcherActive && !isSelected && dimInSwitcherUntilSelected))
                     .overlay(isSelected && !inactive ? CustomizableFluidGradientView().opacity(0.125) : nil)
                     .clipShape(uniformCardRadius ? AnyShape(RoundedRectangle(cornerRadius: 12, style: .continuous)) : AnyShape(Rectangle()))
             }
@@ -177,31 +177,36 @@ struct WindowPreview: View {
 
     @ViewBuilder
     private var previewCoreContent: some View {
-        let isHighlightedInWindowSwitcher = (index == currIndex && windowSwitcherActive)
-        let selected = isHoveringOverDockPeekPreview || isHighlightedInWindowSwitcher || isHoveringOverWindowSwitcherPreview
+        let isSelectedByKeyboardInDock = !windowSwitcherActive && (index == currIndex)
+        let isSelectedByKeyboardInSwitcher = windowSwitcherActive && (index == currIndex)
+
+        let finalIsSelected = isHoveringOverDockPeekPreview ||
+            isSelectedByKeyboardInSwitcher ||
+            isSelectedByKeyboardInDock ||
+            isHoveringOverWindowSwitcherPreview
 
         ZStack(alignment: .topLeading) {
             VStack(alignment: .leading, spacing: 0) {
                 if windowSwitcherActive, windowSwitcherControlPosition == .topLeading ||
                     windowSwitcherControlPosition == .topTrailing
                 {
-                    windowSwitcherContent(selected)
+                    windowSwitcherContent(finalIsSelected)
                 }
 
                 windowContent(
                     isMinimized: windowInfo.isMinimized,
                     isHidden: windowInfo.isHidden,
-                    isSelected: selected
+                    isSelected: finalIsSelected
                 )
 
                 if windowSwitcherActive, windowSwitcherControlPosition == .bottomLeading ||
                     windowSwitcherControlPosition == .bottomTrailing
                 {
-                    windowSwitcherContent(selected)
+                    windowSwitcherContent(finalIsSelected)
                 }
             }
             .background {
-                if selected || isHoveringOverWindowSwitcherPreview {
+                if finalIsSelected {
                     RoundedRectangle(cornerRadius: uniformCardRadius ? 14 : 0)
                         .fill(selectionColor?.opacity(selectionOpacity) ?? Color.secondary.opacity(selectionOpacity))
                         .padding(-6)

--- a/DockDoor/Views/Hover Window/WindowPreviewHoverContainer.swift
+++ b/DockDoor/Views/Hover Window/WindowPreviewHoverContainer.swift
@@ -24,7 +24,6 @@ class MockPreviewWindow: WindowPropertiesProviding {
 
 struct WindowPreviewHoverContainer: View {
     let appName: String
-    let windows: [WindowInfo]
     let onWindowTap: (() -> Void)?
     let dockPosition: DockPosition
     let mouseLocation: CGPoint?
@@ -32,7 +31,7 @@ struct WindowPreviewHoverContainer: View {
     var mockPreviewActive: Bool
     let updateAvailable: Bool
 
-    @ObservedObject var windowSwitcherCoordinator: ScreenCenteredFloatingWindowCoordinator
+    @ObservedObject var previewStateCoordinator: PreviewStateCoordinator
 
     @Default(.uniformCardRadius) var uniformCardRadius
     @Default(.showAppName) var showAppTitleData
@@ -43,8 +42,8 @@ struct WindowPreviewHoverContainer: View {
     @Default(.previewWrap) var previewWrap
     @Default(.switcherWrap) var switcherWrap
     @Default(.gradientColorPalette) private var gradientColorPalette
+    @Default(.showAnimations) var showAnimations
 
-    @State var windowStates: [WindowInfo]
     @State private var draggedWindowIndex: Int? = nil
     @State private var isDragging = false
 
@@ -57,89 +56,67 @@ struct WindowPreviewHoverContainer: View {
     @State private var lastShakeCheck: Date = .init()
 
     init(appName: String,
-         windows: [WindowInfo],
          onWindowTap: (() -> Void)?,
          dockPosition: DockPosition,
          mouseLocation: CGPoint?,
          bestGuessMonitor: NSScreen,
-         windowSwitcherCoordinator: ScreenCenteredFloatingWindowCoordinator,
+         windowSwitcherCoordinator: PreviewStateCoordinator,
          mockPreviewActive: Bool,
          updateAvailable: Bool)
     {
         self.appName = appName
-        self.windows = windows
-        _windowStates = State(initialValue: windows)
         self.onWindowTap = onWindowTap
         self.dockPosition = dockPosition
         self.mouseLocation = mouseLocation
         self.bestGuessMonitor = bestGuessMonitor
-        self.windowSwitcherCoordinator = windowSwitcherCoordinator
+        previewStateCoordinator = windowSwitcherCoordinator
         self.mockPreviewActive = mockPreviewActive
         self.updateAvailable = updateAvailable
     }
 
-    var maxWindowDimension: CGPoint {
-        let thickness = mockPreviewActive ? 200 : (SharedPreviewWindowCoordinator.activeInstance?.windowSize.height ?? getWindowSize().height)
-        var maxWidth: CGFloat = 300
-        var maxHeight: CGFloat = 300
-
-        let orientationIsHorizontal = dockPosition == .bottom || windowSwitcherCoordinator.windowSwitcherActive
-        let maxAspectRatio: CGFloat = 1.5
-
-        for window in windows {
-            if let cgImage = window.image {
-                let cgSize = CGSize(width: cgImage.width, height: cgImage.height)
-
-                if orientationIsHorizontal {
-                    let rawWidthBasedOnHeight = (cgSize.width * thickness) / cgSize.height
-                    let widthBasedOnHeight = min(rawWidthBasedOnHeight, thickness * maxAspectRatio)
-
-                    maxWidth = max(maxWidth, widthBasedOnHeight)
-                    maxHeight = thickness
-                } else {
-                    let rawHeightBasedOnWidth = (cgSize.height * thickness) / cgSize.width
-                    let heightBasedOnWidth = min(rawHeightBasedOnWidth, thickness * maxAspectRatio)
-
-                    maxHeight = max(maxHeight, heightBasedOnWidth)
-                    maxWidth = thickness
-                }
-            }
-        }
-
-        return CGPoint(x: maxWidth, y: maxHeight)
-    }
-
     var body: some View {
-        let orientationIsHorizontal = dockPosition.isHorizontalFlow || windowSwitcherCoordinator.windowSwitcherActive
+        // Directly use dimensions from the coordinator
+        let calculatedMaxDimension = previewStateCoordinator.overallMaxPreviewDimension
+        let calculatedDimensionsMap = previewStateCoordinator.windowDimensionsMap
+
+        let orientationIsHorizontal = dockPosition.isHorizontalFlow || previewStateCoordinator.windowSwitcherActive
 
         ScrollViewReader { scrollProxy in
-            buildFlowStack(windows: windowStates, scrollProxy: scrollProxy, orientationIsHorizontal)
-                .padding(.top, (!windowSwitcherCoordinator.windowSwitcherActive && appNameStyle == .default && showAppTitleData) ? 25 : 0)
-                .overlay(alignment: .topLeading) {
-                    hoverTitleBaseView(labelSize: measureString(appName, fontSize: 14))
-                        .onHover { isHovered in
-                            withAnimation(.snappy) { hoveringWindowTitle = isHovered }
-                        }
-                }
-                .dockStyle(cornerRadius: 16)
-                .padding(.top, (!windowSwitcherCoordinator.windowSwitcherActive && appNameStyle == .popover && showAppTitleData) ? 30 : 0)
-                .overlay {
-                    if !mockPreviewActive, !isDragging {
-                        WindowDismissalContainer(appName: appName,
-                                                 bestGuessMonitor: bestGuessMonitor,
-                                                 dockPosition: dockPosition,
-                                                 minimizeAllWindowsCallback: { minimizeAllWindows() })
-                            .allowsHitTesting(false)
+            buildFlowStack(
+                scrollProxy: scrollProxy,
+                orientationIsHorizontal,
+                currentMaxDimensionForPreviews: calculatedMaxDimension,
+                currentDimensionsMapForPreviews: calculatedDimensionsMap
+            )
+            .padding(.top, (!previewStateCoordinator.windowSwitcherActive && appNameStyle == .default && showAppTitleData) ? 25 : 0)
+            .overlay(alignment: .topLeading) {
+                hoverTitleBaseView(labelSize: measureString(appName, fontSize: 14))
+                    .onHover { isHovered in
+                        withAnimation(.snappy) { hoveringWindowTitle = isHovered }
                     }
+            }
+            .dockStyle(cornerRadius: 16)
+            .padding(.top, (!previewStateCoordinator.windowSwitcherActive && appNameStyle == .popover && showAppTitleData) ? 30 : 0)
+            .overlay {
+                if !mockPreviewActive, !isDragging {
+                    WindowDismissalContainer(appName: appName,
+                                             bestGuessMonitor: bestGuessMonitor,
+                                             dockPosition: dockPosition,
+                                             minimizeAllWindowsCallback: { minimizeAllWindows() })
+                        .allowsHitTesting(false)
                 }
-                .padding(.all, mockPreviewActive ? 0 : 24)
-                .frame(maxWidth: bestGuessMonitor.visibleFrame.width, maxHeight: bestGuessMonitor.visibleFrame.height)
+            }
+            .padding(.all, mockPreviewActive ? 0 : 24)
+            .frame(maxWidth: bestGuessMonitor.visibleFrame.width, maxHeight: bestGuessMonitor.visibleFrame.height)
+        }
+        .onAppear {
+            loadAppIcon()
         }
     }
 
     private func handleWindowDrop(at location: CGPoint, for index: Int) {
-        guard index < windowStates.count else { return }
-        let window = windowStates[index]
+        guard index < previewStateCoordinator.windows.count else { return }
+        let window = previewStateCoordinator.windows[index]
 
         let currentScreen = NSScreen.screenContainingMouse(location)
         let globalLocation = DockObserver.cgPointFromNSPoint(location, forScreen: currentScreen)
@@ -158,7 +135,7 @@ struct WindowPreviewHoverContainer: View {
 
     @ViewBuilder
     private func hoverTitleBaseView(labelSize: CGSize) -> some View {
-        if !windowSwitcherCoordinator.windowSwitcherActive, showAppTitleData {
+        if !previewStateCoordinator.windowSwitcherActive, showAppTitleData {
             Group {
                 switch appNameStyle {
                 case .default:
@@ -181,7 +158,7 @@ struct WindowPreviewHoverContainer: View {
                     }
                     .padding(.top, 10)
                     .padding(.horizontal)
-                    .animation(.spring(response: 0.3), value: hoveringAppIcon)
+                    .animation(.smooth(duration: 0.15), value: hoveringAppIcon)
 
                 case .shadowed:
                     HStack(spacing: 2) {
@@ -202,7 +179,7 @@ struct WindowPreviewHoverContainer: View {
                         massOperations(hoveringAppIcon && !updateAvailable)
                     }
                     .padding(EdgeInsets(top: -11.5, leading: 15, bottom: -1.5, trailing: 1.5))
-                    .animation(.spring(response: 0.3), value: hoveringAppIcon)
+                    .animation(.smooth(duration: 0.15), value: hoveringAppIcon)
 
                 case .popover:
                     HStack {
@@ -230,7 +207,7 @@ struct WindowPreviewHoverContainer: View {
                         Spacer()
                     }
                     .offset(y: -30)
-                    .animation(.spring(response: 0.3), value: hoveringAppIcon)
+                    .animation(.smooth(duration: 0.15), value: hoveringAppIcon)
                 }
             }
             .onHover { hover in
@@ -380,36 +357,44 @@ struct WindowPreviewHoverContainer: View {
     }
 
     @ViewBuilder
-    private func buildFlowStack(windows: [WindowInfo], scrollProxy: ScrollViewProxy, _ isHorizontal: Bool) -> some View {
-        let dimensionsMap = precomputeWindowDimensions()
-        let wrap = windowSwitcherCoordinator.windowSwitcherActive ? switcherWrap : previewWrap
-        let layout = calculateOptimalLayout(windowDimensions: dimensionsMap, isHorizontal: isHorizontal, wrap: wrap)
+    private func buildFlowStack(
+        scrollProxy: ScrollViewProxy,
+        _ isHorizontal: Bool,
+        currentMaxDimensionForPreviews: CGPoint,
+        currentDimensionsMapForPreviews: [Int: WindowDimensions]
+    ) -> some View {
+        let wrap = previewStateCoordinator.windowSwitcherActive ? switcherWrap : previewWrap
+        let layout = calculateOptimalLayout(
+            windowDimensions: currentDimensionsMapForPreviews,
+            isHorizontal: isHorizontal,
+            wrap: wrap,
+            maxDimensionForLayout: currentMaxDimensionForPreviews
+        )
 
         ScrollView(isHorizontal ? .horizontal : .vertical, showsIndicators: false) {
             DynStack(direction: isHorizontal ? .vertical : .horizontal, spacing: 16) {
                 ForEach(Array(layout.windowsPerStack.enumerated()), id: \.offset) { _, range in
                     DynStack(direction: isHorizontal ? .horizontal : .vertical, spacing: 16) {
-                        ForEach(windowStates.indices, id: \.self) { index in
+                        ForEach(previewStateCoordinator.windows.indices, id: \.self) { index in
                             if range.contains(index) {
                                 WindowPreview(
-                                    windowInfo: windowStates[index],
+                                    windowInfo: previewStateCoordinator.windows[index],
                                     onTap: onWindowTap,
                                     index: index,
                                     dockPosition: dockPosition,
-                                    maxWindowDimension: maxWindowDimension,
+                                    maxWindowDimension: currentMaxDimensionForPreviews,
                                     bestGuessMonitor: bestGuessMonitor,
                                     uniformCardRadius: uniformCardRadius,
                                     handleWindowAction: { action in
                                         handleWindowAction(action, at: index)
                                     },
-                                    currIndex: windowSwitcherCoordinator.currIndex,
-                                    windowSwitcherActive: windowSwitcherCoordinator.windowSwitcherActive,
-                                    dimensions: getDimensions(for: index, dimensionsMap: dimensionsMap),
+                                    currIndex: previewStateCoordinator.currIndex,
+                                    windowSwitcherActive: previewStateCoordinator.windowSwitcherActive,
+                                    dimensions: getDimensions(for: index, dimensionsMap: currentDimensionsMapForPreviews),
                                     showAppIconOnly: showAppIconOnly,
                                     mockPreviewActive: mockPreviewActive
                                 )
                                 .id("\(appName)-\(index)")
-                                .animation(.snappy(duration: 0.175), value: windowStates)
                                 .gesture(
                                     DragGesture(minimumDistance: 3, coordinateSpace: .global)
                                         .onChanged { value in
@@ -417,13 +402,13 @@ struct WindowPreviewHoverContainer: View {
                                                 draggedWindowIndex = index
                                                 isDragging = true
                                                 DragPreviewCoordinator.shared.startDragging(
-                                                    windowInfo: windowStates[index],
+                                                    windowInfo: previewStateCoordinator.windows[index],
                                                     at: NSEvent.mouseLocation
                                                 )
                                             }
                                             if draggedWindowIndex == index {
                                                 let currentPoint = value.location
-                                                if !windowSwitcherCoordinator.windowSwitcherActive, aeroShakeAction != .none,
+                                                if !previewStateCoordinator.windowSwitcherActive, aeroShakeAction != .none,
                                                    checkForShakeGesture(currentPoint: currentPoint)
                                                 {
                                                     DragPreviewCoordinator.shared.endDragging()
@@ -434,7 +419,7 @@ struct WindowPreviewHoverContainer: View {
                                                     case .all:
                                                         minimizeAllWindows()
                                                     case .except:
-                                                        minimizeAllWindows(windowStates[index])
+                                                        minimizeAllWindows(previewStateCoordinator.windows[index])
                                                     default: break
                                                     }
                                                 } else {
@@ -459,99 +444,113 @@ struct WindowPreviewHoverContainer: View {
             }
             .padding(20)
         }
-        .onAppear {
-            loadAppIcon()
-        }
-        .onChange(of: windowSwitcherCoordinator.currIndex) { newIndex in
-            withAnimation {
+        .animation(.smooth(duration: 0.1), value: previewStateCoordinator.windows)
+        .onChange(of: previewStateCoordinator.currIndex) { newIndex in
+            if showAnimations {
+                withAnimation(.snappy) {
+                    scrollProxy.scrollTo("\(appName)-\(newIndex)", anchor: .center)
+                }
+            } else {
                 scrollProxy.scrollTo("\(appName)-\(newIndex)", anchor: .center)
             }
         }
     }
 
     private func loadAppIcon() {
-        if let app = windows.first?.app, let icon = app.icon {
+        if let app = previewStateCoordinator.windows.first?.app, let icon = app.icon {
             DispatchQueue.main.async {
-                appIcon = icon
+                if appIcon != icon {
+                    appIcon = icon
+                }
+            }
+        } else if appIcon != nil {
+            DispatchQueue.main.async {
+                appIcon = nil
             }
         }
     }
 
     private func closeAllWindows() {
         onWindowTap?()
-        windowStates.removeAll()
+        let windowsToClose = previewStateCoordinator.windows
+        previewStateCoordinator.removeAllWindows(dockPosition: dockPosition, bestGuessMonitor: bestGuessMonitor, isMockPreviewActive: mockPreviewActive)
 
-        DispatchQueue.concurrentPerform(iterations: windows.count) { index in
-            let window = windows[index]
+        DispatchQueue.concurrentPerform(iterations: windowsToClose.count) { index in
+            let window = windowsToClose[index]
             WindowUtil.closeWindow(windowInfo: window)
         }
     }
 
     private func minimizeAllWindows(_ except: WindowInfo? = nil) {
         onWindowTap?()
+        let originalWindows = previewStateCoordinator.windows
+        var modifiedWindows = originalWindows
+        var didMinimizeAny = false
 
-        if let except {
-            WindowUtil.bringWindowToFront(windowInfo: except)
+        if let except { WindowUtil.bringWindowToFront(windowInfo: except) }
 
-            windowStates.removeAll { $0 != except }
-
-            DispatchQueue.concurrentPerform(iterations: windows.count) { index in
-                let window = windows[index]
-                guard !window.isMinimized else { return }
-                if window != except {
-                    _ = WindowUtil.toggleMinimize(windowInfo: window)
+        for i in 0 ..< modifiedWindows.count {
+            if modifiedWindows[i] == except { continue }
+            if !modifiedWindows[i].isMinimized {
+                if WindowUtil.toggleMinimize(windowInfo: modifiedWindows[i]) == true {
+                    modifiedWindows[i].isMinimized = true
+                    didMinimizeAny = true
                 }
             }
-
-        } else {
-            windowStates.removeAll()
-
-            DispatchQueue.concurrentPerform(iterations: windows.count) { index in
-                let window = windows[index]
-                guard !window.isMinimized else { return }
-                _ = WindowUtil.toggleMinimize(windowInfo: window)
+        }
+        if didMinimizeAny || except == nil { // If we are minimizing all, or some were minimized
+            if except == nil {
+                previewStateCoordinator.setWindows([], dockPosition: dockPosition, bestGuessMonitor: bestGuessMonitor, isMockPreviewActive: mockPreviewActive)
+            } else {
+                var windowsToKeep: [WindowInfo] = []
+                for var window in originalWindows {
+                    if window == except {
+                        windowsToKeep.append(window)
+                        continue
+                    }
+                    if WindowUtil.toggleMinimize(windowInfo: window) == true {
+                        window.isMinimized = true
+                    } else {
+                        windowsToKeep.append(window)
+                    }
+                }
+                previewStateCoordinator.setWindows(windowsToKeep, dockPosition: dockPosition, bestGuessMonitor: bestGuessMonitor, isMockPreviewActive: mockPreviewActive)
             }
         }
     }
 
     private func handleWindowAction(_ action: WindowAction, at index: Int) {
-        guard index < windowStates.count else { return }
-        var window = windowStates[index]
+        guard index < previewStateCoordinator.windows.count else { return }
+        var window = previewStateCoordinator.windows[index]
 
-        withAnimation(.snappy(duration: 0.175)) {
-            switch action {
-            case .quit:
-                WindowUtil.quitApp(windowInfo: window, force: NSEvent.modifierFlags.contains(.option))
-                onWindowTap?()
+        switch action {
+        case .quit:
+            WindowUtil.quitApp(windowInfo: window, force: NSEvent.modifierFlags.contains(.option))
+            onWindowTap?()
 
-            case .close:
-                WindowUtil.closeWindow(windowInfo: window)
-                windowStates.remove(at: index)
+        case .close:
+            WindowUtil.closeWindow(windowInfo: window)
+            previewStateCoordinator.removeWindow(at: index, dockPosition: dockPosition, bestGuessMonitor: bestGuessMonitor, isMockPreviewActive: mockPreviewActive)
 
-                if windowStates.isEmpty {
-                    onWindowTap?()
-                }
-
-            case .minimize:
-                if let newMinimizedState = WindowUtil.toggleMinimize(windowInfo: window) {
-                    window.isMinimized = newMinimizedState
-                    windowStates[index] = window
-                }
-
-            case .toggleFullScreen:
-                WindowUtil.toggleFullScreen(windowInfo: window)
-                onWindowTap?()
-
-            case .hide:
-                if let newHiddenState = WindowUtil.toggleHidden(windowInfo: window) {
-                    window.isHidden = newHiddenState
-                    windowStates[index] = window
-                }
-
-            case .openNewWindow:
-                WindowUtil.openNewWindow(app: window.app)
-                onWindowTap?()
+        case .minimize:
+            if let newMinimizedState = WindowUtil.toggleMinimize(windowInfo: window) {
+                window.isMinimized = newMinimizedState
+                previewStateCoordinator.updateWindow(at: index, with: window, dockPosition: dockPosition, bestGuessMonitor: bestGuessMonitor, isMockPreviewActive: mockPreviewActive)
             }
+
+        case .toggleFullScreen:
+            WindowUtil.toggleFullScreen(windowInfo: window)
+            onWindowTap?()
+
+        case .hide:
+            if let newHiddenState = WindowUtil.toggleHidden(windowInfo: window) {
+                window.isHidden = newHiddenState
+                previewStateCoordinator.updateWindow(at: index, with: window, dockPosition: dockPosition, bestGuessMonitor: bestGuessMonitor, isMockPreviewActive: mockPreviewActive)
+            }
+
+        case .openNewWindow:
+            WindowUtil.openNewWindow(app: window.app)
+            onWindowTap?()
         }
     }
 

--- a/DockDoor/Views/Hover Window/WindowPreviewHoverContainer.swift
+++ b/DockDoor/Views/Hover Window/WindowPreviewHoverContainer.swift
@@ -75,7 +75,6 @@ struct WindowPreviewHoverContainer: View {
     }
 
     var body: some View {
-        // Directly use dimensions from the coordinator
         let calculatedMaxDimension = previewStateCoordinator.overallMaxPreviewDimension
         let calculatedDimensionsMap = previewStateCoordinator.windowDimensionsMap
 
@@ -473,7 +472,7 @@ struct WindowPreviewHoverContainer: View {
     private func closeAllWindows() {
         onWindowTap?()
         let windowsToClose = previewStateCoordinator.windows
-        previewStateCoordinator.removeAllWindows(dockPosition: dockPosition, bestGuessMonitor: bestGuessMonitor, isMockPreviewActive: mockPreviewActive)
+        previewStateCoordinator.removeAllWindows()
 
         DispatchQueue.concurrentPerform(iterations: windowsToClose.count) { index in
             let window = windowsToClose[index]
@@ -530,12 +529,12 @@ struct WindowPreviewHoverContainer: View {
 
         case .close:
             WindowUtil.closeWindow(windowInfo: window)
-            previewStateCoordinator.removeWindow(at: index, dockPosition: dockPosition, bestGuessMonitor: bestGuessMonitor, isMockPreviewActive: mockPreviewActive)
+            previewStateCoordinator.removeWindow(at: index)
 
         case .minimize:
             if let newMinimizedState = WindowUtil.toggleMinimize(windowInfo: window) {
                 window.isMinimized = newMinimizedState
-                previewStateCoordinator.updateWindow(at: index, with: window, dockPosition: dockPosition, bestGuessMonitor: bestGuessMonitor, isMockPreviewActive: mockPreviewActive)
+                previewStateCoordinator.updateWindow(at: index, with: window)
             }
 
         case .toggleFullScreen:
@@ -545,7 +544,7 @@ struct WindowPreviewHoverContainer: View {
         case .hide:
             if let newHiddenState = WindowUtil.toggleHidden(windowInfo: window) {
                 window.isHidden = newHiddenState
-                previewStateCoordinator.updateWindow(at: index, with: window, dockPosition: dockPosition, bestGuessMonitor: bestGuessMonitor, isMockPreviewActive: mockPreviewActive)
+                previewStateCoordinator.updateWindow(at: index, with: window)
             }
 
         case .openNewWindow:


### PR DESCRIPTION
closes #458 closes #368 closes [#574](https://github.com/ejbills/DockDoor/issues/574)

perf improvements

activation attempts

queue window switcher

better flow algorithm

remove window states, rely on observed object to track window states

- this is fundamental to changes requested in #368
- - we need to orchestrate window actions in the child window preview when a dock preview is active. this means that we need direct access to the entire window states array from the child view to ensure that the action is reflected in the window preview. to get around having to pass multiple copies of the same windows objects and bloat memory, we strip out the window states entirely and instead back the windows with an observed object. this means we can access the object from child views, orchestrate view changes, and manage the entire array with little issue.

