### PR TITLE
Implement frontmost app filtering features

### DIFF
--- a/DockDoor/Localizable.xcstrings
+++ b/DockDoor/Localizable.xcstrings
@@ -105,13 +105,13 @@
             "value" : ""
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : ""
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : ""
@@ -295,13 +295,13 @@
             "value" : " "
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : " "
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : " "
@@ -485,16 +485,16 @@
             "value" : " - 비활성"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : " - Inactive"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : " - Inactief"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : " - Inactive"
           }
         },
         "pl" : {
@@ -675,13 +675,13 @@
             "value" : "-%@"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "-%@"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "-%@"
@@ -866,16 +866,16 @@
             "value" : "• 독(Dock)에서의 향상된 시각 정보를 위해 허용합니다"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "• Allows for enhanced visual information in the dock"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Zorgt voor verbeterde visuele informatie in het dock"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "• Allows for enhanced visual information in the dock"
           }
         },
         "pl" : {
@@ -1057,16 +1057,16 @@
             "value" : "• 독(Dock)에 있는 항목과의 실시간 상호작용을 가능하게 합니다"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "• Enables real-time interaction with dock items"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Maakt realtime interactie met dock items mogelijk"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "• Enables real-time interaction with dock items"
           }
         },
         "pl" : {
@@ -1248,16 +1248,16 @@
             "value" : "• 이미지와 창의 미리보기를 생성합니다"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "• To capture previews of images and windows"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Voorvertoningen van afbeeldingen en vensters vastleggen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "• To capture previews of images and windows"
           }
         },
         "pl" : {
@@ -1439,16 +1439,16 @@
             "value" : "• 독에 마우스를 올렸는지 감지합니다"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "• To detect when you hover over the dock"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Om te detecteren wanneer u boven het dock zweeft"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "• To detect when you hover over the dock"
           }
         },
         "pl" : {
@@ -1630,16 +1630,16 @@
             "value" : "• 하단의 도크 위로 마우스를 가져가면 창이 왼쪽에서 오른쪽으로 일렬로 흐릅니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "• When hovering over the Dock at the bottom, windows flow in rows from left to right"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Wanneer u met de muis over het Dock onderaan beweegt, vloeien de vensters in rijen van links naar rechts"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "• When hovering over the Dock at the bottom, windows flow in rows from left to right"
           }
         },
         "pl" : {
@@ -1821,16 +1821,16 @@
             "value" : "• 측면의 도크 위로 마우스를 가져가면 창이 위에서 아래로 기둥 모양으로 흐릅니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "• When hovering over the Dock on the sides, windows flow in columns from top to bottom"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Wanneer u met de muis over het Dock aan de zijkanten zweeft, vloeien de vensters in kolommen van boven naar beneden"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "• When hovering over the Dock on the sides, windows flow in columns from top to bottom"
           }
         },
         "pl" : {
@@ -2012,16 +2012,16 @@
             "value" : "• 창 전환기를 사용할 때 창은 항상 왼쪽에서 오른쪽으로 일렬로 흐릅니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "• When using the Window Switcher, windows always flow in rows from left to right"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bij gebruik van de Window Switcher lopen de vensters altijd in rijen van links naar rechts"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "• When using the Window Switcher, windows always flow in rows from left to right"
           }
         },
         "pl" : {
@@ -2202,15 +2202,15 @@
             "value" : "+"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "+"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "+"
           }
         },
@@ -2392,13 +2392,13 @@
             "value" : "+%lld more"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "+%lld more"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "+%lld more"
@@ -2582,13 +2582,13 @@
             "value" : "×"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "×"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "×"
@@ -2772,15 +2772,15 @@
             "value" : "1."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "1."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "1."
           }
         },
@@ -2963,16 +2963,16 @@
             "value" : ""
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "1. Select \"Command (⌘)\" as the initialization key."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "1. Selecteer \"Command (⌘)\" als initialisatie toets."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "1. Select \"Command (⌘)\" as the initialization key."
           }
         },
         "pl" : {
@@ -3154,15 +3154,15 @@
             "value" : "1/%lldx"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "1/%lldx"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "1/%lldx"
           }
         },
@@ -3344,15 +3344,15 @@
             "value" : "2."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "2."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "2."
           }
         },
@@ -3535,16 +3535,16 @@
             "value" : "2. \"트리거 키 녹화 시작\"을 클릭합니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "2. Click \"Start Recording Trigger Key\"."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "2. Klik op \"Start opname sneltoets\"."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "2. Click \"Start Recording Trigger Key\"."
           }
         },
         "pl" : {
@@ -3725,15 +3725,15 @@
             "value" : "3."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "3."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "3."
           }
         },
@@ -3916,16 +3916,16 @@
             "value" : "3. Tab 키만 누릅니다(Command+Tab이 아닌)."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "3. Press ONLY the Tab key (not Command+Tab)."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "3. Druk ALLEEN op de TAB toets (niet Command+Tab)."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "3. Press ONLY the Tab key (not Command+Tab)."
           }
         },
         "pl" : {
@@ -4106,15 +4106,15 @@
             "value" : "4."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "4."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "4."
           }
         },
@@ -4297,16 +4297,16 @@
             "value" : ""
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "4. Your keybind will be set to Command+Tab."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "4. De sneltoets wordt ingesteld op Command+Tab."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "4. Your keybind will be set to Command+Tab."
           }
         },
         "pl" : {
@@ -4487,16 +4487,16 @@
             "value" : "손쉬운 사용"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Accessibility"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Toegankelijkheid"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Accessibility"
           }
         },
         "pl" : {
@@ -4678,16 +4678,16 @@
             "value" : "손쉬운 사용 권한"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Accessibility Permissions"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Toegankelijkheid rechten"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Accessibility Permissions"
           }
         },
         "pl" : {
@@ -4869,16 +4869,16 @@
             "value" : "손쉬운 사용:"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Accessibility:"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Toegankelijkheid:"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Accessibility:"
           }
         },
         "pl" : {
@@ -5059,16 +5059,16 @@
             "value" : "추가"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Add"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Toevoegen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Add"
           }
         },
         "pl" : {
@@ -5250,16 +5250,16 @@
             "value" : "응용 프로그램을 검색할 경로를 추가하세요"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Add additional directories to scan for applications"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Voeg extra mappen toe om te scannen voor applicaties"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Add additional directories to scan for applications"
           }
         },
         "pl" : {
@@ -5440,16 +5440,16 @@
             "value" : "애플리케이션을 검색할 디렉터리를 추가합니다. 이 기능은 앱을 표준 위치 외부에 보관하는 경우에 유용합니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Add additional directories to scan for applications. This is useful if you keep apps outside standard locations."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Voeg extra mappen toe om naar applicaties te scannen. Dit is handig als u apps buiten de standaardlocaties bewaart."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Add additional directories to scan for applications. This is useful if you keep apps outside standard locations."
           }
         },
         "pl" : {
@@ -5525,6 +5525,12 @@
           }
         }
       }
+    },
+    "Add App" : {
+
+    },
+    "Add App to Blacklist" : {
+
     },
     "Add Directory" : {
       "localizations" : {
@@ -5630,16 +5636,16 @@
             "value" : "경로 추가"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Add Directory"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Map toevoegen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Add Directory"
           }
         },
         "pl" : {
@@ -5820,16 +5826,16 @@
             "value" : "필터 추가"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Add Filter"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Filter toevoegen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Add Filter"
           }
         },
         "pl" : {
@@ -6011,16 +6017,16 @@
             "value" : "프리뷰가 도크와 맞지 않으면 이것을 조정하세요"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Adjust this if the preview is misaligned with dock"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Pas aan als de uitlijning in de Dock niet goed is"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Adjust this if the preview is misaligned with dock"
           }
         },
         "pl" : {
@@ -6201,16 +6207,16 @@
             "value" : "상호 작용 중에 앱의 반응 속도와 동작을 조정합니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Adjusts how responsive the app feels and behaves during interaction."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Hiermee past u aan hoe responsief de app aanvoelt en zich gedraagt ​​tijdens interactie."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Adjusts how responsive the app feels and behaves during interaction."
           }
         },
         "pl" : {
@@ -6392,16 +6398,16 @@
             "value" : "에어로 쉐이크 액션"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Aero Shake Action"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Aero Schud Actie"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Aero Shake Action"
           }
         },
         "pl" : {
@@ -6582,16 +6588,16 @@
             "value" : "모든 버튼 제거"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "All buttons removed"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Alle knoppen verwijderd"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "All buttons removed"
           }
         },
         "pl" : {
@@ -6772,13 +6778,13 @@
             "value" : "오른쪽 클릭 메뉴를 통해 특별한 앱 컨트롤을 화면에 고정할 수 있습니다."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Allow special app controls to be pinned to the screen via right-click menu."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Allow special app controls to be pinned to the screen via right-click menu."
@@ -6964,16 +6970,16 @@
             "value" : "항상"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Always"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Altijd"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Always"
           }
         },
         "pl" : {
@@ -7155,16 +7161,16 @@
             "value" : "항상 표시"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Always visible"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Altijd zichtbaar"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Always visible"
           }
         },
         "pl" : {
@@ -7346,16 +7352,16 @@
             "value" : "항상 보기; 불투명도 최대"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Always visible; Full opacity"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Altijd zichtbaar; volle doorzichtigheid"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Always visible; Full opacity"
           }
         },
         "pl" : {
@@ -7536,16 +7542,16 @@
             "value" : "금액"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "amount"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "aantal"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "amount"
           }
         },
         "pl" : {
@@ -7726,16 +7732,16 @@
             "value" : "애니메이션 속도"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Animation speed"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Animatie snelheid"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Animation speed"
           }
         },
         "pl" : {
@@ -7916,16 +7922,16 @@
             "value" : "앱명 스타일"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "App Name Style"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "App naam stijl"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "App Name Style"
           }
         },
         "pl" : {
@@ -8107,16 +8113,16 @@
             "value" : "모양"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Appearance"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Uiterlijk"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Appearance"
           }
         },
         "pl" : {
@@ -8297,16 +8303,16 @@
             "value" : "모양 설정"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Appearance settings"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Uiterlijk Instellingen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Appearance settings"
           }
         },
         "pl" : {
@@ -8487,16 +8493,16 @@
             "value" : "애플리케이션 기본 사항"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Application Basics"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Basisprincipes van de app"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Application Basics"
           }
         },
         "pl" : {
@@ -8678,16 +8684,16 @@
             "value" : "애플리케이션 필터"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Application filters"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Applicatie filter"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Application filters"
           }
         },
         "pl" : {
@@ -8868,16 +8874,16 @@
             "value" : "애플리케이션 필터"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Application Filters"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Applicatie filters"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Application Filters"
           }
         },
         "pl" : {
@@ -8953,6 +8959,9 @@
           }
         }
       }
+    },
+    "Apps in this list will not respond to window switcher shortcuts when in fullscreen mode." : {
+
     },
     "Are you sure you want to proceed?" : {
       "localizations" : {
@@ -9058,16 +9067,16 @@
             "value" : "계속 진행하겠습니까?"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Are you sure you want to proceed?"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Weet je zeker dat je wilt doorgaan?"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Are you sure you want to proceed?"
           }
         },
         "pl" : {
@@ -9249,16 +9258,16 @@
             "value" : "모든 설정을 기본값으로 초기화하시겠습니까?"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Are you sure you want to reset all settings to their default values?"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Weet je zeker dat je alle instellingen wil resetten naar de standaard waarden?"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Are you sure you want to reset all settings to their default values?"
           }
         },
         "pl" : {
@@ -9439,16 +9448,16 @@
             "value" : "모든 설정을 기본값으로 초기화하시겠습니까? 이렇게 하면 고급 설정도 초기화됩니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Are you sure you want to reset all settings to their default values? This will reset advanced settings as well."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Weet u zeker dat u alle instellingen wilt terugzetten naar de standaardwaarden? Hiermee worden ook de geavanceerde instellingen teruggezet."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Are you sure you want to reset all settings to their default values? This will reset advanced settings as well."
           }
         },
         "pl" : {
@@ -9629,16 +9638,16 @@
             "value" : "하단 - 왼쪽의 컨트롤, 오른쪽의 제목"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "At bottom - Controls on left, title on right"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Onderaan - Bedieningselementen links, titel rechts"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "At bottom - Controls on left, title on right"
           }
         },
         "pl" : {
@@ -9819,16 +9828,16 @@
             "value" : "하단 - 왼쪽은 제목, 오른쪽은 컨트롤"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "At bottom - Title on left, controls on right"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Onderaan - titel links, bediening rechts"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "At bottom - Title on left, controls on right"
           }
         },
         "pl" : {
@@ -10009,16 +10018,16 @@
             "value" : "상단 - 왼쪽의 컨트롤, 오른쪽의 제목"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "At top - Controls on left, title on right"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bovenaan - bediening links, titel rechts"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "At top - Controls on left, title on right"
           }
         },
         "pl" : {
@@ -10199,16 +10208,16 @@
             "value" : "상단 - 왼쪽의 제목, 오른쪽의 컨트롤"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "At top - Title on left, controls on right"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bovenaan - titel links, bediening rechts"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "At top - Title on left, controls on right"
           }
         },
         "pl" : {
@@ -10389,16 +10398,16 @@
             "value" : "자동 업데이트"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Automatic Updates"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Automatische Updates"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Automatic Updates"
           }
         },
         "pl" : {
@@ -10580,16 +10589,16 @@
             "value" : "자동으로 업데이트 확인"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Automatically check for updates"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Controleer automatisch voor updates"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Automatically check for updates"
           }
         },
         "pl" : {
@@ -10770,16 +10779,16 @@
             "value" : "블러 정도"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Blur amount"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Blur hoeveelheid"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Blur amount"
           }
         },
         "pl" : {
@@ -10961,16 +10970,16 @@
             "value" : "왼쪽 하단"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Bottom Left"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Linksonderaan"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Bottom Left"
           }
         },
         "pl" : {
@@ -11152,16 +11161,16 @@
             "value" : "오른쪽 하단"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Bottom Right"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Rechtsonderaan"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Bottom Right"
           }
         },
         "pl" : {
@@ -11237,6 +11246,9 @@
           }
         }
       }
