### PR TITLE
Respect inactivity timer when hovering empty apps with lateral movement off

### DIFF
--- a/DockDoor/Views/Hover Window/WindowPreview Supporting/WindowDismissalContainer.swift
+++ b/DockDoor/Views/Hover Window/WindowPreview Supporting/WindowDismissalContainer.swift
@@ -86,6 +86,9 @@ class MouseTrackingNSView: NSView {
 
     private func checkIfMouseIsOverDockIcon() -> Bool {
         guard let activeDockObserver = DockObserver.activeInstance else { return false }
+        // If DockObserver requests inactivity-based dismissal (e.g., hovered an empty app with lateral movement off),
+        // treat the dock icon as not hovered so the inactivity timer can dismiss the window.
+        if activeDockObserver.requireInactivityDismissal { return false }
         let currentAppReturnType = activeDockObserver.getDockItemAppStatusUnderMouse()
         return currentAppReturnType.status != .notFound
     }
@@ -144,6 +147,7 @@ class MouseTrackingNSView: NSView {
             guard self != nil else { return }
             SharedPreviewWindowCoordinator.activeInstance?.hideWindow()
             if !preventLastAppClear { DockObserver.activeInstance?.lastAppUnderMouse = nil }
+            DockObserver.activeInstance?.resetTrackingAfterContainerDismissal()
         }
     }
 }


### PR DESCRIPTION
Added behavior:

- When “Keep previews…” is turned off, hovering a Dock icon for an app with no active windows no longer triggers an immediate hideWindow(). Instead, DockObserver sets the requireInactivityDismissal flag and hands off to WindowDismissalContainer, where the “Preview Window Inactivity Timer” fires and the preview fades out.

- After the fade completes, WindowDismissalContainer calls hideWindow(), and then DockObserver.resetTrackingAfterContainerDismissal(), preserving the required reset of tracking (lastAppUnderMouse, etc.).

- If the user re-enters the preview area, the fade is correctly canceled (as before).