+    },
+    "Browse for .app file..." : {
+
     },
     "Buy me a coffee" : {
       "localizations" : {
@@ -11342,16 +11354,16 @@
             "value" : "커피 한 잔 사주세요"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Buy me a coffee"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Koop een kopje koffie voor me"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Buy me a coffee"
           }
         },
         "pl" : {
@@ -11533,16 +11545,16 @@
             "value" : "따듯한 커피 한 잔 감사합니다"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Buy me a coffee here, thank you!"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Koop hier een koffie voor me, bedankt!"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Buy me a coffee here, thank you!"
           }
         },
         "pl" : {
@@ -11723,13 +11735,13 @@
             "value" : "캘린더 액세스 필요"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Calendar Access Needed"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Calendar Access Needed"
@@ -11915,16 +11927,16 @@
             "value" : "이것도 볼 수 있나요?"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Can you even see this?"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Kan je dit zien?"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Can you even see this?"
           }
         },
         "pl" : {
@@ -12105,16 +12117,16 @@
             "value" : "취소"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Cancel"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Annuleer"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Cancel"
           }
         },
         "pl" : {
@@ -12295,16 +12307,16 @@
             "value" : "색상을 추가할 수 없습니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Cannot Add Color"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Kan kleur niet toevoegen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Cannot Add Color"
           }
         },
         "pl" : {
@@ -12485,16 +12497,16 @@
             "value" : "색상을 제거할 수 없습니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Cannot Remove Color"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Kan kleur niet verwijderen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Cannot Remove Color"
           }
         },
         "pl" : {
@@ -12675,16 +12687,16 @@
             "value" : "업데이트 확인"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Check for Updates"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Controleer op Updates"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Check for Updates"
           }
         },
         "pl" : {
@@ -12865,16 +12877,16 @@
             "value" : "\"트리거 키 설정\"을 클릭합니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Click \"Set Trigger Key\""
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Klik op \"Set Trigger Key\""
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Click \"Set Trigger Key\""
           }
         },
         "pl" : {
@@ -13055,16 +13067,16 @@
             "value" : "닫기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Close"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sluiten"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close"
           }
         },
         "pl" : {
@@ -13245,16 +13257,16 @@
             "value" : "모두 닫기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Close All"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sluit alles"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close All"
           }
         },
         "pl" : {
@@ -13436,13 +13448,13 @@
             "value" : "임베디드 모드로 축소"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Collapse to embedded mode"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Collapse to embedded mode"
@@ -13626,16 +13638,16 @@
             "value" : "색상 사용자 지정"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Color Customization"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Kleuraanpassing"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Color Customization"
           }
         },
         "pl" : {
@@ -13817,16 +13829,16 @@
             "value" : "색상"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Colors"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Kleuren"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Colors"
           }
         },
         "pl" : {
@@ -14007,15 +14019,15 @@
             "value" : "커맨드키 (⌘)"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Command (⌘)"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Command (⌘)"
           }
         },
@@ -14197,16 +14209,16 @@
             "value" : "확인"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Confirm"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bevestigen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Confirm"
           }
         },
         "pl" : {
@@ -14387,16 +14399,16 @@
             "value" : "번역 기여하기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Contribute translation"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bijdragen aan vertalingen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Contribute translation"
           }
         },
         "pl" : {
@@ -14578,16 +14590,16 @@
             "value" : "여기에서 번역에 기여하세요!"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Contribute translation here!"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Werk mee aan de vertaling!"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Contribute translation here!"
           }
         },
         "pl" : {
@@ -14768,15 +14780,15 @@
             "value" : "컨트롤키 (⌃)"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Control (⌃)"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Control (⌃)"
           }
         },
@@ -14958,16 +14970,16 @@
             "value" : "창 미리보기의 시각적 세부 사항과 업데이트 빈도를 제어합니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Controls the visual detail and update frequency of window previews."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bepaalt de visuele details en de updatefrequentie van venstervoorbeelden."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Controls the visual detail and update frequency of window previews."
           }
         },
         "pl" : {
@@ -15149,16 +15161,16 @@
             "value" : "현재 키 조합: %@"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Current Keybind: %@"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Huidige Toetscombinatie: %@"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Current Keybind: %@"
           }
         },
         "pl" : {
@@ -15339,16 +15351,16 @@
             "value" : "현재 바로 가기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Current Shortcut"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Huidige sneltoets"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Current Shortcut"
           }
         },
         "pl" : {
@@ -15529,16 +15541,16 @@
             "value" : "현재 버전"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Current Version"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Huidige Versie"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Current Version"
           }
         },
         "pl" : {
@@ -15720,16 +15732,16 @@
             "value" : "현재 버전: %@"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Current Version: %@"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Huidige Versie: %@"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Current Version: %@"
           }
         },
         "pl" : {
@@ -15910,16 +15922,16 @@
             "value" : "사용자 지정 애플리케이션 디렉토리"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Custom Application Directories"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Aangepaste applicatie mappen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Custom Application Directories"
           }
         },
         "pl" : {
@@ -16101,16 +16113,16 @@
             "value" : "기본값"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Default"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Standaard"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Default"
           }
         },
         "pl" : {
@@ -16293,16 +16305,16 @@
             "value" : "기본값(중간 크기)"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Default (Medium Large)"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Standaard (Medium Groot)"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Default (Medium Large)"
           }
         },
         "pl" : {
@@ -16483,16 +16495,16 @@
             "value" : "상세한"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Detailed"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Gedetailleerd"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Detailed"
           }
         },
         "pl" : {
@@ -16673,16 +16685,16 @@
             "value" : "선택되지 않은 창 흐리게 표시"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Dim Unselected Windows"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Dim niet geselecteerd venster"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Dim Unselected Windows"
           }
         },
         "pl" : {
@@ -16863,16 +16875,16 @@
             "value" : "연결 해제된 디스플레이"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Disconnected Display"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Verbreek verbind met scherm"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Disconnected Display"
           }
         },
         "pl" : {
@@ -17053,16 +17065,16 @@
             "value" : "기능에 대해 토론하고 커뮤니티에서 도움 받기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Discuss features and get help from the community"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bespreek functies en krijg hulp van de community"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Discuss features and get help from the community"
           }
         },
         "pl" : {
@@ -17244,16 +17256,16 @@
             "value" : "표시 %u"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Display %u"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Weergave %u"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Display %u"
           }
         },
         "pl" : {
@@ -17434,16 +17446,16 @@
             "value" : "Dock 미리보기 에어로 쉐이크 액션"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Dock Preview Aero Shake Action"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Dock voorvertoning Aero Schud Actie"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Dock Preview Aero Shake Action"
           }
         },
         "pl" : {
@@ -17624,16 +17636,16 @@
             "value" : "Dock 미리보기 호버 액션"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Dock Preview Hover Action"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Dock voorvertoning Hover Action"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Dock Preview Hover Action"
           }
         },
         "pl" : {
@@ -17814,16 +17826,16 @@
             "value" : "Dock 미리보기 설정"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Dock Preview Settings"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Dock voorbeeldinstellingen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Dock Preview Settings"
           }
         },
         "pl" : {
@@ -18005,16 +18017,16 @@
             "value" : "Dock 미리보기 창 호버 액션"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Dock Preview Window Hover Action"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Venster van Dock voorvertoning Hover Action"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Dock Preview Window Hover Action"
           }
         },
         "pl" : {
@@ -18195,16 +18207,16 @@
             "value" : "독 미리 보기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Dock Previews"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Dock voorbeelden"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Dock Previews"
           }
         },
         "pl" : {
@@ -18386,16 +18398,16 @@
             "value" : "Dock 미리보기 & 창 전환"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Dock Previews & Window Switcher"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Dock Previews & Venster switcher"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Dock Previews & Window Switcher"
           }
         },
         "pl" : {
@@ -18577,16 +18589,16 @@
             "value" : "Dock 미리보기만"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Dock Previews only"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Alleen Dock voorbeelden"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Dock Previews only"
           }
         },
         "pl" : {
@@ -18767,16 +18779,16 @@
             "value" : "DockDoor는 컴퓨터의 화면 및 오디오를 녹화하지 않으며, 창 미리보기 화면만 띄웁니다. 모든 정보는 저장 및 공유하지 않으며, 모든 작업은 본 기기에서 안전하게 이루어집니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "DockDoor does not record your screen or audio. It only captures static window previews. No information is stored or shared; all processing occurs privately on your device."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "DockDoor neemt je scherm of audio niet op. Het legt alleen statische venstervoorbeelden vast. Er wordt geen informatie opgeslagen of gedeeld; alle verwerking vindt plaats op uw eigen apparaat."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "DockDoor does not record your screen or audio. It only captures static window previews. No information is stored or shared; all processing occurs privately on your device."
           }
         },
         "pl" : {
@@ -18957,13 +18969,13 @@
             "value" : "DockDoor가 캘린더에 액세스하려면 권한이 필요합니다."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "DockDoor needs permission to access your calendar."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "DockDoor needs permission to access your calendar."
@@ -19147,16 +19159,16 @@
             "value" : "DockDoor는 화면 녹화 권한이 필요합니다. macOS Sequoia를 사용하신다면, 새로운 시스템 보안 정책으로 인해 설치하신 모든 캡처 앱에서 이 창을 매주, 매달, 혹은 재부팅 후에 보시게 될 겁니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "DockDoor needs screen recording access. In macOS Sequoia, you'll see this prompt every week or month and after reboots. This is a new system-wide security policy for all screen capture apps."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Dockdoor heeft toestemming nodig om schermopname te maken. In macOS Sequoia, zie je deze pop-up elke week of maand wanneer het is heropgestart. Dit is een nieuw, systeem breed, veiligheids-beleid voor alle schermopnemende apps."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "DockDoor needs screen recording access. In macOS Sequoia, you'll see this prompt every week or month and after reboots. This is a new system-wide security policy for all screen capture apps."
           }
         },
         "pl" : {
@@ -19337,16 +19349,16 @@
             "value" : "색 편집"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Edit Color"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bewerk Kleur"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Edit Color"
           }
         },
         "pl" : {
@@ -19528,16 +19540,16 @@
             "value" : "요소 중첩"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Elements Overlap"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Elementen overlappen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Elements Overlap"
           }
         },
         "pl" : {
@@ -19718,13 +19730,13 @@
             "value" : "창 미리보기가 있는 컨트롤 임베드(미리보기가 표시된 경우)"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Embed controls with window previews (if previews shown)"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Embed controls with window previews (if previews shown)"
@@ -19910,16 +19922,16 @@
             "value" : "임베디드"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Embedded"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ingesloten"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Embedded"
           }
         },
         "pl" : {
@@ -20100,16 +20112,16 @@
             "value" : "자동으로 업데이트 확인하기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Enable automatic checking for updates"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Automatisch controleren op updates inschakelen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Enable automatic checking for updates"
           }
         },
         "pl" : {
@@ -20291,16 +20303,16 @@
             "value" : "호버 창 슬라이딩 애니메이션 활성화"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Enable Hover Window Sliding Animation"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Zwevend venster schuifanimatie inschakelen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Enable Hover Window Sliding Animation"
           }
         },
         "pl" : {
@@ -20481,13 +20493,13 @@
             "value" : "고정 사용"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Enable Pinning"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Enable Pinning"
@@ -20672,16 +20684,16 @@
             "value" : "창 미리보기 슬라이딩 애니메이션 활성화"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Enable Preview Window Sliding Animation"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Schuifanimatie van voorvertoningsvenster inschakelen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Enable Preview Window Sliding Animation"
           }
         },
         "pl" : {
@@ -20862,16 +20874,16 @@
             "value" : "윈도우 스위치 활성화"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Enable Window Switcher"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sta venster schakelaar toe"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Enable Window Switcher"
           }
         },
         "pl" : {
@@ -21052,16 +21064,16 @@
             "value" : "활성화됨"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Enabled"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Aan"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Enabled"
           }
         },
         "pl" : {
@@ -21242,16 +21254,16 @@
             "value" : "활성화된 버튼"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Enabled Buttons"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Activeer knoppen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Enabled Buttons"
           }
         },
         "pl" : {
@@ -21432,16 +21444,16 @@
             "value" : "도크 경험을 향상하세요!"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Enhance your dock experience!"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Verbeter je Dock ervaring!"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Enhance your dock experience!"
           }
         },
         "pl" : {
@@ -21622,13 +21634,13 @@
             "value" : "여유로운 하루를 즐기거나 캘린더에 이벤트를 추가하세요."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Enjoy your free day or add some events to your calendar."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Enjoy your free day or add some events to your calendar."
@@ -21812,16 +21824,16 @@
             "value" : "필터링할 텍스트 입력"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Enter text to filter"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Voer tekst in om te filteren"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Enter text to filter"
           }
         },
         "pl" : {
@@ -22002,16 +22014,16 @@
             "value" : "이제 모든 준비가 끝났어요!"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Everything is now set up!"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Alles is nu ingesteld!"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Everything is now set up!"
           }
         },
         "pl" : {
@@ -22193,16 +22205,16 @@
             "value" : "예제:"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Example:"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Voorbeeld:"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Example:"
           }
         },
         "pl" : {
@@ -22384,16 +22396,16 @@
             "value" : "제목의 특정 텍스트를 필터링하여 창을 캡처에서 제외하기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Exclude windows from capture by filtering specific text in their titles"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sluit vensters uit van vastlegging door specifieke tekst in hun titels te filteren"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Exclude windows from capture by filtering specific text in their titles"
           }
         },
         "pl" : {
@@ -22574,16 +22586,16 @@
             "value" : "제목의 특정 텍스트를 필터링하여 창을 캡처에서 제외합니다(대소문자 구분 없음)."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Exclude windows from capture by filtering specific text in their titles (case-insensitive)."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Vensters uitsluiten van vastlegging door specifieke tekst in hun titels te filteren (hoofdlettergevoelig)."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Exclude windows from capture by filtering specific text in their titles (case-insensitive)."
           }
         },
         "pl" : {
@@ -22765,13 +22777,13 @@
             "value" : "전체 모드로 확장"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Expand to full mode"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Expand to full mode"
@@ -22956,16 +22968,16 @@
             "value" : "실험적: 앱 레이블 위에 미리보기 표시"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "EXPERIMENTAL: Show preview above app labels"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "EXPERIMENTEEL: Voorbeeld weergeven boven app labels"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "EXPERIMENTAL: Show preview above app labels"
           }
         },
         "pl" : {
@@ -23148,16 +23160,16 @@
             "value" : "매무 매우 작음"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Extra Extra Small"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Extra extra klein"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Extra Extra Small"
           }
         },
         "pl" : {
@@ -23340,16 +23352,16 @@
             "value" : "매우 작음"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Extra Small"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Extra Klein"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Extra Small"
           }
         },
         "pl" : {
@@ -23536,16 +23548,16 @@
             "value" : "v%1$@: %2$@을(를) 다운로드하지 못했습니다"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Failed to download v%1$@: %2$@"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Het downloaden van v%1$@ is mislukt: %2$@"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Failed to download v%1$@: %2$@"
           }
         },
         "pl" : {
@@ -23727,15 +23739,15 @@
             "value" : "필터"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Filters"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Filters"
           }
         },
@@ -23917,16 +23929,16 @@
             "value" : "필터 설정"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Filters settings"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Filterinstellingen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Filters settings"
           }
         },
         "pl" : {
@@ -24107,16 +24119,16 @@
             "value" : "시각적 세부 사항과 레이아웃 옵션을 미세 조정할 수 있습니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Fine-tune visual details and layout options."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Verfijn visuele details en lay-outopties."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Fine-tune visual details and layout options."
           }
         },
         "pl" : {
@@ -24297,13 +24309,13 @@
             "value" : "지원되는 앱(음악, Spotify, 캘린더)의 경우 Dock 아이콘을 가리키면 창 미리보기 대신 대화형 컨트롤을 표시합니다."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "For supported apps (Music, Spotify, Calendar), show interactive controls instead of window previews when hovering their Dock icons."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "For supported apps (Music, Spotify, Calendar), show interactive controls instead of window previews when hovering their Dock icons."
@@ -24487,16 +24499,16 @@
             "value" : "강제 종료"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Force Quit"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Afsluiten forceren"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Force Quit"
           }
         },
         "pl" : {
@@ -24677,16 +24689,16 @@
             "value" : "버그가 있나요?"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Found a Bug?"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Een bug gevonden?"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Found a Bug?"
           }
         },
         "pl" : {
@@ -24867,16 +24879,16 @@
             "value" : "전체 화면"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Fullscreen"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Volledig scherm"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Fullscreen"
           }
         },
         "pl" : {
@@ -24952,6 +24964,9 @@
           }
         }
       }
+    },
+    "Fullscreen App Blacklist" : {
+
     },
     "General" : {
       "comment" : "Settings tab title",
@@ -25058,16 +25073,16 @@
             "value" : "일반"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "General"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Algemeen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "General"
           }
         },
         "pl" : {
@@ -25248,16 +25263,16 @@
             "value" : "일반 모양"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "General Appearance"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Algemeen uiterlijk"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "General Appearance"
           }
         },
         "pl" : {
@@ -25439,16 +25454,16 @@
             "value" : "일반 제외 사항"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "General Exclusions"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Algemene uitsluitingen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "General Exclusions"
           }
         },
         "pl" : {
@@ -25629,16 +25644,16 @@
             "value" : "일반 설정"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "General settings"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Algemene Instellingen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "General settings"
           }
         },
         "pl" : {
@@ -25819,16 +25834,16 @@
             "value" : "시작하기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Get Started"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Begin"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Get Started"
           }
         },
         "pl" : {
@@ -26009,13 +26024,13 @@
             "value" : "글로벌 패딩 스케일"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Global Padding Scale"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Global Padding Scale"
@@ -26199,13 +26214,13 @@
             "value" : "액세스 권한 부여"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Grant Access"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Grant Access"
@@ -26389,16 +26404,16 @@
             "value" : "허용"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Granted"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Toegekend"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Granted"
           }
         },
         "pl" : {
@@ -26579,16 +26594,16 @@
             "value" : "아이디어가 있나요?"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Have an Idea?"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Heb je een idee?"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Have an Idea?"
           }
         },
         "pl" : {
@@ -26771,16 +26786,16 @@
             "value" : "도움말"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Help"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Hulp"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Help"
           }
         },
         "pl" : {
@@ -26961,16 +26976,16 @@
             "value" : "도움말 및 지원"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Help & Support"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Hulp en ondersteuning"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Help & Support"
           }
         },
         "pl" : {
@@ -27152,16 +27167,16 @@
             "value" : "도움말 및 질문 설정"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Help and questions settings"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Instellingen voor hulp en vragen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Help and questions settings"
           }
         },
         "pl" : {
@@ -27342,16 +27357,16 @@
             "value" : "DockDoor를 귀하의 언어로 사용할 수 있도록 도와주세요"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Help make DockDoor available in your language"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Help DockDoor beschikbaar te maken in jouw taal"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Help make DockDoor available in your language"
           }
         },
         "pl" : {
@@ -27532,16 +27547,16 @@
             "value" : "버그와 같은 이슈들을 제보하여 DockDoor를 개선해 주세요."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Help us improve DockDoor by reporting any issues you encounter."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Help ons DockDoor verbeteren door problemen die je ervaart te rapporteren."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Help us improve DockDoor by reporting any issues you encounter."
           }
         },
         "pl" : {
@@ -27724,16 +27739,16 @@
             "value" : "숨김"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Hidden"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Verborgen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Hidden"
           }
         },
         "pl" : {
@@ -27914,16 +27929,16 @@
             "value" : "고급 설정 숨기기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Hide Advanced Settings"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Verberg geavanceerde instellingen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Hide Advanced Settings"
           }
         },
         "pl" : {
@@ -28104,16 +28119,16 @@
             "value" : "도크 아이콘 클릭 시 모든 앱 창 숨기기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Hide all app windows on dock icon click"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Verberg alle app vensters bij klikken op het dockpictogram"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Hide all app windows on dock icon click"
           }
         },
         "pl" : {
@@ -28295,16 +28310,16 @@
             "value" : "도크 아이콘을 클릭하면 모든 애플리케이션 창을 숨깁니다"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Hide all application windows when clicking on the dock icon"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Verberg alle applicatievensters wanneer u op het dockpictogram klikt"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Hide all application windows when clicking on the dock icon"
           }
         },
         "pl" : {
@@ -28485,16 +28500,16 @@
             "value" : "하이라이트 그라데이션 색상"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Highlight Gradient Colors"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Markeer verloopkleuren"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Highlight Gradient Colors"
           }
         },
         "pl" : {
@@ -28676,16 +28691,16 @@
             "value" : "호버 창 열기 지연"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Hover Window Open Delay"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Vertraging bij openen van zwevend venster"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Hover Window Open Delay"
           }
         },
         "pl" : {
@@ -28867,16 +28882,16 @@
             "value" : "호버 창 제목 스타일"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Hover Window Title Style"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Stijl van de zwevend venster titel"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Hover Window Title Style"
           }
         },
         "pl" : {
@@ -29057,16 +29072,16 @@
             "value" : "설정 방법"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "How to Set Up"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Hoe te configureren"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "How to Set Up"
           }
         },
         "pl" : {
@@ -29248,13 +29263,13 @@
             "value" : "비활성화하면 창 미리 보기를 사용할 수 없는 경우(예: 모든 창이 최소화됨)에만 특수 컨트롤이 나타납니다. 활성화하면 가능한 경우 컨트롤이 미리 보기와 통합됩니다."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "If disabled, special controls only appear if no window previews are available (e.g., all windows minimized). If enabled, controls integrate with previews when possible."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "If disabled, special controls only appear if no window previews are available (e.g., all windows minimized). If enabled, controls integrate with previews when possible."
@@ -29438,13 +29453,13 @@
             "value" : "활성화하면 가능한 경우 컨트롤이 미리 보기와 통합됩니다."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "If enabled, controls integrate with previews when possible."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "If enabled, controls integrate with previews when possible."
@@ -29628,16 +29643,16 @@
             "value" : "DockDoor를 유용하게 사용하고 계신다면, 저희 팀을 후원해 주세요!"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "If you find DockDoor useful, consider donating. Your support helps keep the project going!"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Vindt u DockDoor nuttig? Overweeg dan een donatie. Uw steun helpt het project gaande te houden!"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "If you find DockDoor useful, consider donating. Your support helps keep the project going!"
           }
         },
         "pl" : {
@@ -29819,16 +29834,16 @@
             "value" : "메뉴 막대의 아이콘에 접근하려면 앱을 실행하여 10초 간 노출시킬 수 있습니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "If you need to access the menu bar icon, launch the app to reveal it for 10 seconds."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Als u het menubalk pictogram nodig hebt, start u de app zodat het 10 seconden lang zichtbaar is."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "If you need to access the menu bar icon, launch the app to reveal it for 10 seconds."
           }
         },
         "pl" : {
@@ -30009,16 +30024,16 @@
             "value" : "하나의 창으로 앱 무시하기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Ignore apps with one window"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Negeer apps met één venster"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Ignore apps with one window"
           }
         },
         "pl" : {
@@ -30200,16 +30215,16 @@
             "value" : "하나의 창만 있는 앱 무시"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Ignore Apps with One Window"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Negeer apps met één venster"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Ignore Apps with One Window"
           }
         },
         "pl" : {
@@ -30391,16 +30406,16 @@
             "value" : "중요: 녹화할 때는 트리거 키만 누르세요(예: 명령 + Tab을 원할 경우 Tab만 누르세요). 녹화 중에는 초기화 키를 누르지 마세요."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Important: When recording, press ONLY the trigger key (e.g. just press Tab if you want command + Tab). Do not press the initialization key during recording."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Belangrijk: druk tijdens het opnemen ALLEEN op de trigger-toets (druk bijvoorbeeld alleen op Tab als u Command + Tab wilt). Druk tijdens het opnemen niet op de initialisatietoets."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Important: When recording, press ONLY the trigger key (e.g. just press Tab if you want command + Tab). Do not press the initialization key during recording."
           }
         },
         "pl" : {
@@ -30582,16 +30597,16 @@
             "value" : "창 전환기에 숨김 및 최소화 창 포함하기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Include Hidden and Minimized Windows in the Window Switcher"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Verborgen en geminimaliseerde vensters opnemen in de venster wisselaar"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Include Hidden and Minimized Windows in the Window Switcher"
           }
         },
         "pl" : {
@@ -30772,16 +30787,16 @@
             "value" : "스위처에 숨김/최소화된 창 포함하기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Include hidden/minimized windows in Switcher"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Verborgen / geminimaliseerde vensters opnemen in de switcher"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Include hidden/minimized windows in Switcher"
           }
         },
         "pl" : {
@@ -30963,16 +30978,16 @@
             "value" : "스위처에 숨김/최소화된 창 포함하기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Include Hidden/Minimized Windows in Switcher"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Verborgen / geminimaliseerde vensters opnemen in de switcher"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Include Hidden/Minimized Windows in Switcher"
           }
         },
         "pl" : {
@@ -31153,16 +31168,16 @@
             "value" : "초기화 키"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Initialization Key"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Initialisatie sleutel"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Initialization Key"
           }
         },
         "pl" : {
@@ -31343,16 +31358,16 @@
             "value" : "지침"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Instructions"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Instructies"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Instructions"
           }
         },
         "pl" : {
@@ -31533,16 +31548,16 @@
             "value" : "상호작용 및 동작(Dock 미리보기)"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Interaction & Behavior (Dock Previews)"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Interactie en gedrag (Dock voorbeelden)"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Interaction & Behavior (Dock Previews)"
           }
         },
         "pl" : {
@@ -31723,16 +31738,16 @@
             "value" : "Discord 가입하기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Join our Discord"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Word lid van onze Discord"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Join our Discord"
           }
         },
         "pl" : {
@@ -31913,16 +31928,16 @@
             "value" : "측면 이동 중에도 미리보기 표시 유지"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Keep previews visible during lateral movement"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Houd previews zichtbaar tijdens zijwaartse beweging"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Keep previews visible during lateral movement"
           }
         },
         "pl" : {
@@ -32103,16 +32118,16 @@
             "value" : "키보드 단축키"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Keyboard Shortcut"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sneltoets"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Keyboard Shortcut"
           }
         },
         "pl" : {
@@ -32295,16 +32310,16 @@
             "value" : "크게"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Large"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Groot"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Large"
           }
         },
         "pl" : {
@@ -32485,16 +32500,16 @@
             "value" : "대형(1/2)"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Large (1/2)"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Groot (1/2)"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Large (1/2)"
           }
         },
         "pl" : {
@@ -32675,16 +32690,16 @@
             "value" : "마지막으로 확인함: %@"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Last checked: %@"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Laatst Gecontroleerd: %@"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Last checked: %@"
           }
         },
         "pl" : {
@@ -32865,16 +32880,16 @@
             "value" : "로그인할 때 DockDoor 실행"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Launch DockDoor at login"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Start DockDoor bij het inloggen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Launch DockDoor at login"
           }
         },
         "pl" : {
@@ -33056,16 +33071,16 @@
             "value" : "레이아웃 제한"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Layout Limits"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Lay-out grenzen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Layout Limits"
           }
         },
         "pl" : {
@@ -33246,16 +33261,16 @@
             "value" : "준비를 시작해봐요"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Let's set things up"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Laten we de dingen instellen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Let's set things up"
           }
         },
         "pl" : {
@@ -33436,16 +33451,16 @@
             "value" : "경량"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Lightweight"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Lichtgewicht"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Lightweight"
           }
         },
         "pl" : {
@@ -33521,6 +33536,9 @@
           }
         }
       }
+    },
+    "Limit Window Switcher to active app only" : {
+
     },
     "Loading lyrics..." : {
       "localizations" : {
@@ -33626,13 +33644,13 @@
             "value" : "가사 로드 중..."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Loading lyrics..."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Loading lyrics..."
@@ -33816,16 +33834,16 @@
             "value" : "미리 보기 로드 중..."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Loading preview..."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Preview aan het laden..."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Loading preview..."
           }
         },
         "pl" : {
@@ -34006,16 +34024,16 @@
             "value" : "스위처 미리보기의 최대 행 수"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Max Rows for Switcher Previews"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Maximaal aantal rijen voor Switcher voorbeelden"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Max Rows for Switcher Previews"
           }
         },
         "pl" : {
@@ -34196,16 +34214,16 @@
             "value" : "Dock 미리보기용 최대 스택"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Max Stacks for Dock Previews"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Maximale stapels voor Dock voorbeelden"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Max Stacks for Dock Previews"
           }
         },
         "pl" : {
@@ -34387,16 +34405,16 @@
             "value" : "최대 가로 행"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Maximum Horizontal Rows"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Maximaal aantal horizontale rijen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Maximum Horizontal Rows"
           }
         },
         "pl" : {
@@ -34577,16 +34595,16 @@
             "value" : "최대 색상 수(%lld)에 도달했습니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Maximum number of colors (%lld) reached."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Maximaal aantal kleuren (%lld) bereikt."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Maximum number of colors (%lld) reached."
           }
         },
         "pl" : {
@@ -34768,16 +34786,16 @@
             "value" : "최대 세로 열"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Maximum Vertical Columns"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Maximale verticale kolommen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Maximum Vertical Columns"
           }
         },
         "pl" : {
@@ -34960,15 +34978,15 @@
             "value" : "중간"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Medium"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Medium"
           }
         },
@@ -35150,16 +35168,16 @@
             "value" : "중간(1/%lld)"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Medium (1/%lld)"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Gemiddeld (1/%lld)"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Medium (1/%lld)"
           }
         },
         "pl" : {
@@ -35341,16 +35359,16 @@
             "value" : "메뉴바 아이콘 숨김"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Menu Bar Icon Hidden"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Menubalk pictogram verborgen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Menu Bar Icon Hidden"
           }
         },
         "pl" : {
@@ -35531,16 +35549,16 @@
             "value" : "최소화"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Minimize"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Minimaliseer"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Minimize"
           }
         },
         "pl" : {
@@ -35721,16 +35739,16 @@
             "value" : "모두 최소화"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Minimize All"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Minimaliseer alles"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Minimize All"
           }
         },
         "pl" : {
@@ -35912,16 +35930,16 @@
             "value" : "모든 창 최소화"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Minimize all windows"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Minimaliseer alle vensters"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Minimize all windows"
           }
         },
         "pl" : {
@@ -36103,16 +36121,16 @@
             "value" : "현재 창을 제외한 모든 창을 최소화합니다"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Minimize all windows except the current one"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Minimaliseer alle vensters behalve de huidige"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Minimize all windows except the current one"
           }
         },
         "pl" : {
@@ -36293,16 +36311,16 @@
             "value" : "도달한 최소 색상 수입니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Minimum number of colors reached."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Minimale aantal kleuren bereikt."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Minimum number of colors reached."
           }
         },
         "pl" : {
@@ -36483,16 +36501,16 @@
             "value" : "설정 → 개인정보 및 보안으로 이동합니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Navigate to Settings → Privacy & Security"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Navigeer naar Instellingen → Privacy & Veiligheid"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Navigate to Settings → Privacy & Security"
           }
         },
         "pl" : {
@@ -36674,16 +36692,16 @@
             "value" : "항상 보이지 않음"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Never visible"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Nooit zichtbaar"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Never visible"
           }
         },
         "pl" : {
@@ -36864,16 +36882,16 @@
             "value" : "새 윈도우"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "New Window"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Nieuw venster"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "New Window"
           }
         },
         "pl" : {
@@ -37054,16 +37072,16 @@
             "value" : "다음"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Next page"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Volgende pagina"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Next page"
           }
         },
         "pl" : {
@@ -37245,16 +37263,16 @@
             "value" : "동작 없음"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No action"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Geen Actie"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "No action"
           }
         },
         "pl" : {
@@ -37435,16 +37453,16 @@
             "value" : "아직 검색되거나 스캔된 애플리케이션이 없습니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No applications found or scanned yet."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Nog geen toepassingen gevonden of gescand."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "No applications found or scanned yet."
           }
         },
         "pl" : {
@@ -37520,6 +37538,9 @@
           }
         }
       }
+    },
+    "No apps in blacklist" : {
+
     },
     "No audio devices found" : {
       "localizations" : {
@@ -37625,13 +37646,13 @@
             "value" : "오디오 장치를 찾을 수 없습니다."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "No audio devices found"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "No audio devices found"
@@ -37815,16 +37836,16 @@
             "value" : "사용자 지정 디렉터리가 추가되지 않았습니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No custom directories added"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Geen aangepaste mappen toegevoegd"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "No custom directories added"
           }
         },
         "pl" : {
@@ -38005,13 +38026,13 @@
             "value" : "오늘은 예정된 이벤트가 없습니다!"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "No events scheduled for today!"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "No events scheduled for today!"
@@ -38195,13 +38216,13 @@
             "value" : "오늘은 이벤트 없음"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "No events today"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "No events today"
@@ -38386,16 +38407,16 @@
             "value" : "추가한 필터 없음"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No filters added"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Geen filters toegevoegd"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "No filters added"
           }
         },
         "pl" : {
@@ -38578,16 +38599,16 @@
             "value" : "호버 동작 없음"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No hover action"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Geen zweef actie"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "No hover action"
           }
         },
         "pl" : {
@@ -38768,13 +38789,13 @@
             "value" : "사용 가능한 가사 없음"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "No lyrics available"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "No lyrics available"
@@ -38958,16 +38979,16 @@
             "value" : "최근 확인사항 없음"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No recent checks"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Geen recente checks"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "No recent checks"
           }
         },
         "pl" : {
@@ -39148,16 +39169,16 @@
             "value" : "창 제목 필터가 추가되지 않았습니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No window title filters added"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Geen venstertitel filters toegevoegd"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "No window title filters added"
           }
         },
         "pl" : {
@@ -39338,16 +39359,16 @@
             "value" : "%@ 아니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Not %@"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Niet %@"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Not %@"
           }
         },
         "pl" : {
@@ -39529,16 +39550,16 @@
             "value" : "허용되지 않음"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Not granted"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Niet toegekend"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Not granted"
           }
         },
         "pl" : {
@@ -39719,16 +39740,16 @@
             "value" : "확인"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "OK"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ok"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "OK"
           }
         },
         "pl" : {
@@ -39910,16 +39931,16 @@
             "value" : "창을 가리키면; 버튼이 가리킬 때까지 어둡게 표시됨"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "On window hover; Dimmed until button hover"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bij venster zweven; gedimd tot knop zweven"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "On window hover; Dimmed until button hover"
           }
         },
         "pl" : {
@@ -40101,16 +40122,16 @@
             "value" : "창에 마우스를 올렸을 때; 불투명도 최대"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "On window hover; Full opacity"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bij venster zweven; volledige ondoorzichtigheid"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "On window hover; Full opacity"
           }
         },
         "pl" : {
@@ -40186,6 +40207,9 @@
           }
         }
       }
+    },
+    "Only show windows from the currently active/frontmost application." : {
+
     },
     "Only takes effect when dock auto-hide is enabled" : {
       "extractionState" : "stale",
@@ -40292,16 +40316,16 @@
             "value" : "독 자동 숨기기가 활성화된 경우에만 적용됩니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Only takes effect when dock auto-hide is enabled"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Wordt alleen van kracht als automatisch verbergen van het dock is ingeschakeld"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Only takes effect when dock auto-hide is enabled"
           }
         },
         "pl" : {
@@ -40483,16 +40507,16 @@
             "value" : "손쉬운 사용 설정 열기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Open Accessibility Settings"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Open Toegankelijkheidsinstellingen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Open Accessibility Settings"
           }
         },
         "pl" : {
@@ -40674,16 +40698,16 @@
             "value" : "화면 기록 설정 열기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Open Screen Recording Settings"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Open Schermopname Instellingen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Open Screen Recording Settings"
           }
         },
         "pl" : {
@@ -40864,16 +40888,16 @@
             "value" : "설정 열기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Open Settings"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Open Instellingen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Open Settings"
           }
         },
         "pl" : {
@@ -41054,13 +41078,13 @@
             "value" : "시스템 개인 정보 설정 열기"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Open System Privacy Settings"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Open System Privacy Settings"
@@ -41244,15 +41268,15 @@
             "value" : "옵션 키 (⌥)"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Option (⌥)"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Option (⌥)"
           }
         },
@@ -41434,16 +41458,16 @@
             "value" : "성능 프로필"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Performance Profiles"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Prestatie profiel"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Performance Profiles"
           }
         },
         "pl" : {
@@ -41624,16 +41648,16 @@
             "value" : "성능 튜닝(dock 미리보기)"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Performance Tuning (Dock Previews)"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Prestatie tuning (Dock voorbeelden)"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Performance Tuning (Dock Previews)"
           }
         },
         "pl" : {
@@ -41815,16 +41839,16 @@
             "value" : "권한 오류"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Permission error"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Machtigingsprobleem"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Permission error"
           }
         },
         "pl" : {
@@ -42006,16 +42030,16 @@
             "value" : "권한"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Permissions"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Machtigingen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Permissions"
           }
         },
         "pl" : {
@@ -42197,16 +42221,16 @@
             "value" : "권한 설정"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Permissions settings"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Machtigingsinstellingen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Permissions settings"
           }
         },
         "pl" : {
@@ -42387,16 +42411,16 @@
             "value" : "화면에 고정"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pin to Screen"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Vastzetten aan scherm"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Pin to Screen"
           }
         },
         "pl" : {
@@ -42577,13 +42601,13 @@
             "value" : "화면에 고정(컴팩트)"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Pin to Screen (Compact)"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Pin to Screen (Compact)"
@@ -42767,13 +42791,13 @@
             "value" : "화면에 고정(전체)"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Pin to Screen (Full)"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Pin to Screen (Full)"
@@ -42958,16 +42982,16 @@
             "value" : "화면에 고정됨"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pinned to screen"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Vastgezet aan scherm"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Pinned to screen"
           }
         },
         "pl" : {
@@ -43148,16 +43172,16 @@
             "value" : "배치 방향"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Placement Strategy"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Plaatsingsstrategie"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Placement Strategy"
           }
         },
         "pl" : {
@@ -43339,16 +43363,16 @@
             "value" : "변경사항을 적용하기 위해 앱을 종료하세요! :)"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Please Quit the App to Apply Changes! :)"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sluit de app om de wijzigingen toe te passen! :)"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Please Quit the App to Apply Changes! :)"
           }
         },
         "pl" : {
@@ -43530,16 +43554,16 @@
             "value" : "변경사항을 적용하기 위해 앱을 껐다가 켜주세요! :)"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Please Restart the App to Apply Changes! :)"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Start de app opnieuw op om de wijzigingen toe te passen! :)"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Please Restart the App to Apply Changes! :)"
           }
         },
         "pl" : {
@@ -43720,16 +43744,16 @@
             "value" : "변경사항을 적용하기 위해 앱을 껐다 켜주세요. OK를 누르면 앱이 종료됩니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Please restart the application to apply your changes. Click OK to quit the app."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Herstart de app om je veranderingen op te slaan. Druk OK om de app af te sluiten."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Please restart the application to apply your changes. Click OK to quit the app."
           }
         },
         "pl" : {
@@ -43911,15 +43935,15 @@
             "value" : "팝오버"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Popover"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Popover"
           }
         },
@@ -44101,16 +44125,16 @@
             "value" : "위치 창 컨트롤"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Position Window Controls"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Positie vensterbesturing"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Position Window Controls"
           }
         },
         "pl" : {
@@ -44292,16 +44316,16 @@
             "value" : "창의 전체 크기 미리 보기 표시"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Present a full size preview of the window"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Geef een voorbeeld van het venster op volledige grootte weer"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Present a full size preview of the window"
           }
         },
         "pl" : {
@@ -44483,16 +44507,16 @@
             "value" : "초기화 키를 누른 상태에서 아무 키 조합이나 눌러 키 바인딩을 설정하세요."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Press any key combination after holding the initialization key to set the keybind."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Om de sneltoetsencombinatie in te stellen: druk op een willekeurige toetsencombinatie nadat u de initialisatie toets ingedrukt hebt gehouden."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Press any key combination after holding the initialization key to set the keybind."
           }
         },
         "pl" : {
@@ -44674,16 +44698,16 @@
             "value" : "아무 키나 눌러서 단축키를 설정하세요"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Press any key to set the keybind."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Druk op een toets om de toetscombinatie in te stellen."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Press any key to set the keybind."
           }
         },
         "pl" : {
@@ -44864,16 +44888,16 @@
             "value" : "아무 키나 누르세요"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Press any key..."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Druk op een toets..."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Press any key..."
           }
         },
         "pl" : {
@@ -45054,16 +45078,16 @@
             "value" : "트리거 키만 누릅니다(예: Tab 키만 누름)."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Press ONLY the trigger key (e.g. just Tab)"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Druk ALLEEN op de trigger toets (bijv. alleen Tab)"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Press ONLY the trigger key (e.g. just Tab)"
           }
         },
         "pl" : {
@@ -45245,16 +45269,16 @@
             "value" : "키 조합 입력..."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Press the key combination..."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Druk de toetscombinatie in..."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Press the key combination..."
           }
         },
         "pl" : {
@@ -45435,16 +45459,16 @@
             "value" : "미리보기 중에 도크가 숨겨지지 않도록 하기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Prevent dock from hiding during previews"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Voorkom dat het dock tijdens previews wordt verborgen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Prevent dock from hiding during previews"
           }
         },
         "pl" : {
@@ -45625,16 +45649,16 @@
             "value" : "창이 하나만 있는 앱이 미리 보기에 표시되지 않도록 합니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Prevents apps that only ever have a single window from appearing in previews."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Voorkomt dat apps die slechts één venster hebben, in voorvertoningen worden weergegeven."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Prevents apps that only ever have a single window from appearing in previews."
           }
         },
         "pl" : {
@@ -45816,16 +45840,16 @@
             "value" : "인접한 창으로 옆으로 이동할 때 미리보기가 사라지는 것을 방지합니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Prevents previews from disappearing when moving sideways to adjacent windows"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Voorkomt dat voorvertoningen verdwijnen wanneer u zijwaarts naar aangrenzende vensters beweegt"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Prevents previews from disappearing when moving sideways to adjacent windows"
           }
         },
         "pl" : {
@@ -46006,16 +46030,16 @@
             "value" : "모양 및 품질 미리보기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Preview Appearance & Quality"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Voorbeeld uiterlijk & kwaliteit"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Preview Appearance & Quality"
           }
         },
         "pl" : {
@@ -46197,16 +46221,16 @@
             "value" : "모양 및 품질 미리보기(독 미리보기)"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Preview Appearance & Quality (Dock Previews)"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Voorbeeld uiterlijk & kwaliteit (Dock voorbeeld)"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Preview Appearance & Quality (Dock Previews)"
           }
         },
         "pl" : {
@@ -46388,16 +46412,16 @@
             "value" : "호버 동작 미리보기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Preview Hover Action"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Voorbeeld van Hover Actie"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Preview Hover Action"
           }
         },
         "pl" : {
@@ -46578,16 +46602,16 @@
             "value" : "미리보기 호버 동작 지연"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Preview Hover Action Delay"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Voorbeeld van Hover Actie vertraging"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Preview Hover Action Delay"
           }
         },
         "pl" : {
@@ -46769,16 +46793,16 @@
             "value" : "호버 딜레이 미리보기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Preview Hover Delay"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Voorbeeld van Hover Actie"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Preview Hover Delay"
           }
         },
         "pl" : {
@@ -46959,13 +46983,13 @@
             "value" : "레이아웃 미리보기(독)"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Preview Layout (Dock)"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Preview Layout (Dock)"
@@ -47149,13 +47173,13 @@
             "value" : "레이아웃 미리보기(스위쳐)"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Preview Layout (Switcher)"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Preview Layout (Switcher)"
@@ -47339,13 +47363,13 @@
             "value" : "품질 프로필 미리보기"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Preview Quality Profiles"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Preview Quality Profiles"
@@ -47529,16 +47553,16 @@
             "value" : "미리보기 크기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Preview Size"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Grootte voorvertoning"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Preview Size"
           }
         },
         "pl" : {
@@ -47719,13 +47743,13 @@
             "value" : "미리보기 창 페이드 아웃 기간"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Preview Window Fade Out Duration"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Preview Window Fade Out Duration"
@@ -47909,13 +47933,13 @@
             "value" : "미리보기 창 비활성 타이머"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Preview Window Inactivity Timer"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Preview Window Inactivity Timer"
@@ -48099,13 +48123,13 @@
             "value" : "미리보기 창 열기 지연"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Preview Window Open Delay"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Preview Window Open Delay"
@@ -48290,13 +48314,13 @@
             "value" : "미리보기 창 크기는 화면 크기의 1/%lld로 조정됩니다."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Preview windows are sized to 1/%lld of your screen dimensions"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Preview windows are sized to 1/%lld of your screen dimensions"
@@ -48480,15 +48504,15 @@
             "value" : "픽셀"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "px"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "px"
           }
         },
@@ -48670,16 +48694,16 @@
             "value" : "종료"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Quit"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Afsluiten"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Quit"
           }
         },
         "pl" : {
@@ -48861,16 +48885,16 @@
             "value" : "앱 종료"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Quit App"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sluit App"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Quit App"
           }
         },
         "pl" : {
@@ -49051,16 +49075,16 @@
             "value" : "DockDoor 종료"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Quit DockDoor"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sluit DockDoor"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Quit DockDoor"
           }
         },
         "pl" : {
@@ -49136,6 +49160,9 @@
           }
         }
       }
+    },
+    "Reading app information..." : {
+
     },
     "Reduce motion" : {
       "localizations" : {
@@ -49241,16 +49268,16 @@
             "value" : "모션 감소"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Reduce motion"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Beweging verminderen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reduce motion"
           }
         },
         "pl" : {
@@ -49431,16 +49458,16 @@
             "value" : "편안한"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Relaxed"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ontspannen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Relaxed"
           }
         },
         "pl" : {
@@ -49621,16 +49648,16 @@
             "value" : "스위처에서 창을 선택하려면 초기화 키에서 손을 떼세요."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Release initializer key to select window in Switcher"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Laat de initialisatie toets los om een ​​venster in Switcher te selecteren"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Release initializer key to select window in Switcher"
           }
         },
         "pl" : {
@@ -49811,16 +49838,16 @@
             "value" : "제거"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Remove"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Verwijderen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Remove"
           }
         },
         "pl" : {
@@ -50001,16 +50028,16 @@
             "value" : "모두 제거"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Remove All"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Alles verwijderen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Remove All"
           }
         },
         "pl" : {
@@ -50191,16 +50218,16 @@
             "value" : "버그 제보하기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Report a Bug"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Een bug doorgeven"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Report a Bug"
           }
         },
         "pl" : {
@@ -50381,16 +50408,16 @@
             "value" : "새로운 기능 요청"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Request a Feature"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Vraag een nieuwe feature aan"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Request a Feature"
           }
         },
         "pl" : {
@@ -50571,16 +50598,16 @@
             "value" : "다른 앱의 창 미리 보기를 캡처하는 데 필요합니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Required for capturing window previews of other apps"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Vereist voor het vastleggen van venstervoorbeelden van andere apps"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Required for capturing window previews of other apps"
           }
         },
         "pl" : {
@@ -50761,16 +50788,16 @@
             "value" : "도크 호버 감지 및 창 전환기 핫키에 필요합니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Required for dock hover detection and window switcher hotkeys"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Vereist voor dock hover detectie en sneltoetsen voor vensterwisseling"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Required for dock hover detection and window switcher hotkeys"
           }
         },
         "pl" : {
@@ -50951,15 +50978,15 @@
             "value" : "초기화"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Reset"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Reset"
           }
         },
@@ -51142,16 +51169,16 @@
             "value" : "모든 설정 초기화"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Reset All Settings"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Reset Alle Instellingen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reset All Settings"
           }
         },
         "pl" : {
@@ -51332,16 +51359,16 @@
             "value" : "모든 설정을 기본값으로 초기화"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Reset All Settings to Defaults"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Reset Alle Instellingen naar Standaard"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reset All Settings to Defaults"
           }
         },
         "pl" : {
@@ -51522,16 +51549,16 @@
             "value" : "기본 설정으로 초기화"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Reset to Defaults"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Reset naar Standaard"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reset to Defaults"
           }
         },
         "pl" : {
@@ -51712,16 +51739,16 @@
             "value" : "앱 다시 시작하기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Restart app"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "App herstarten"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Restart app"
           }
         },
         "pl" : {
@@ -51903,16 +51930,16 @@
             "value" : "앱 다시 시작하기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Restart App"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Herstart app"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Restart App"
           }
         },
         "pl" : {
@@ -52093,16 +52120,16 @@
             "value" : "재시작 필요합니다"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Restart required"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Herstart nodig"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Restart required"
           }
         },
         "pl" : {
@@ -52283,16 +52310,16 @@
             "value" : "색을 우클릭하여 삭제하세요."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Right click a color to remove it."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Klik met je rechtermuisknop om een kleur te verwijderen."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Right click a color to remove it."
           }
         },
         "pl" : {
@@ -52473,16 +52500,16 @@
             "value" : "둥근 이미지 모서리"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Rounded image corners"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Afbeelding met afgeronde hoeken"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Rounded image corners"
           }
         },
         "pl" : {
@@ -52663,16 +52690,16 @@
             "value" : "화면"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Screen"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Scherm"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Screen"
           }
         },
         "pl" : {
@@ -52854,16 +52881,16 @@
             "value" : "화면 기록:"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Screen Capturing:"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Scherm Vastleggen:"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Screen Capturing:"
           }
         },
         "pl" : {
@@ -53044,16 +53071,16 @@
             "value" : "화면 녹화"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Screen recording"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Schermopname"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Screen recording"
           }
         },
         "pl" : {
@@ -53235,16 +53262,16 @@
             "value" : "화면 기록 권한"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Screen Recording Permissions"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Schermopname Machtigingen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Screen Recording Permissions"
           }
         },
         "pl" : {
@@ -53426,16 +53453,16 @@
             "value" : "마지막으로 활성화된 창이 있는 화면"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Screen with last active window"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Scherm met laatst actieve venster"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Screen with last active window"
           }
         },
         "pl" : {
@@ -53617,16 +53644,16 @@
             "value" : "마우스가 있는 화면"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Screen with mouse"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Scherm met muis"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Screen with mouse"
           }
         },
         "pl" : {
@@ -53807,16 +53834,16 @@
             "value" : "초"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "seconds"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "seconden"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "seconds"
           }
         },
         "pl" : {
@@ -53999,16 +54026,16 @@
             "value" : "창 크게 보기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "See a large preview of the window"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Zie een grote voorvertoning van het scherm"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "See a large preview of the window"
           }
         },
         "pl" : {
@@ -54191,16 +54218,16 @@
             "value" : "창 미리보기 보기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "See a preview of the window"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Zie een voorvertoning van het scherm"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "See a preview of the window"
           }
         },
         "pl" : {
@@ -54381,16 +54408,16 @@
             "value" : "더 보기..."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "See more..."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Zie meer..."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "See more..."
           }
         },
         "pl" : {
@@ -54571,16 +54598,16 @@
             "value" : "프로필을 선택하면 일반적인 성능 설정을 빠르게 조정할 수 있습니다. 수동으로 제어하려면 '고급'을 선택합니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Select a profile to quickly adjust common performance settings. Choose \"Advanced\" for manual control."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Selecteer een profiel om snel algemene prestatie-instellingen aan te passen. Kies 'Geavanceerd' voor handmatige bediening."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Select a profile to quickly adjust common performance settings. Choose \"Advanced\" for manual control."
           }
         },
         "pl" : {
@@ -54656,6 +54683,9 @@
           }
         }
       }
+    },
+    "Select an application:" : {
+
     },
     "Select an initialization key (e.g. Command ⌘)" : {
       "localizations" : {
@@ -54761,16 +54791,16 @@
             "value" : "초기화 키(예: Command ⌘)를 선택합니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Select an initialization key (e.g. Command ⌘)"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Selecteer een initialisatie sleutel (bijv. Command ⌘)"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Select an initialization key (e.g. Command ⌘)"
           }
         },
         "pl" : {
@@ -54952,16 +54982,16 @@
             "value" : "캡처하고 미리 볼 수 있는 애플리케이션을 선택합니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Select which applications can be captured and previewed"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Selecteer welke applicaties vastgelegd en vooraf bekeken kunnen worden"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Select which applications can be captured and previewed"
           }
         },
         "pl" : {
@@ -55142,16 +55172,16 @@
             "value" : "DockDoor에 미리보기를 표시할 애플리케이션을 선택합니다. 선택하지 않은 앱은 무시됩니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Select which applications DockDoor should show previews for. Unchecked apps will be ignored."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Selecteer voor welke apps DockDoor previews moet weergeven. Niet aangevinkte apps worden genegeerd."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Select which applications DockDoor should show previews for. Unchecked apps will be ignored."
           }
         },
         "pl" : {
@@ -55227,6 +55257,9 @@
           }
         }
       }
+    },
+    "Selected app:" : {
+
     },
     "Selection Highlight" : {
       "localizations" : {
@@ -55332,16 +55365,16 @@
             "value" : "선택 하이라이트"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Selection Highlight"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Selectie markering"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Selection Highlight"
           }
         },
         "pl" : {
@@ -55523,16 +55556,16 @@
             "value" : "초기화 키와 키 바인딩 설정"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Set Initialization Key and Keybind"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Stel initialisatie sleutel en toetscombinatie in"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Set Initialization Key and Keybind"
           }
         },
         "pl" : {
@@ -55714,16 +55747,16 @@
             "value" : "무제한의 경우 0으로 설정"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Set to 0 for unlimited"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Instellen op 0 voor onbeperkt"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Set to 0 for unlimited"
           }
         },
         "pl" : {
@@ -55904,16 +55937,16 @@
             "value" : "트리거 키 설정"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Set Trigger Key"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Trigger toets instellen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Set Trigger Key"
           }
         },
         "pl" : {
@@ -56094,16 +56127,16 @@
             "value" : "미리보기에서 사용할 최대 행(하단/상단 독의 경우) 또는 열(측면 독의 경우)을 설정합니다. '0'은 동적으로 맞춤을 결정합니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Sets the max rows (for bottom/top Dock) or columns (for side Dock) previews will use. '0' dynamically determines fit."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Hiermee stelt u het maximum aantal rijen (voor onderste/bovenste Dock) of kolommen (voor zij-Dock) in dat voorvertoningen worden gebruikt. '0' bepaalt dynamisch de pasvorm."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Sets the max rows (for bottom/top Dock) or columns (for side Dock) previews will use. '0' dynamically determines fit."
           }
         },
         "pl" : {
@@ -56284,16 +56317,16 @@
             "value" : "창 전환기에서 사용할 최대 행 수를 설정합니다. '0'은 화면 높이에 따라 행을 동적으로 결정합니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Sets the maximum number of rows the Window Switcher will use. '0' dynamically determines rows based on screen height."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Hiermee stelt u het maximale aantal rijen in dat de venster wisselaar gebruikt. '0' bepaalt dynamisch het aantal rijen op basis van de schermhoogte."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Sets the maximum number of rows the Window Switcher will use. '0' dynamically determines rows based on screen height."
           }
         },
         "pl" : {
@@ -56475,16 +56508,16 @@
             "value" : "그림자"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Shadowed"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Schaduwen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shadowed"
           }
         },
         "pl" : {
@@ -56665,16 +56698,16 @@
             "value" : "고급 설정 표시"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Show Advanced Settings"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Toon geavanceerde instellingen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Show Advanced Settings"
           }
         },
         "pl" : {
@@ -56855,16 +56888,16 @@
             "value" : "앱 이름 표시"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Show App Name"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "App-naam weergeven"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Show App Name"
           }
         },
         "pl" : {
@@ -57045,16 +57078,16 @@
             "value" : "Dock 미리 보기에서 앱 이름 표시"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Show App Name in Dock Previews"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "App-naam in Dock Previews tonen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Show App Name in Dock Previews"
           }
         },
         "pl" : {
@@ -57235,13 +57268,13 @@
             "value" : "유효한 창이 없을 때 큰 컨트롤 표시"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Show big controls when no valid windows"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Show big controls when no valid windows"
@@ -57425,13 +57458,13 @@
             "value" : "도크 마우스오버 시 미디어/캘린더 컨트롤 보기"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Show media/calendar controls on Dock hover"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Show media/calendar controls on Dock hover"
@@ -57615,16 +57648,16 @@
             "value" : "메뉴 막대 아이콘 표시"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Show menu bar icon"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Menubalkpictogram weergeven"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Show menu bar icon"
           }
         },
         "pl" : {
@@ -57806,16 +57839,16 @@
             "value" : "메뉴 막대에 아이콘 표시"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Show Menu Bar Icon"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Laat Menu Bar Icon Zien"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Show Menu Bar Icon"
           }
         },
         "pl" : {
@@ -57996,16 +58029,16 @@
             "value" : "앱 레이블 위에 미리보기 표시"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Show preview above app labels"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Voorbeeld weergeven boven app-labels"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Show preview above app labels"
           }
         },
         "pl" : {
@@ -58186,16 +58219,16 @@
             "value" : "창 제목 표시"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Show Window Title"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Toon venstertitel"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Show Window Title"
           }
         },
         "pl" : {
@@ -58376,16 +58409,16 @@
             "value" : "창 제목 표시"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Show Window Title in"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Laat de Schermnaam Zien in"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Show Window Title in"
           }
         },
         "pl" : {
@@ -58567,16 +58600,16 @@
             "value" : "미리보기에서 창 제목 표시"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Show Window Title in Previews"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Laat de Schermnaam Zien in Voorvertoning"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Show Window Title in Previews"
           }
         },
         "pl" : {
@@ -58758,16 +58791,16 @@
             "value" : "창 제목 표시"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Show Window Titles"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Laat de Schermnaam Zien"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Show Window Titles"
           }
         },
         "pl" : {
@@ -58949,16 +58982,16 @@
             "value" : "미리보기에서 창 제목 표시"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Show Window Titles on Previews"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Toon venstertitels op previews"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Show Window Titles on Previews"
           }
         },
         "pl" : {
@@ -59139,16 +59172,16 @@
             "value" : "현재 창 대신 마지막으로 활성화된 창을 먼저 표시합니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Shows last active window first, instead of current window."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Toont het laatst actieve venster eerst, in plaats van het huidige venster."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shows last active window first, instead of current window."
           }
         },
         "pl" : {
@@ -59331,16 +59364,16 @@
             "value" : "클릭 시뮬레이션"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Simulate a click"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Simuleer een klik"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Simulate a click"
           }
         },
         "pl" : {
@@ -59522,16 +59555,16 @@
             "value" : "클릭 시뮬레이션(창 열기)"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Simulate a click (open the window)"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Simuleer een klik (open het scherm)"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Simulate a click (open the window)"
           }
         },
         "pl" : {
@@ -59714,16 +59747,16 @@
             "value" : "작게"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Small"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Klein"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Small"
           }
         },
         "pl" : {
@@ -59904,16 +59937,16 @@
             "value" : "소형(1/%lld)"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Small (1/%lld)"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Klein (1/%lld)"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Small (1/%lld)"
           }
         },
         "pl" : {
@@ -60094,16 +60127,16 @@
             "value" : "Snappy"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Snappy"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Vlug"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Snappy"
           }
         },
         "pl" : {
@@ -60285,16 +60318,16 @@
             "value" : "날짜별로 창 미리보기 정렬"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Sort Window Previews by Date"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sorteer venster voorvertoningen op datum"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Sort Window Previews by Date"
           }
         },
         "pl" : {
@@ -60475,16 +60508,16 @@
             "value" : "날짜별로 창 미리보기 정렬(여러 개일 경우)"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Sort Window Previews by Date (if multiple)"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sorteer venster voorvertoningen op datum (indien veelvoud)"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Sort Window Previews by Date (if multiple)"
           }
         },
         "pl" : {
@@ -60665,16 +60698,16 @@
             "value" : "표준"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Standard"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Standaard"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Standard"
           }
         },
         "pl" : {
@@ -60856,16 +60889,16 @@
             "value" : "키 바인드 기록 시작"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Start recording keybind"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Start opname toetscombinatie"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Start recording keybind"
           }
         },
         "pl" : {
@@ -61047,16 +61080,16 @@
             "value" : "키 입력 기록 시작"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Start Recording Keybind"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Start opname toetscombinatie"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Start Recording Keybind"
           }
         },
         "pl" : {
@@ -61238,16 +61271,16 @@
             "value" : "녹화 시작 키 설정"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Start recording trigger key"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Start opname trigger toets"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Start recording trigger key"
           }
         },
         "pl" : {
@@ -61430,16 +61463,16 @@
             "value" : "아원자"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Subatomic"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sub atomisch"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Subatomic"
           }
         },
         "pl" : {
@@ -61620,16 +61653,16 @@
             "value" : "DockDoor를 더욱 발전시키기 위한 새로운 기능을 제안해 주세요."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Suggest new features to make DockDoor even better."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Stel nieuwe functies voor om DockDoor nog beter te maken."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Suggest new features to make DockDoor even better."
           }
         },
         "pl" : {
@@ -61811,16 +61844,16 @@
             "value" : "지원"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Support"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ondersteuning"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Support"
           }
         },
         "pl" : {
@@ -62001,16 +62034,16 @@
             "value" : "지원 및 기여"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Support & Contributions"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ondersteuning & bijdragen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Support & Contributions"
           }
         },
         "pl" : {
@@ -62191,16 +62224,16 @@
             "value" : "소액 기부로 개발 지원"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Support development with a small donation"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ondersteun ontwikkeling met een kleine donatie"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Support development with a small donation"
           }
         },
         "pl" : {
@@ -62381,16 +62414,16 @@
             "value" : "DockDoor 지원"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Support DockDoor"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Steun DockDoor"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Support DockDoor"
           }
         },
         "pl" : {
@@ -62571,16 +62604,16 @@
             "value" : "지원 설정"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Support settings"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Instellingen voor ondersteuning"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Support settings"
           }
         },
         "pl" : {
@@ -62761,16 +62794,16 @@
             "value" : "모든 기여자에게 감사합니다 ❤️"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Thank you to all contributors ❤️"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Dank aan alle bijdragers ❤️"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Thank you to all contributors ❤️"
           }
         },
         "pl" : {
@@ -62951,16 +62984,16 @@
             "value" : "DockDoor를 응원해 주셔서 감사합니다! 💖"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Thanks for supporting DockDoor! 💖"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bedankt voor het steunen van DockDoor! 💖"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Thanks for supporting DockDoor! 💖"
           }
         },
         "pl" : {
@@ -63141,16 +63174,16 @@
             "value" : "권한 변경 사항은 재시작 후 적용됩니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The changes to permissions will take effect after restarting."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "De gewijzigde machtigingen worden van kracht nadat u opnieuw bent opgestart."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "The changes to permissions will take effect after restarting."
           }
         },
         "pl" : {
@@ -63332,16 +63365,16 @@
             "value" : "신호등 버튼과 창 제목에 대해 선택한 위치가 겹치게 됩니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The selected positions for Traffic Light Buttons and Window Title will overlap."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "De geselecteerde posities voor verkeerslichtknoppen en venstertitels zullen elkaar overlappen."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "The selected positions for Traffic Light Buttons and Window Title will overlap."
           }
         },
         "pl" : {
@@ -63522,16 +63555,16 @@
             "value" : "창 전환기(보통 Alt/Cmd-Tab)를 사용하면 키보드 단축키로 열려 있는 앱 창 사이를 빠르게 전환할 수 있습니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The Window Switcher (often Alt/Cmd-Tab) lets you quickly cycle between open app windows with a keyboard shortcut."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Met de venster wisselaar (vaak Alt/Cmd-Tab) kunt u met een sneltoets schakelen tussen geopende app-vensters."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "The Window Switcher (often Alt/Cmd-Tab) lets you quickly cycle between open app windows with a keyboard shortcut."
           }
         },
         "pl" : {
@@ -63713,16 +63746,16 @@
             "value" : "이 디스플레이는 현재 연결이 끊어졌습니다. 선택한 디스플레이가 다시 연결될 때까지 창 전환기가 기본 디스플레이에 나타납니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This display is currently disconnected. The window switcher will appear on the main display until the selected display is reconnected."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Dit scherm is momenteel niet verbonden. De venster schakelaar blijft op het hoofdscherm zichtbaar totdat het geselecteerde scherm weer is verbonden."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "This display is currently disconnected. The window switcher will appear on the main display until the selected display is reconnected."
           }
         },
         "pl" : {
@@ -63903,13 +63936,13 @@
             "value" : "이 설정은 위에서 '창 미리보기가 있는 컨트롤 포함'이 활성화된 경우에만 적용됩니다."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "This setting only applies when \"Embed controls with window previews\" is enabled above."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "This setting only applies when \"Embed controls with window previews\" is enabled above."
@@ -63988,6 +64021,9 @@
           }
         }
       }
+    },
+    "This will add the app to the blacklist using its bundle identifier for reliable matching." : {
+
     },
     "Tiny (1/%lld)" : {
       "localizations" : {
@@ -64093,16 +64129,16 @@
             "value" : "작은(1/%lld)"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Tiny (1/%lld)"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Klein (1/%lld)"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Tiny (1/%lld)"
           }
         },
         "pl" : {
@@ -64283,13 +64319,13 @@
             "value" : "오늘"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Today"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Today"
@@ -64473,16 +64509,16 @@
             "value" : "토글"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Toggle"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Omschakelen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Toggle"
           }
         },
         "pl" : {
@@ -64663,16 +64699,16 @@
             "value" : "전체화면 켜기/끄기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Toggle Full Screen"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Volledig scherm in-/uitschakelen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Toggle Full Screen"
           }
         },
         "pl" : {
@@ -64854,16 +64890,16 @@
             "value" : "왼쪽 상단"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Top Left"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Linksboven"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Top Left"
           }
         },
         "pl" : {
@@ -65045,16 +65081,16 @@
             "value" : "오른쪽 상단"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Top Right"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Rechtsboven"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Top Right"
           }
         },
         "pl" : {
@@ -65236,16 +65272,16 @@
             "value" : "신호등 버튼"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Traffic Light Buttons"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Verkeerslichtknoppen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Traffic Light Buttons"
           }
         },
         "pl" : {
@@ -65426,16 +65462,16 @@
             "value" : "미리보기의 신호등 버튼"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Traffic Light Buttons in Previews"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Verkeerslichtknoppen in previews"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Traffic Light Buttons in Previews"
           }
         },
         "pl" : {
@@ -65617,16 +65653,16 @@
             "value" : "신호등 버튼 위치"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Traffic Light Buttons Position"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Positie van verkeerslichtknoppen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Traffic Light Buttons Position"
           }
         },
         "pl" : {
@@ -65807,16 +65843,16 @@
             "value" : "신호등 버튼 가시성"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Traffic Light Buttons Visibility"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Zichtbaarheid van verkeerslichtknoppen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Traffic Light Buttons Visibility"
           }
         },
         "pl" : {
@@ -65997,16 +66033,16 @@
             "value" : "트리거 키"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Trigger Key"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Trigger toets"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Trigger Key"
           }
         },
         "pl" : {
@@ -66188,16 +66224,16 @@
             "value" : "독 미리보기에서 창 위로 마우스를 가져가면 동작을 트리거합니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Triggers an action when hovering over a window in a dock preview"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Activeert een actie wanneer u met de muis over een venster in een dock voorbeeld beweegt"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Triggers an action when hovering over a window in a dock preview"
           }
         },
         "pl" : {
@@ -66379,16 +66415,16 @@
             "value" : "도크 미리보기에서 창을 드래그하는 동안 창을 흔들면 동작을 트리거합니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Triggers an action when shaking a window while it is being dragged from a dock preview"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Activeert een actie wanneer een venster wordt geschud terwijl het vanuit een dock voorbeeld wordt gesleept"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Triggers an action when shaking a window while it is being dragged from a dock preview"
           }
         },
         "pl" : {
@@ -66569,16 +66605,16 @@
             "value" : "최소화 해제"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Un-minimize"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Minimaliseren ongedaan maken"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Un-minimize"
           }
         },
         "pl" : {
@@ -66759,16 +66795,16 @@
             "value" : "알 수 없는 디스플레이"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unknown Display"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Onbekend display"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Unknown Display"
           }
         },
         "pl" : {
@@ -66949,13 +66985,13 @@
             "value" : "고정해제"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Unpin"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Unpin"
@@ -67139,16 +67175,16 @@
             "value" : "최신 버전입니다"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Up to date"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Actueel"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Up to date"
           }
         },
         "pl" : {
@@ -67329,16 +67365,16 @@
             "value" : "최신 버전입니다"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Up to Date"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Up-to-date"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Up to Date"
           }
         },
         "pl" : {
@@ -67519,16 +67555,16 @@
             "value" : "업데이트가 중단되었습니다: %@"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Update aborted: %@"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Update afgebroken: %@"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Update aborted: %@"
           }
         },
         "pl" : {
@@ -67709,16 +67745,16 @@
             "value" : "업데이트 사용 가능"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Update available"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Update beschikbaar"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Update available"
           }
         },
         "pl" : {
@@ -67900,16 +67936,16 @@
             "value" : "업데이트 설정"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Update settings"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Instellingen bijwerken"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Update settings"
           }
         },
         "pl" : {
@@ -68090,16 +68126,16 @@
             "value" : "v%@ 업데이트 가능"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Update v%@ available"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Update v%@ beschikbaar"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Update v%@ available"
           }
         },
         "pl" : {
@@ -68280,16 +68316,16 @@
             "value" : "업데이터가 구성되지 않았습니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Updater not configured."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Updater niet geconfigureerd."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Updater not configured."
           }
         },
         "pl" : {
@@ -68471,15 +68507,15 @@
             "value" : "업데이트"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Updates"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Updates"
           }
         },
@@ -68662,16 +68698,16 @@
             "value" : "클래식 창 명령 사용"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Use classic window ordering"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Gebruik klassieke venster volgorde"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Use classic window ordering"
           }
         },
         "pl" : {
@@ -68853,16 +68889,16 @@
             "value" : "기본 MacOS 키 바인드 ⌘ + ⇥ 사용"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Use default MacOS keybind ⌘ + ⇥"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Gebruik standaard MacOS toetsencombinatie ⌘ + ⇥"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Use default MacOS keybind ⌘ + ⇥"
           }
         },
         "pl" : {
@@ -69043,16 +69079,16 @@
             "value" : "단색 색상 사용"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Use Monochrome Colors"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Gebruik monochrome kleuren"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Use Monochrome Colors"
           }
         },
         "pl" : {
@@ -69233,16 +69269,16 @@
             "value" : "강조 표시를 위해 시스템 강조 색상 사용"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Use System Accent Color for Highlight"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Gebruik systeem accentkleur voor markering"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Use System Accent Color for Highlight"
           }
         },
         "pl" : {
@@ -69424,16 +69460,16 @@
             "value" : "균일한 이미지 미리보기 반경 사용"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Use Uniform Image Preview Radius"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Uniforme afbeelding voorvertoning-radius gebruiken"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Use Uniform Image Preview Radius"
           }
         },
         "pl" : {
@@ -69615,16 +69651,16 @@
             "value" : "Windows 스타일 창 순서 사용"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Use Windows-style window ordering"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Gebruik venstervolgorde in Windows-stijl"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Use Windows-style window ordering"
           }
         },
         "pl" : {
@@ -69805,16 +69841,16 @@
             "value" : "스위처에서 Windows 스타일 창 순서 사용"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Use Windows-style window ordering in Switcher"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Gebruik venstervolgorde in Windows-stijl in Switcher"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Use Windows-style window ordering in Switcher"
           }
         },
         "pl" : {
@@ -69996,16 +70032,16 @@
             "value" : "창 전환기에서 Windows 스타일 창 순서 사용"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Use Windows-style window ordering in the window switcher"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Gebruik Windows-stijl venstervolgorde in de vensterwisselaar"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Use Windows-style window ordering in the window switcher"
           }
         },
         "pl" : {
@@ -70187,16 +70223,16 @@
             "value" : "버전 %@"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Version %@"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Versie %@"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Version %@"
           }
         },
         "pl" : {
@@ -70377,16 +70413,16 @@
             "value" : "직접 보고 싶으신가요? 소스 코드 살펴보기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Want to see for yourself? Review our source code"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Zelf zien? Bekijk onze broncode"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Want to see for yourself? Review our source code"
           }
         },
         "pl" : {
@@ -70568,16 +70604,16 @@
             "value" : "해당 언어로 앱을 보고 싶으신가요?"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Want to see the app in your language?"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Wilt u de app in uw taal bekijken?"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Want to see the app in your language?"
           }
         },
         "pl" : {
@@ -70759,16 +70795,16 @@
             "value" : "개발 후원하기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Want to support development?"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Wilt u ontwikkeling steunen?"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Want to support development?"
           }
         },
         "pl" : {
@@ -70949,16 +70985,16 @@
             "value" : "DockDoor에 오신 것을 환영합니다!"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Welcome to DockDoor!"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Welkom bij DockDoor!"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Welcome to DockDoor!"
           }
         },
         "pl" : {
@@ -71141,16 +71177,16 @@
             "value" : "이게 뭐야? 개미를 위한 창문인가?"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "What is this? A window for ANTS?"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Wat is dit? Een raam voor MIEREN?"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "What is this? A window for ANTS?"
           }
         },
         "pl" : {
@@ -71331,13 +71367,13 @@
             "value" : "임베디드 모드가 활성화된 경우, 모든 창이 최소화/숨겨져 있거나 창이 없는 경우 임베디드 컨트롤 대신 큰 컨트롤을 표시합니다."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "When embedded mode is enabled, show big controls instead of embedded ones if all windows are minimized/hidden or there are no windows."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "When embedded mode is enabled, show big controls instead of embedded ones if all windows are minimized/hidden or there are no windows."
@@ -71521,16 +71557,16 @@
             "value" : "활성화하면 모든 미리보기 이미지가 둥근 직사각형으로 잘립니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "When enabled, all preview images will be cropped to a rounded rectangle."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Wanneer deze optie is ingeschakeld, worden alle voorbeeldafbeeldingen bijgesneden tot een afgeronde rechthoek."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "When enabled, all preview images will be cropped to a rounded rectangle."
           }
         },
         "pl" : {
@@ -71712,16 +71748,16 @@
             "value" : "이 기능을 활성화하면 앱의 Dock 아이콘을 클릭하면 Windows 작업 표시줄 동작과 유사하게 해당 애플리케이션의 모든 창이 최소화됩니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "When enabled, clicking an app's Dock icon will minimize all windows of that application, similar to Windows taskbar behavior"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Als deze optie is ingeschakeld, worden alle vensters van die toepassing geminimaliseerd als u op het Dock pictogram van een app klikt, vergelijkbaar met het gedrag van de Windows taakbalk"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "When enabled, clicking an app's Dock icon will minimize all windows of that application, similar to Windows taskbar behavior"
           }
         },
         "pl" : {
@@ -71902,16 +71938,16 @@
             "value" : "활성화하면 현재 선택되어 있는 창을 제외한 모든 창을 어둡게 합니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "When enabled, dims all windows except those currently under selected."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Wanneer deze optie is ingeschakeld, worden alle vensters gedimd, behalve de vensters die op dat moment zijn geselecteerd."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "When enabled, dims all windows except those currently under selected."
           }
         },
         "pl" : {
@@ -72093,16 +72129,16 @@
             "value" : "활성화하면 현재 창 대신 마지막으로 활성화된 창을 먼저 표시합니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "When enabled, shows the last active window first instead of the current window"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Wanneer ingeschakeld, wordt het laatst actieve venster eerst weergegeven in plaats van het huidige venster"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "When enabled, shows the last active window first instead of the current window"
           }
         },
         "pl" : {
@@ -72284,16 +72320,16 @@
             "value" : "미리보기 위로 마우스를 가져가면"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "When hovering over the preview"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Wanneer u met de muis over de voorvertoning beweegt"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "When hovering over the preview"
           }
         },
         "pl" : {
@@ -72476,16 +72512,16 @@
             "value" : "도크 타일 미리 보기를 표시할 때"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "When Showing Dock Tile Previews"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bij het tonen van Dock tegel previews"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "When Showing Dock Tile Previews"
           }
         },
         "pl" : {
@@ -72668,16 +72704,16 @@
             "value" : "윈도우 스위쳐를 사용하는 경우"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "When Using Window Switcher"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bij het gebruik van de vensterschakelaar"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "When Using Window Switcher"
           }
         },
         "pl" : {
@@ -72858,16 +72894,16 @@
             "value" : "아래 버튼을 클릭하면 DockDoor가 다시 시작되고 메뉴 표시줄로 이동하여 백그라운드에서 실행됩니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "When you click the button below, DockDoor will restart and move to the menu bar to run in the background."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Wanneer u op de onderstaande knop klikt, wordt DockDoor opnieuw opgestart en wordt de menubalk op de achtergrond uitgevoerd."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "When you click the button below, DockDoor will restart and move to the menu bar to run in the background."
           }
         },
         "pl" : {
@@ -73049,16 +73085,16 @@
             "value" : "권한이 필요한 이유"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Why we need permissions"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Waarom we toestemming nodig hebben"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Why we need permissions"
           }
         },
         "pl" : {
@@ -73240,16 +73276,16 @@
             "value" : "윈도우 버퍼"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Window Buffer"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Scherm Buffer"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Window Buffer"
           }
         },
         "pl" : {
@@ -73430,16 +73466,16 @@
             "value" : "독의 창 버퍼(픽셀)"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Window Buffer from Dock (pixels)"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Venster buffer van Dock (pixels)"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Window Buffer from Dock (pixels)"
           }
         },
         "pl" : {
@@ -73621,16 +73657,16 @@
             "value" : "윈도우 캐시 수명"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Window Cache Lifespan"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Levensduur venster cache"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Window Cache Lifespan"
           }
         },
         "pl" : {
@@ -73811,16 +73847,16 @@
             "value" : "창 이미지 캐시 수명"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Window Image Cache Lifespan"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Levensduur van de cache van de venster afbeelding"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Window Image Cache Lifespan"
           }
         },
         "pl" : {
@@ -74001,16 +74037,16 @@
             "value" : "창 이미지 해상도 스케일(1=최고)"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Window Image Resolution Scale (1=Best)"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Resolutieschaal van venster afbeelding (1=beste)"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Window Image Resolution Scale (1=Best)"
           }
         },
         "pl" : {
@@ -74192,16 +74228,16 @@
             "value" : "창 이미지 해상도 스케일(높을수록 해상도가 낮음)"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Window Image Resolution Scale (higher means lower resolution)"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Resolutieschaal van venster afbeelding (hoger betekent lagere resolutie)"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Window Image Resolution Scale (higher means lower resolution)"
           }
         },
         "pl" : {
@@ -74383,16 +74419,16 @@
             "value" : "창 미리보기 레이아웃"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Window Preview Layout"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Voorvertoning venster lay-out"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Window Preview Layout"
           }
         },
         "pl" : {
@@ -74574,16 +74610,16 @@
             "value" : "창 미리보기 레이아웃 제한"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Window Preview Layout Limits"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Voorvertoning venster lay-out limieten"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Window Preview Layout Limits"
           }
         },
         "pl" : {
@@ -74765,16 +74801,16 @@
             "value" : "창 미리보기 크기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Window Preview Size"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Voorvertoning venster grootte"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Window Preview Size"
           }
         },
         "pl" : {
@@ -74955,16 +74991,16 @@
             "value" : "창 선택 배경색"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Window Selection Background Color"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Achtergrondkleur van venster selectie"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Window Selection Background Color"
           }
         },
         "pl" : {
@@ -75145,16 +75181,16 @@
             "value" : "창 선택 배경 불투명도"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Window Selection Background Opacity"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Achtergrond dekking van venster selectie"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Window Selection Background Opacity"
           }
         },
         "pl" : {
@@ -75336,16 +75372,16 @@
             "value" : "창 크기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Window Size"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Scherm Formaat"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Window Size"
           }
         },
         "pl" : {
@@ -75527,16 +75563,16 @@
             "value" : "윈도우 스위쳐"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Window Switcher"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Scherm Wisselaar"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Window Switcher"
           }
         },
         "pl" : {
@@ -75717,16 +75753,16 @@
             "value" : "창 전환기 사용자 지정"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Window Switcher Customization"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Aanpassing van venster schakelaar"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Window Switcher Customization"
           }
         },
         "pl" : {
@@ -75908,16 +75944,16 @@
             "value" : "창 전환기 전용"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Window Switcher only"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Alleen Scherm Wisselaar"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Window Switcher only"
           }
         },
         "pl" : {
@@ -76098,16 +76134,16 @@
             "value" : "창 전환기 배치"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Window Switcher Placement"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Plaatsing van de venster schakelaar"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Window Switcher Placement"
           }
         },
         "pl" : {
@@ -76288,16 +76324,16 @@
             "value" : "창 전환기 설정"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Window Switcher Settings"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Scherm wisselaar instellingen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Window Switcher Settings"
           }
         },
         "pl" : {
@@ -76479,16 +76515,16 @@
             "value" : "창 제목 필터"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Window title filters"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Venstertitel filters"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Window title filters"
           }
         },
         "pl" : {
@@ -76669,16 +76705,16 @@
             "value" : "창 제목 필터"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Window Title Filters"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Venster titel filters"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Window Title Filters"
           }
         },
         "pl" : {
@@ -76859,16 +76895,16 @@
             "value" : "창 제목 위치"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Window Title Position"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Schermnaam Positie"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Window Title Position"
           }
         },
         "pl" : {
@@ -77049,16 +77085,16 @@
             "value" : "창 제목 가시성"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Window Title Visibility"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Schermnaam Zichtbaarheid"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Window Title Visibility"
           }
         },
         "pl" : {
@@ -77239,16 +77275,16 @@
             "value" : "미리보기의 창 제목"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Window Titles in Previews"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Venstertitels in Previews"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Window Titles in Previews"
           }
         },
         "pl" : {
@@ -77430,16 +77466,16 @@
             "value" : "창 전환 설정"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Windows switching settings"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Scherm wisselaar instellingen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Windows switching settings"
           }
         },
         "pl" : {
@@ -77621,16 +77657,16 @@
             "value" : "DockDoor의 작동을 위해 손쉬운 사용 권한을 허용해야 합니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "You need to give DockDoor access to the accessibility API in order for it to function."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "U moet DockDoor toegang geven tot de toegankelijkheids-API om deze te laten functioneren."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You need to give DockDoor access to the accessibility API in order for it to function."
           }
         },
         "pl" : {
@@ -77811,16 +77847,16 @@
             "value" : "앱 버전: %@"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your app is on version %@"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Je hebt app versie %@"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Your app is on version %@"
           }
         },
         "pl" : {
@@ -78001,16 +78037,16 @@
             "value" : "단축키가 설정됩니다(예: ⌘ + Tab)."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your shortcut will be set (e.g. ⌘ + Tab)"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Uw sneltoets wordt ingesteld (bijv. ⌘ + Tab)"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Your shortcut will be set (e.g. ⌘ + Tab)"
           }
         },
         "pl" : {
@@ -78191,16 +78227,16 @@
             "value" : "신호등이 자동으로 비활성화되도록 설정됩니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your traffic lights will be set to disabled automatically."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Uw verkeerslichten worden automatisch uitgeschakeld."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Your traffic lights will be set to disabled automatically."
           }
         },
         "pl" : {
@@ -78381,15 +78417,15 @@
             "value" : "Z"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Z"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Z"
           }
         },

--- a/DockDoor/Utilities/KeybindHelper.swift
+++ b/DockDoor/Utilities/KeybindHelper.swift
@@ -269,6 +269,11 @@ class KeybindHelper {
     }
 
     private func determineActionForKeyDown(event: CGEvent) -> (shouldConsume: Bool, actionTask: (() async -> Void)?) {
+        // Check if we should ignore keybinds for fullscreen blacklisted apps
+        if WindowUtil.shouldIgnoreKeybindForFrontmostApp() {
+            return (false, nil)
+        }
+
         let keyCode = event.getIntegerValueField(.keyboardEventKeycode)
         let flags = event.flags
         let keyBoardShortcutSaved: UserKeyBind = Defaults[.UserKeybind]

--- a/DockDoor/consts.swift
+++ b/DockDoor/consts.swift
@@ -78,6 +78,11 @@ extension Defaults.Keys {
     static let dimInSwitcherUntilSelected = Key<Bool>("dimInSwitcherUntilSelected", default: false)
     static let pinnedScreenIdentifier = Key<String>("pinnedScreenIdentifier", default: NSScreen.main?.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? String ?? "")
 
+    // MARK: - Window Switcher Filters
+
+    static let limitSwitcherToFrontmostApp = Key<Bool>("limitSwitcherToFrontmostApp", default: false)
+    static let fullscreenAppBlacklist = Key<[String]>("fullscreenAppBlacklist", default: [])
+
     // MARK: - Filters
 
     static let appNameFilters = Key<[String]>("appNameFilters", default: [])


### PR DESCRIPTION
- Add option to limit Window Switcher to active app only
- Add fullscreen app blacklist to prevent key combinations
- Improve UI with file picker for app selection instead of manual text entry
- Use NSWorkspace.shared.frontmostApplication for reliable app detection
- Support both app names and bundle identifiers for blacklist matching
- Add comprehensive settings UI with add/remove functionality

Closes #615, Closes #562