### PR TITLE
Added option for keeping the traficlights when tabs are hidden and yo…

### DIFF
--- a/DockDoor.xcodeproj/project.pbxproj
+++ b/DockDoor.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		BB21067B2E8351A5002F87D6 /* KeyboardLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB21067A2E8351A5002F87D6 /* KeyboardLabel.swift */; };
 		0531F8D22C3CC04600327808 /* AppearanceSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0531F8D12C3CC04600327808 /* AppearanceSettingsView.swift */; };
 		0596C2C32C3E060D00DCABEF /* PrivateApis.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0596C2C22C3E060D00DCABEF /* PrivateApis.swift */; };
 		05C0C7182C60629C000ADAC6 /* AXUIElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05C0C7172C60629C000ADAC6 /* AXUIElement.swift */; };
@@ -149,7 +148,6 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		BB21067A2E8351A5002F87D6 /* KeyboardLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardLabel.swift; sourceTree = "<group>"; };
 		0531F8D12C3CC04600327808 /* AppearanceSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppearanceSettingsView.swift; sourceTree = "<group>"; };
 		0596C2C22C3E060D00DCABEF /* PrivateApis.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivateApis.swift; sourceTree = "<group>"; };
 		05C0C7172C60629C000ADAC6 /* AXUIElement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AXUIElement.swift; sourceTree = "<group>"; };
@@ -1071,7 +1069,7 @@
 				CURRENT_PROJECT_VERSION = 1.18.3;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"DockDoor/Preview Content\"";
-				DEVELOPMENT_TEAM = 2Q775S63Q3;
+				DEVELOPMENT_TEAM = 5U8JD2UDWK;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				ENABLE_RESOURCE_ACCESS_AUDIO_INPUT = NO;
@@ -1118,7 +1116,7 @@
 				CURRENT_PROJECT_VERSION = 1.18.3;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"DockDoor/Preview Content\"";
-				DEVELOPMENT_TEAM = 2Q775S63Q3;
+				DEVELOPMENT_TEAM = 5U8JD2UDWK;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				ENABLE_RESOURCE_ACCESS_AUDIO_INPUT = NO;

--- a/DockDoor/Localizable.xcstrings
+++ b/DockDoor/Localizable.xcstrings
@@ -105,13 +105,13 @@
             "value" : ""
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : ""
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : ""
@@ -295,13 +295,13 @@
             "value" : " "
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : " "
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : " "
@@ -486,16 +486,16 @@
             "value" : " - 비활성"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : " - Inactive"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : " - Inactief"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : " - Inactive"
           }
         },
         "pl" : {
@@ -676,13 +676,13 @@
             "value" : "-%@"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "-%@"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "-%@"
@@ -866,13 +866,13 @@
             "value" : "%@"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "%@"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "%@"
@@ -1062,13 +1062,13 @@
             "value" : "%1$@ — %2$@"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "%1$@ — %2$@"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "%1$@ — %2$@"
@@ -1253,16 +1253,16 @@
             "value" : "• 독(Dock)에서의 향상된 시각 정보를 위해 허용합니다"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "• Allows for enhanced visual information in the dock"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Zorgt voor verbeterde visuele informatie in het dock"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "• Allows for enhanced visual information in the dock"
           }
         },
         "pl" : {
@@ -1444,16 +1444,16 @@
             "value" : "• 독(Dock)에 있는 항목과의 실시간 상호작용을 가능하게 합니다"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "• Enables real-time interaction with dock items"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Maakt realtime interactie met dock items mogelijk"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "• Enables real-time interaction with dock items"
           }
         },
         "pl" : {
@@ -1635,16 +1635,16 @@
             "value" : "• 이미지와 창의 미리보기를 생성합니다"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "• To capture previews of images and windows"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Voorvertoningen van afbeeldingen en vensters vastleggen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "• To capture previews of images and windows"
           }
         },
         "pl" : {
@@ -1826,16 +1826,16 @@
             "value" : "• 독에 마우스를 올렸는지 감지합니다"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "• To detect when you hover over the dock"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Om te detecteren wanneer u boven het dock zweeft"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "• To detect when you hover over the dock"
           }
         },
         "pl" : {
@@ -2017,16 +2017,16 @@
             "value" : "• 하단의 도크 위로 마우스를 가져가면 창이 왼쪽에서 오른쪽으로 일렬로 흐릅니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "• When hovering over the Dock at the bottom, windows flow in rows from left to right"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Wanneer u met de muis over het Dock onderaan beweegt, vloeien de vensters in rijen van links naar rechts"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "• When hovering over the Dock at the bottom, windows flow in rows from left to right"
           }
         },
         "pl" : {
@@ -2208,16 +2208,16 @@
             "value" : "• 측면의 도크 위로 마우스를 가져가면 창이 위에서 아래로 기둥 모양으로 흐릅니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "• When hovering over the Dock on the sides, windows flow in columns from top to bottom"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Wanneer u met de muis over het Dock aan de zijkanten zweeft, vloeien de vensters in kolommen van boven naar beneden"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "• When hovering over the Dock on the sides, windows flow in columns from top to bottom"
           }
         },
         "pl" : {
@@ -2399,16 +2399,16 @@
             "value" : "• 창 전환기를 사용할 때 창은 항상 왼쪽에서 오른쪽으로 일렬로 흐릅니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "• When using the Window Switcher, windows always flow in rows from left to right"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bij gebruik van de Window Switcher lopen de vensters altijd in rijen van links naar rechts"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "• When using the Window Switcher, windows always flow in rows from left to right"
           }
         },
         "pl" : {
@@ -2589,15 +2589,15 @@
             "value" : "+"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "+"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "+"
           }
         },
@@ -2779,13 +2779,13 @@
             "value" : "+%lld more"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "+%lld more"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "+%lld more"
@@ -2969,13 +2969,13 @@
             "value" : "×"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "×"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "×"
@@ -3160,15 +3160,15 @@
             "value" : "1."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "1."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "1."
           }
         },
@@ -3351,16 +3351,16 @@
             "value" : ""
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "1. Select \"Command (⌘)\" as the initialization key."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "1. Selecteer \"Command (⌘)\" als initialisatie toets."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "1. Select \"Command (⌘)\" as the initialization key."
           }
         },
         "pl" : {
@@ -3542,15 +3542,15 @@
             "value" : "1/%lldx"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "1/%lldx"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "1/%lldx"
           }
         },
@@ -3733,15 +3733,15 @@
             "value" : "2."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "2."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "2."
           }
         },
@@ -3924,16 +3924,16 @@
             "value" : "2. \"트리거 키 녹화 시작\"을 클릭합니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "2. Click \"Start Recording Trigger Key\"."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "2. Klik op \"Start opname sneltoets\"."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "2. Click \"Start Recording Trigger Key\"."
           }
         },
         "pl" : {
@@ -4115,15 +4115,15 @@
             "value" : "3."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "3."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "3."
           }
         },
@@ -4306,16 +4306,16 @@
             "value" : "3. Tab 키만 누릅니다(Command+Tab이 아닌)."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "3. Press ONLY the Tab key (not Command+Tab)."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "3. Druk ALLEEN op de TAB toets (niet Command+Tab)."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "3. Press ONLY the Tab key (not Command+Tab)."
           }
         },
         "pl" : {
@@ -4497,15 +4497,15 @@
             "value" : "4."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "4."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "4."
           }
         },
@@ -4688,16 +4688,16 @@
             "value" : ""
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "4. Your keybind will be set to Command+Tab."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "4. De sneltoets wordt ingesteld op Command+Tab."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "4. Your keybind will be set to Command+Tab."
           }
         },
         "pl" : {
@@ -4878,16 +4878,16 @@
             "value" : "손쉬운 사용"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Accessibility"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Toegankelijkheid"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Accessibility"
           }
         },
         "pl" : {
@@ -5069,16 +5069,16 @@
             "value" : "손쉬운 사용 권한"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Accessibility Permissions"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Toegankelijkheid rechten"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Accessibility Permissions"
           }
         },
         "pl" : {
@@ -5260,16 +5260,16 @@
             "value" : "손쉬운 사용:"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Accessibility:"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Toegankelijkheid:"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Accessibility:"
           }
         },
         "pl" : {
@@ -5450,13 +5450,13 @@
             "value" : "Acknowledgments"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Acknowledgments"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Acknowledgments"
@@ -5640,16 +5640,16 @@
             "value" : "추가"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Add"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Toevoegen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Add"
           }
         },
         "pl" : {
@@ -5831,16 +5831,16 @@
             "value" : "응용 프로그램을 검색할 경로를 추가하세요"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Add additional directories to scan for applications"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Voeg extra mappen toe om te scannen voor applicaties"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Add additional directories to scan for applications"
           }
         },
         "pl" : {
@@ -6021,16 +6021,16 @@
             "value" : "애플리케이션을 검색할 디렉터리를 추가합니다. 이 기능은 앱을 표준 위치 외부에 보관하는 경우에 유용합니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Add additional directories to scan for applications. This is useful if you keep apps outside standard locations."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Voeg extra mappen toe om naar applicaties te scannen. Dit is handig als u apps buiten de standaardlocaties bewaart."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Add additional directories to scan for applications. This is useful if you keep apps outside standard locations."
           }
         },
         "pl" : {
@@ -6211,13 +6211,13 @@
             "value" : "Add App"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Add App"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Add App"
@@ -6401,13 +6401,13 @@
             "value" : "Add App to Blacklist"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Add App to Blacklist"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Add App to Blacklist"
@@ -6591,16 +6591,16 @@
             "value" : "경로 추가"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Add Directory"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Map toevoegen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Add Directory"
           }
         },
         "pl" : {
@@ -6781,16 +6781,16 @@
             "value" : "필터 추가"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Add Filter"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Filter toevoegen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Add Filter"
           }
         },
         "pl" : {
@@ -6972,16 +6972,16 @@
             "value" : "프리뷰가 도크와 맞지 않으면 이것을 조정하세요"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Adjust this if the preview is misaligned with dock"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Pas aan als de uitlijning in de Dock niet goed is"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Adjust this if the preview is misaligned with dock"
           }
         },
         "pl" : {
@@ -7162,16 +7162,16 @@
             "value" : "상호 작용 중에 앱의 반응 속도와 동작을 조정합니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Adjusts how responsive the app feels and behaves during interaction."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Hiermee past u aan hoe responsief de app aanvoelt en zich gedraagt ​​tijdens interactie."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Adjusts how responsive the app feels and behaves during interaction."
           }
         },
         "pl" : {
@@ -7353,16 +7353,16 @@
             "value" : "에어로 쉐이크 액션"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Aero Shake Action"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Aero Schud Actie"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Aero Shake Action"
           }
         },
         "pl" : {
@@ -7543,16 +7543,16 @@
             "value" : "모든 버튼 제거"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "All buttons removed"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Alle knoppen verwijderd"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "All buttons removed"
           }
         },
         "pl" : {
@@ -7733,13 +7733,13 @@
             "value" : "All window previews show a gray background. When hovered, the background changes to the accent color or custom color below."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "All window previews show a gray background. When hovered, the background changes to the accent color or custom color below."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "All window previews show a gray background. When hovered, the background changes to the accent color or custom color below."
@@ -7923,13 +7923,13 @@
             "value" : "Allow dynamic image sizing"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Allow dynamic image sizing"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Allow dynamic image sizing"
@@ -8113,13 +8113,13 @@
             "value" : "오른쪽 클릭 메뉴를 통해 특별한 앱 컨트롤을 화면에 고정할 수 있습니다."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Allow special app controls to be pinned to the screen via right-click menu."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Allow special app controls to be pinned to the screen via right-click menu."
@@ -8303,13 +8303,13 @@
             "value" : "Allows window preview images to scale dynamically to reasonable dimensions, overriding fixed frame constraints."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Allows window preview images to scale dynamically to reasonable dimensions, overriding fixed frame constraints."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Allows window preview images to scale dynamically to reasonable dimensions, overriding fixed frame constraints."
@@ -8495,16 +8495,16 @@
             "value" : "항상"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Always"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Altijd"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Always"
           }
         },
         "pl" : {
@@ -8686,16 +8686,16 @@
             "value" : "항상 표시"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Always visible"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Altijd zichtbaar"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Always visible"
           }
         },
         "pl" : {
@@ -8877,16 +8877,16 @@
             "value" : "항상 보기; 불투명도 최대"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Always visible; Full opacity"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Altijd zichtbaar; volle doorzichtigheid"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Always visible; Full opacity"
           }
         },
         "pl" : {
@@ -9067,16 +9067,16 @@
             "value" : "금액"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "amount"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "aantal"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "amount"
           }
         },
         "pl" : {
@@ -9257,16 +9257,16 @@
             "value" : "애니메이션 속도"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Animation speed"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Animatie snelheid"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Animation speed"
           }
         },
         "pl" : {
@@ -9447,16 +9447,16 @@
             "value" : "앱명 스타일"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "App Name Style"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "App naam stijl"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "App Name Style"
           }
         },
         "pl" : {
@@ -9638,16 +9638,16 @@
             "value" : "모양"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Appearance"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Uiterlijk"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Appearance"
           }
         },
         "pl" : {
@@ -9828,16 +9828,16 @@
             "value" : "모양 설정"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Appearance settings"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Uiterlijk Instellingen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Appearance settings"
           }
         },
         "pl" : {
@@ -10018,16 +10018,16 @@
             "value" : "애플리케이션 기본 사항"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Application Basics"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Basisprincipes van de app"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Application Basics"
           }
         },
         "pl" : {
@@ -10209,16 +10209,16 @@
             "value" : "애플리케이션 필터"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Application filters"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Applicatie filter"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Application filters"
           }
         },
         "pl" : {
@@ -10399,16 +10399,16 @@
             "value" : "애플리케이션 필터"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Application Filters"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Applicatie filters"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Application Filters"
           }
         },
         "pl" : {
@@ -10589,13 +10589,13 @@
             "value" : "Apps in this list will not respond to window switcher shortcuts when in fullscreen mode."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Apps in this list will not respond to window switcher shortcuts when in fullscreen mode."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Apps in this list will not respond to window switcher shortcuts when in fullscreen mode."
@@ -10779,16 +10779,16 @@
             "value" : "계속 진행하겠습니까?"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Are you sure you want to proceed?"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Weet je zeker dat je wilt doorgaan?"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Are you sure you want to proceed?"
           }
         },
         "pl" : {
@@ -10970,16 +10970,16 @@
             "value" : "모든 설정을 기본값으로 초기화하시겠습니까?"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Are you sure you want to reset all settings to their default values?"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Weet je zeker dat je alle instellingen wil resetten naar de standaard waarden?"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Are you sure you want to reset all settings to their default values?"
           }
         },
         "pl" : {
@@ -11160,16 +11160,16 @@
             "value" : "모든 설정을 기본값으로 초기화하시겠습니까? 이렇게 하면 고급 설정도 초기화됩니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Are you sure you want to reset all settings to their default values? This will reset advanced settings as well."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Weet u zeker dat u alle instellingen wilt terugzetten naar de standaardwaarden? Hiermee worden ook de geavanceerde instellingen teruggezet."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Are you sure you want to reset all settings to their default values? This will reset advanced settings as well."
           }
         },
         "pl" : {
@@ -11350,16 +11350,16 @@
             "value" : "하단 - 왼쪽의 컨트롤, 오른쪽의 제목"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "At bottom - Controls on left, title on right"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Onderaan - Bedieningselementen links, titel rechts"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "At bottom - Controls on left, title on right"
           }
         },
         "pl" : {
@@ -11540,16 +11540,16 @@
             "value" : "하단 - 왼쪽은 제목, 오른쪽은 컨트롤"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "At bottom - Title on left, controls on right"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Onderaan - titel links, bediening rechts"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "At bottom - Title on left, controls on right"
           }
         },
         "pl" : {
@@ -11730,16 +11730,16 @@
             "value" : "상단 - 왼쪽의 컨트롤, 오른쪽의 제목"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "At top - Controls on left, title on right"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bovenaan - bediening links, titel rechts"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "At top - Controls on left, title on right"
           }
         },
         "pl" : {
@@ -11920,16 +11920,16 @@
             "value" : "상단 - 왼쪽의 제목, 오른쪽의 컨트롤"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "At top - Title on left, controls on right"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bovenaan - titel links, bediening rechts"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "At top - Title on left, controls on right"
           }
         },
         "pl" : {
@@ -12110,16 +12110,16 @@
             "value" : "자동 업데이트"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Automatic Updates"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Automatische Updates"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Automatic Updates"
           }
         },
         "pl" : {
@@ -12301,16 +12301,16 @@
             "value" : "자동으로 업데이트 확인"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Automatically check for updates"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Controleer automatisch voor updates"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Automatically check for updates"
           }
         },
         "pl" : {
@@ -12491,13 +12491,13 @@
             "value" : "Background Opacity"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Background Opacity"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Background Opacity"
@@ -12682,13 +12682,13 @@
             "value" : "Best quality (full resolution)"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Best quality (full resolution)"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Best quality (full resolution)"
@@ -12872,13 +12872,13 @@
             "value" : "Beta"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Beta"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Beta"
@@ -13062,16 +13062,16 @@
             "value" : "블러 정도"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Blur amount"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Blur hoeveelheid"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Blur amount"
           }
         },
         "pl" : {
@@ -13253,16 +13253,16 @@
             "value" : "왼쪽 하단"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Bottom Left"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Linksonderaan"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Bottom Left"
           }
         },
         "pl" : {
@@ -13444,16 +13444,16 @@
             "value" : "오른쪽 하단"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Bottom Right"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Rechtsonderaan"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Bottom Right"
           }
         },
         "pl" : {
@@ -13634,13 +13634,13 @@
             "value" : "Browse for .app file..."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Browse for .app file..."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Browse for .app file..."
@@ -13824,16 +13824,16 @@
             "value" : "커피 한 잔 사주세요"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Buy me a coffee"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Koop een kopje koffie voor me"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Buy me a coffee"
           }
         },
         "pl" : {
@@ -14015,16 +14015,16 @@
             "value" : "따듯한 커피 한 잔 감사합니다"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Buy me a coffee here, thank you!"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Koop hier een koffie voor me, bedankt!"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Buy me a coffee here, thank you!"
           }
         },
         "pl" : {
@@ -14205,13 +14205,13 @@
             "value" : "캘린더 액세스 필요"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Calendar Access Needed"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Calendar Access Needed"
@@ -14397,16 +14397,16 @@
             "value" : "이것도 볼 수 있나요?"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Can you even see this?"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Kan je dit zien?"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Can you even see this?"
           }
         },
         "pl" : {
@@ -14587,16 +14587,16 @@
             "value" : "취소"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Cancel"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Annuleer"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Cancel"
           }
         },
         "pl" : {
@@ -14777,16 +14777,16 @@
             "value" : "색상을 추가할 수 없습니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Cannot Add Color"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Kan kleur niet toevoegen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Cannot Add Color"
           }
         },
         "pl" : {
@@ -14967,16 +14967,16 @@
             "value" : "색상을 제거할 수 없습니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Cannot Remove Color"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Kan kleur niet verwijderen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Cannot Remove Color"
           }
         },
         "pl" : {
@@ -15157,13 +15157,13 @@
             "value" : "Change…"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Change…"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Change…"
@@ -15347,16 +15347,16 @@
             "value" : "업데이트 확인"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Check for Updates"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Controleer op Updates"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Check for Updates"
           }
         },
         "pl" : {
@@ -15537,13 +15537,13 @@
             "value" : "Choose how large window previews appear when hovering over dock icons. All window images are automatically scaled to fit within this size while maintaining their original proportions."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Choose how large window previews appear when hovering over dock icons. All window images are automatically scaled to fit within this size while maintaining their original proportions."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Choose how large window previews appear when hovering over dock icons. All window images are automatically scaled to fit within this size while maintaining their original proportions."
@@ -15728,16 +15728,16 @@
             "value" : "\"트리거 키 설정\"을 클릭합니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Click \"Set Trigger Key\""
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Klik op \"Set Trigger Key\""
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Click \"Set Trigger Key\""
           }
         },
         "pl" : {
@@ -15918,16 +15918,16 @@
             "value" : "닫기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Close"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sluiten"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close"
           }
         },
         "pl" : {
@@ -16109,16 +16109,16 @@
             "value" : "모두 닫기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Close All"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sluit alles"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close All"
           }
         },
         "pl" : {
@@ -16299,13 +16299,13 @@
             "value" : "Cmd+A focuses previews, Left/Right navigate, Down clears selection."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Cmd+A focuses previews, Left/Right navigate, Down clears selection."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Cmd+A focuses previews, Left/Right navigate, Down clears selection."
@@ -16490,13 +16490,13 @@
             "value" : "임베디드 모드로 축소"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Collapse to embedded mode"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Collapse to embedded mode"
@@ -16680,16 +16680,16 @@
             "value" : "색상 사용자 지정"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Color Customization"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Kleuraanpassing"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Color Customization"
           }
         },
         "pl" : {
@@ -16871,16 +16871,16 @@
             "value" : "색상"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Colors"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Kleuren"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Colors"
           }
         },
         "pl" : {
@@ -17061,13 +17061,13 @@
             "value" : "Command"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Command"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Command"
@@ -17252,15 +17252,15 @@
             "value" : "커맨드키 (⌘)"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Command (⌘)"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Command (⌘)"
           }
         },
@@ -17442,13 +17442,13 @@
             "value" : "Command ⌘"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Command ⌘"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Command ⌘"
@@ -17632,13 +17632,13 @@
             "value" : "Community Contributors"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Community Contributors"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Community Contributors"
@@ -17822,16 +17822,16 @@
             "value" : "확인"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Confirm"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bevestigen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Confirm"
           }
         },
         "pl" : {
@@ -18012,16 +18012,16 @@
             "value" : "번역 기여하기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Contribute translation"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bijdragen aan vertalingen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Contribute translation"
           }
         },
         "pl" : {
@@ -18203,16 +18203,16 @@
             "value" : "여기에서 번역에 기여하세요!"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Contribute translation here!"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Werk mee aan de vertaling!"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Contribute translation here!"
           }
         },
         "pl" : {
@@ -18393,13 +18393,13 @@
             "value" : "Contributions"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Contributions"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Contributions"
@@ -18583,13 +18583,13 @@
             "value" : "Control"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Control"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Control"
@@ -18774,15 +18774,15 @@
             "value" : "컨트롤키 (⌃)"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Control (⌃)"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Control (⌃)"
           }
         },
@@ -18964,13 +18964,13 @@
             "value" : "Control ⌃"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Control ⌃"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Control ⌃"
@@ -19154,13 +19154,13 @@
             "value" : "Control the transparency of the dock preview background. Lower values make the preview more transparent, which can help prevent it from blocking window content."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Control the transparency of the dock preview background. Lower values make the preview more transparent, which can help prevent it from blocking window content."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Control the transparency of the dock preview background. Lower values make the preview more transparent, which can help prevent it from blocking window content."
@@ -19344,13 +19344,13 @@
             "value" : "Controls how many rows of windows are shown in the window switcher. Windows are distributed across rows automatically."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Controls how many rows of windows are shown in the window switcher. Windows are distributed across rows automatically."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Controls how many rows of windows are shown in the window switcher. Windows are distributed across rows automatically."
@@ -19534,13 +19534,13 @@
             "value" : "Controls how many rows/columns of windows are shown in dock previews. Only the relevant setting applies based on dock position."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Controls how many rows/columns of windows are shown in dock previews. Only the relevant setting applies based on dock position."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Controls how many rows/columns of windows are shown in dock previews. Only the relevant setting applies based on dock position."
@@ -19724,16 +19724,16 @@
             "value" : "창 미리보기의 시각적 세부 사항과 업데이트 빈도를 제어합니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Controls the visual detail and update frequency of window previews."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bepaalt de visuele details en de updatefrequentie van venstervoorbeelden."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Controls the visual detail and update frequency of window previews."
           }
         },
         "pl" : {
@@ -19914,13 +19914,13 @@
             "value" : "Current aspect ratio: %@"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Current aspect ratio: %@"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Current aspect ratio: %@"
@@ -20105,16 +20105,16 @@
             "value" : "현재 키 조합: %@"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Current Keybind: %@"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Huidige Toetscombinatie: %@"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Current Keybind: %@"
           }
         },
         "pl" : {
@@ -20296,16 +20296,16 @@
             "value" : "현재 바로 가기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Current Shortcut"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Huidige sneltoets"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Current Shortcut"
           }
         },
         "pl" : {
@@ -20486,16 +20486,16 @@
             "value" : "현재 버전"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Current Version"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Huidige Versie"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Current Version"
           }
         },
         "pl" : {
@@ -20677,16 +20677,16 @@
             "value" : "현재 버전: %@"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Current Version: %@"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Huidige Versie: %@"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Current Version: %@"
           }
         },
         "pl" : {
@@ -20867,16 +20867,16 @@
             "value" : "사용자 지정 애플리케이션 디렉토리"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Custom Application Directories"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Aangepaste applicatie mappen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Custom Application Directories"
           }
         },
         "pl" : {
@@ -21057,13 +21057,13 @@
             "value" : "Custom Hover Highlight Color"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Custom Hover Highlight Color"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Custom Hover Highlight Color"
@@ -21248,16 +21248,16 @@
             "value" : "기본값"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Default"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Standaard"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Default"
           }
         },
         "pl" : {
@@ -21440,16 +21440,16 @@
             "value" : "기본값(중간 크기)"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Default (Medium Large)"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Standaard (Medium Groot)"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Default (Medium Large)"
           }
         },
         "pl" : {
@@ -21630,13 +21630,13 @@
             "value" : "Delete"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Delete"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Delete"
@@ -21820,16 +21820,16 @@
             "value" : "상세한"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Detailed"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Gedetailleerd"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Detailed"
           }
         },
         "pl" : {
@@ -22010,13 +22010,13 @@
             "value" : "Diagonal - Title bottom left, controls top right"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Diagonal - Title bottom left, controls top right"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Diagonal - Title bottom left, controls top right"
@@ -22200,13 +22200,13 @@
             "value" : "Diagonal - Title bottom right, controls top left"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Diagonal - Title bottom right, controls top left"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Diagonal - Title bottom right, controls top left"
@@ -22390,13 +22390,13 @@
             "value" : "Diagonal - Title top left, controls bottom right"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Diagonal - Title top left, controls bottom right"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Diagonal - Title top left, controls bottom right"
@@ -22580,13 +22580,13 @@
             "value" : "Diagonal - Title top right, controls bottom left"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Diagonal - Title top right, controls bottom left"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Diagonal - Title top right, controls bottom left"
@@ -22771,16 +22771,16 @@
             "value" : "선택되지 않은 창 흐리게 표시"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Dim Unselected Windows"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Dim niet geselecteerd venster"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Dim Unselected Windows"
           }
         },
         "pl" : {
@@ -22961,13 +22961,13 @@
             "value" : "Disable dock styling on traffic light buttons"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Disable dock styling on traffic light buttons"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Disable dock styling on traffic light buttons"
@@ -23151,13 +23151,13 @@
             "value" : "Disable dock styling on window titles"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Disable dock styling on window titles"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Disable dock styling on window titles"
@@ -23341,16 +23341,16 @@
             "value" : "연결 해제된 디스플레이"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Disconnected Display"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Verbreek verbind met scherm"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Disconnected Display"
           }
         },
         "pl" : {
@@ -23531,16 +23531,16 @@
             "value" : "기능에 대해 토론하고 커뮤니티에서 도움 받기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Discuss features and get help from the community"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bespreek functies en krijg hulp van de community"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Discuss features and get help from the community"
           }
         },
         "pl" : {
@@ -23722,16 +23722,16 @@
             "value" : "표시 %u"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Display %u"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Weergave %u"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Display %u"
           }
         },
         "pl" : {
@@ -23912,13 +23912,13 @@
             "value" : "Distinguish minimized/hidden windows"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Distinguish minimized/hidden windows"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Distinguish minimized/hidden windows"
@@ -24102,13 +24102,13 @@
             "value" : "Dock Click Action"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Dock Click Action"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Dock Click Action"
@@ -24292,16 +24292,16 @@
             "value" : "Dock 미리보기 에어로 쉐이크 액션"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Dock Preview Aero Shake Action"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Dock voorvertoning Aero Schud Actie"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Dock Preview Aero Shake Action"
           }
         },
         "pl" : {
@@ -24482,16 +24482,16 @@
             "value" : "Dock 미리보기 호버 액션"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Dock Preview Hover Action"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Dock voorvertoning Hover Action"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Dock Preview Hover Action"
           }
         },
         "pl" : {
@@ -24672,13 +24672,13 @@
             "value" : "Dock Preview Layout"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Dock Preview Layout"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Dock Preview Layout"
@@ -24862,16 +24862,16 @@
             "value" : "Dock 미리보기 설정"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Dock Preview Settings"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Dock voorbeeldinstellingen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Dock Preview Settings"
           }
         },
         "pl" : {
@@ -25052,13 +25052,13 @@
             "value" : "Dock Preview Toolbar"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Dock Preview Toolbar"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Dock Preview Toolbar"
@@ -25242,13 +25242,13 @@
             "value" : "Dock Preview Transparency"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Dock Preview Transparency"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Dock Preview Transparency"
@@ -25433,16 +25433,16 @@
             "value" : "Dock 미리보기 창 호버 액션"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Dock Preview Window Hover Action"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Venster van Dock voorvertoning Hover Action"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Dock Preview Window Hover Action"
           }
         },
         "pl" : {
@@ -25623,16 +25623,16 @@
             "value" : "독 미리 보기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Dock Previews"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Dock voorbeelden"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Dock Previews"
           }
         },
         "pl" : {
@@ -25814,16 +25814,16 @@
             "value" : "Dock 미리보기 & 창 전환"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Dock Previews & Window Switcher"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Dock Previews & Venster switcher"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Dock Previews & Window Switcher"
           }
         },
         "pl" : {
@@ -26005,16 +26005,16 @@
             "value" : "Dock 미리보기만"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Dock Previews only"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Alleen Dock voorbeelden"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Dock Previews only"
           }
         },
         "pl" : {
@@ -26195,16 +26195,16 @@
             "value" : "DockDoor는 컴퓨터의 화면 및 오디오를 녹화하지 않으며, 창 미리보기 화면만 띄웁니다. 모든 정보는 저장 및 공유하지 않으며, 모든 작업은 본 기기에서 안전하게 이루어집니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "DockDoor does not record your screen or audio. It only captures static window previews. No information is stored or shared; all processing occurs privately on your device."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "DockDoor neemt je scherm of audio niet op. Het legt alleen statische venstervoorbeelden vast. Er wordt geen informatie opgeslagen of gedeeld; alle verwerking vindt plaats op uw eigen apparaat."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "DockDoor does not record your screen or audio. It only captures static window previews. No information is stored or shared; all processing occurs privately on your device."
           }
         },
         "pl" : {
@@ -26385,13 +26385,13 @@
             "value" : "DockDoor가 캘린더에 액세스하려면 권한이 필요합니다."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "DockDoor needs permission to access your calendar."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "DockDoor needs permission to access your calendar."
@@ -26575,16 +26575,16 @@
             "value" : "DockDoor는 화면 녹화 권한이 필요합니다. macOS Sequoia를 사용하신다면, 새로운 시스템 보안 정책으로 인해 설치하신 모든 캡처 앱에서 이 창을 매주, 매달, 혹은 재부팅 후에 보시게 될 겁니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "DockDoor needs screen recording access. In macOS Sequoia, you'll see this prompt every week or month and after reboots. This is a new system-wide security policy for all screen capture apps."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Dockdoor heeft toestemming nodig om schermopname te maken. In macOS Sequoia, zie je deze pop-up elke week of maand wanneer het is heropgestart. Dit is een nieuw, systeem breed, veiligheids-beleid voor alle schermopnemende apps."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "DockDoor needs screen recording access. In macOS Sequoia, you'll see this prompt every week or month and after reboots. This is a new system-wide security policy for all screen capture apps."
           }
         },
         "pl" : {
@@ -26765,16 +26765,16 @@
             "value" : "색 편집"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Edit Color"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bewerk Kleur"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Edit Color"
           }
         },
         "pl" : {
@@ -26955,13 +26955,13 @@
             "value" : "Either left or right Command, Option, or Control keys work. You can also hold the modifier while pressing the trigger to capture both."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Either left or right Command, Option, or Control keys work. You can also hold the modifier while pressing the trigger to capture both."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Either left or right Command, Option, or Control keys work. You can also hold the modifier while pressing the trigger to capture both."
@@ -27146,16 +27146,16 @@
             "value" : "요소 중첩"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Elements Overlap"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Elementen overlappen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Elements Overlap"
           }
         },
         "pl" : {
@@ -27336,13 +27336,13 @@
             "value" : "Embed controls in preview frames"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Embed controls in preview frames"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Embed controls in preview frames"
@@ -27526,13 +27526,13 @@
             "value" : "창 미리보기가 있는 컨트롤 임베드(미리보기가 표시된 경우)"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Embed controls with window previews (if previews shown)"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Embed controls with window previews (if previews shown)"
@@ -27718,16 +27718,16 @@
             "value" : "임베디드"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Embedded"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ingesloten"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Embedded"
           }
         },
         "pl" : {
@@ -27908,16 +27908,16 @@
             "value" : "자동으로 업데이트 확인하기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Enable automatic checking for updates"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Automatisch controleren op updates inschakelen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Enable automatic checking for updates"
           }
         },
         "pl" : {
@@ -28098,13 +28098,13 @@
             "value" : "Enable Cmd+Tab Enhancements"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Enable Cmd+Tab Enhancements"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Enable Cmd+Tab Enhancements"
@@ -28288,13 +28288,13 @@
             "value" : "Enable Dock Previews"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Enable Dock Previews"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Enable Dock Previews"
@@ -28479,16 +28479,16 @@
             "value" : "호버 창 슬라이딩 애니메이션 활성화"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Enable Hover Window Sliding Animation"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Zwevend venster schuifanimatie inschakelen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Enable Hover Window Sliding Animation"
           }
         },
         "pl" : {
@@ -28669,13 +28669,13 @@
             "value" : "고정 사용"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Enable Pinning"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Enable Pinning"
@@ -28860,16 +28860,16 @@
             "value" : "창 미리보기 슬라이딩 애니메이션 활성화"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Enable Preview Window Sliding Animation"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Schuifanimatie van voorvertoningsvenster inschakelen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Enable Preview Window Sliding Animation"
           }
         },
         "pl" : {
@@ -29050,13 +29050,13 @@
             "value" : "Enable search while using Window Switcher"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Enable search while using Window Switcher"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Enable search while using Window Switcher"
@@ -29240,16 +29240,16 @@
             "value" : "윈도우 스위치 활성화"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Enable Window Switcher"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sta venster schakelaar toe"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Enable Window Switcher"
           }
         },
         "pl" : {
@@ -29430,16 +29430,16 @@
             "value" : "활성화됨"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Enabled"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Aan"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Enabled"
           }
         },
         "pl" : {
@@ -29620,16 +29620,16 @@
             "value" : "활성화된 버튼"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Enabled Buttons"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Activeer knoppen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Enabled Buttons"
           }
         },
         "pl" : {
@@ -29810,16 +29810,16 @@
             "value" : "도크 경험을 향상하세요!"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Enhance your dock experience!"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Verbeter je Dock ervaring!"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Enhance your dock experience!"
           }
         },
         "pl" : {
@@ -30000,13 +30000,13 @@
             "value" : "여유로운 하루를 즐기거나 캘린더에 이벤트를 추가하세요."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Enjoy your free day or add some events to your calendar."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Enjoy your free day or add some events to your calendar."
@@ -30190,16 +30190,16 @@
             "value" : "필터링할 텍스트 입력"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Enter text to filter"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Voer tekst in om te filteren"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Enter text to filter"
           }
         },
         "pl" : {
@@ -30380,13 +30380,13 @@
             "value" : "Escape"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Escape"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Escape"
@@ -30570,16 +30570,16 @@
             "value" : "이제 모든 준비가 끝났어요!"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Everything is now set up!"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Alles is nu ingesteld!"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Everything is now set up!"
           }
         },
         "pl" : {
@@ -30761,16 +30761,16 @@
             "value" : "예제:"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Example:"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Voorbeeld:"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Example:"
           }
         },
         "pl" : {
@@ -30952,16 +30952,16 @@
             "value" : "제목의 특정 텍스트를 필터링하여 창을 캡처에서 제외하기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Exclude windows from capture by filtering specific text in their titles"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sluit vensters uit van vastlegging door specifieke tekst in hun titels te filteren"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Exclude windows from capture by filtering specific text in their titles"
           }
         },
         "pl" : {
@@ -31142,16 +31142,16 @@
             "value" : "제목의 특정 텍스트를 필터링하여 창을 캡처에서 제외합니다(대소문자 구분 없음)."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Exclude windows from capture by filtering specific text in their titles (case-insensitive)."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Vensters uitsluiten van vastlegging door specifieke tekst in hun titels te filteren (hoofdlettergevoelig)."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Exclude windows from capture by filtering specific text in their titles (case-insensitive)."
           }
         },
         "pl" : {
@@ -31333,13 +31333,13 @@
             "value" : "전체 모드로 확장"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Expand to full mode"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Expand to full mode"
@@ -31524,16 +31524,16 @@
             "value" : "실험적: 앱 레이블 위에 미리보기 표시"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "EXPERIMENTAL: Show preview above app labels"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "EXPERIMENTEEL: Voorbeeld weergeven boven app labels"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "EXPERIMENTAL: Show preview above app labels"
           }
         },
         "pl" : {
@@ -31716,16 +31716,16 @@
             "value" : "매무 매우 작음"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Extra Extra Small"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Extra extra klein"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Extra Extra Small"
           }
         },
         "pl" : {
@@ -31908,16 +31908,16 @@
             "value" : "매우 작음"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Extra Small"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Extra Klein"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Extra Small"
           }
         },
         "pl" : {
@@ -32104,16 +32104,16 @@
             "value" : "v%1$@: %2$@을(를) 다운로드하지 못했습니다"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Failed to download v%1$@: %2$@"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Het downloaden van v%1$@ is mislukt: %2$@"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Failed to download v%1$@: %2$@"
           }
         },
         "pl" : {
@@ -32295,15 +32295,15 @@
             "value" : "필터"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Filters"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Filters"
           }
         },
@@ -32485,16 +32485,16 @@
             "value" : "필터 설정"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Filters settings"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Filterinstellingen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Filters settings"
           }
         },
         "pl" : {
@@ -32675,16 +32675,16 @@
             "value" : "시각적 세부 사항과 레이아웃 옵션을 미세 조정할 수 있습니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Fine-tune visual details and layout options."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Verfijn visuele details en lay-outopties."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Fine-tune visual details and layout options."
           }
         },
         "pl" : {
@@ -32865,13 +32865,13 @@
             "value" : "Focus and use previews"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Focus and use previews"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Focus and use previews"
@@ -33055,13 +33055,13 @@
             "value" : "지원되는 앱(음악, Spotify, 캘린더)의 경우 Dock 아이콘을 가리키면 창 미리보기 대신 대화형 컨트롤을 표시합니다."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "For supported apps (Music, Spotify, Calendar), show interactive controls instead of window previews when hovering their Dock icons."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "For supported apps (Music, Spotify, Calendar), show interactive controls instead of window previews when hovering their Dock icons."
@@ -33245,16 +33245,16 @@
             "value" : "강제 종료"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Force Quit"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Afsluiten forceren"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Force Quit"
           }
         },
         "pl" : {
@@ -33435,16 +33435,16 @@
             "value" : "버그가 있나요?"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Found a Bug?"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Een bug gevonden?"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Found a Bug?"
           }
         },
         "pl" : {
@@ -33625,16 +33625,16 @@
             "value" : "전체 화면"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Fullscreen"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Volledig scherm"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Fullscreen"
           }
         },
         "pl" : {
@@ -33815,13 +33815,13 @@
             "value" : "Fullscreen App Blacklist"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Fullscreen App Blacklist"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Fullscreen App Blacklist"
@@ -34006,16 +34006,16 @@
             "value" : "일반"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "General"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Algemeen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "General"
           }
         },
         "pl" : {
@@ -34196,16 +34196,16 @@
             "value" : "일반 모양"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "General Appearance"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Algemeen uiterlijk"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "General Appearance"
           }
         },
         "pl" : {
@@ -34387,16 +34387,16 @@
             "value" : "일반 제외 사항"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "General Exclusions"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Algemene uitsluitingen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "General Exclusions"
           }
         },
         "pl" : {
@@ -34577,16 +34577,16 @@
             "value" : "일반 설정"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "General settings"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Algemene Instellingen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "General settings"
           }
         },
         "pl" : {
@@ -34767,16 +34767,16 @@
             "value" : "시작하기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Get Started"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Begin"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Get Started"
           }
         },
         "pl" : {
@@ -34958,13 +34958,13 @@
             "value" : "글로벌 패딩 스케일"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Global Padding Scale"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Global Padding Scale"
@@ -35148,13 +35148,13 @@
             "value" : "액세스 권한 부여"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Grant Access"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Grant Access"
@@ -35338,16 +35338,16 @@
             "value" : "허용"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Granted"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Toegekend"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Granted"
           }
         },
         "pl" : {
@@ -35528,16 +35528,16 @@
             "value" : "아이디어가 있나요?"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Have an Idea?"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Heb je een idee?"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Have an Idea?"
           }
         },
         "pl" : {
@@ -35720,16 +35720,16 @@
             "value" : "도움말"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Help"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Hulp"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Help"
           }
         },
         "pl" : {
@@ -35910,16 +35910,16 @@
             "value" : "도움말 및 지원"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Help & Support"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Hulp en ondersteuning"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Help & Support"
           }
         },
         "pl" : {
@@ -36101,16 +36101,16 @@
             "value" : "도움말 및 질문 설정"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Help and questions settings"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Instellingen voor hulp en vragen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Help and questions settings"
           }
         },
         "pl" : {
@@ -36291,16 +36291,16 @@
             "value" : "DockDoor를 귀하의 언어로 사용할 수 있도록 도와주세요"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Help make DockDoor available in your language"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Help DockDoor beschikbaar te maken in jouw taal"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Help make DockDoor available in your language"
           }
         },
         "pl" : {
@@ -36481,16 +36481,16 @@
             "value" : "버그와 같은 이슈들을 제보하여 DockDoor를 개선해 주세요."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Help us improve DockDoor by reporting any issues you encounter."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Help ons DockDoor verbeteren door problemen die je ervaart te rapporteren."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Help us improve DockDoor by reporting any issues you encounter."
           }
         },
         "pl" : {
@@ -36672,16 +36672,16 @@
             "value" : "숨김"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Hidden"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Verborgen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Hidden"
           }
         },
         "pl" : {
@@ -36862,16 +36862,16 @@
             "value" : "고급 설정 숨기기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Hide Advanced Settings"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Verberg geavanceerde instellingen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Hide Advanced Settings"
           }
         },
         "pl" : {
@@ -37052,16 +37052,16 @@
             "value" : "도크 아이콘 클릭 시 모든 앱 창 숨기기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Hide all app windows on dock icon click"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Verberg alle app vensters bij klikken op het dockpictogram"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Hide all app windows on dock icon click"
           }
         },
         "pl" : {
@@ -37243,16 +37243,16 @@
             "value" : "도크 아이콘을 클릭하면 모든 애플리케이션 창을 숨깁니다"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Hide all application windows when clicking on the dock icon"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Verberg alle applicatievensters wanneer u op het dockpictogram klikt"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Hide all application windows when clicking on the dock icon"
           }
         },
         "pl" : {
@@ -37434,13 +37434,13 @@
             "value" : "Hide application"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Hide application"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Hide application"
@@ -37624,13 +37624,13 @@
             "value" : "Hide preview card background"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Hide preview card background"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Hide preview card background"
@@ -37814,16 +37814,16 @@
             "value" : "하이라이트 그라데이션 색상"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Highlight Gradient Colors"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Markeer verloopkleuren"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Highlight Gradient Colors"
           }
         },
         "pl" : {
@@ -38005,16 +38005,16 @@
             "value" : "호버 창 열기 지연"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Hover Window Open Delay"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Vertraging bij openen van zwevend venster"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Hover Window Open Delay"
           }
         },
         "pl" : {
@@ -38196,16 +38196,16 @@
             "value" : "호버 창 제목 스타일"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Hover Window Title Style"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Stijl van de zwevend venster titel"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Hover Window Title Style"
           }
         },
         "pl" : {
@@ -38387,16 +38387,16 @@
             "value" : "설정 방법"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "How to Set Up"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Hoe te configureren"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "How to Set Up"
           }
         },
         "pl" : {
@@ -38578,13 +38578,13 @@
             "value" : "비활성화하면 창 미리 보기를 사용할 수 없는 경우(예: 모든 창이 최소화됨)에만 특수 컨트롤이 나타납니다. 활성화하면 가능한 경우 컨트롤이 미리 보기와 통합됩니다."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "If disabled, special controls only appear if no window previews are available (e.g., all windows minimized). If enabled, controls integrate with previews when possible."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "If disabled, special controls only appear if no window previews are available (e.g., all windows minimized). If enabled, controls integrate with previews when possible."
@@ -38768,13 +38768,13 @@
             "value" : "활성화하면 가능한 경우 컨트롤이 미리 보기와 통합됩니다."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "If enabled, controls integrate with previews when possible."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "If enabled, controls integrate with previews when possible."
@@ -38958,16 +38958,16 @@
             "value" : "DockDoor를 유용하게 사용하고 계신다면, 저희 팀을 후원해 주세요!"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "If you find DockDoor useful, consider donating. Your support helps keep the project going!"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Vindt u DockDoor nuttig? Overweeg dan een donatie. Uw steun helpt het project gaande te houden!"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "If you find DockDoor useful, consider donating. Your support helps keep the project going!"
           }
         },
         "pl" : {
@@ -39149,16 +39149,16 @@
             "value" : "메뉴 막대의 아이콘에 접근하려면 앱을 실행하여 10초 간 노출시킬 수 있습니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "If you need to access the menu bar icon, launch the app to reveal it for 10 seconds."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Als u het menubalk pictogram nodig hebt, start u de app zodat het 10 seconden lang zichtbaar is."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "If you need to access the menu bar icon, launch the app to reveal it for 10 seconds."
           }
         },
         "pl" : {
@@ -39339,16 +39339,16 @@
             "value" : "하나의 창으로 앱 무시하기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Ignore apps with one window"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Negeer apps met één venster"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Ignore apps with one window"
           }
         },
         "pl" : {
@@ -39530,16 +39530,16 @@
             "value" : "하나의 창만 있는 앱 무시"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Ignore Apps with One Window"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Negeer apps met één venster"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Ignore Apps with One Window"
           }
         },
         "pl" : {
@@ -39721,16 +39721,16 @@
             "value" : "중요: 녹화할 때는 트리거 키만 누르세요(예: 명령 + Tab을 원할 경우 Tab만 누르세요). 녹화 중에는 초기화 키를 누르지 마세요."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Important: When recording, press ONLY the trigger key (e.g. just press Tab if you want command + Tab). Do not press the initialization key during recording."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Belangrijk: druk tijdens het opnemen ALLEEN op de trigger-toets (druk bijvoorbeeld alleen op Tab als u Command + Tab wilt). Druk tijdens het opnemen niet op de initialisatietoets."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Important: When recording, press ONLY the trigger key (e.g. just press Tab if you want command + Tab). Do not press the initialization key during recording."
           }
         },
         "pl" : {
@@ -39912,13 +39912,13 @@
             "value" : "Improved performance (nominal)"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Improved performance (nominal)"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Improved performance (nominal)"
@@ -40103,16 +40103,16 @@
             "value" : "창 전환기에 숨김 및 최소화 창 포함하기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Include Hidden and Minimized Windows in the Window Switcher"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Verborgen en geminimaliseerde vensters opnemen in de venster wisselaar"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Include Hidden and Minimized Windows in the Window Switcher"
           }
         },
         "pl" : {
@@ -40293,16 +40293,16 @@
             "value" : "스위처에 숨김/최소화된 창 포함하기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Include hidden/minimized windows in Switcher"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Verborgen / geminimaliseerde vensters opnemen in de switcher"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Include hidden/minimized windows in Switcher"
           }
         },
         "pl" : {
@@ -40484,16 +40484,16 @@
             "value" : "스위처에 숨김/최소화된 창 포함하기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Include Hidden/Minimized Windows in Switcher"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Verborgen / geminimaliseerde vensters opnemen in de switcher"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Include Hidden/Minimized Windows in Switcher"
           }
         },
         "pl" : {
@@ -40675,16 +40675,16 @@
             "value" : "초기화 키"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Initialization Key"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Initialisatie sleutel"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Initialization Key"
           }
         },
         "pl" : {
@@ -40865,13 +40865,13 @@
             "value" : "Initializer"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Initializer"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Initializer"
@@ -41056,16 +41056,16 @@
             "value" : "지침"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Instructions"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Instructies"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Instructions"
           }
         },
         "pl" : {
@@ -41246,16 +41246,16 @@
             "value" : "상호작용 및 동작(Dock 미리보기)"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Interaction & Behavior (Dock Previews)"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Interactie en gedrag (Dock voorbeelden)"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Interaction & Behavior (Dock Previews)"
           }
         },
         "pl" : {
@@ -41436,16 +41436,16 @@
             "value" : "Discord 가입하기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Join our Discord"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Word lid van onze Discord"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Join our Discord"
           }
         },
         "pl" : {
@@ -41626,13 +41626,13 @@
             "value" : "Keep preview when app terminates"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Keep preview when app terminates"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Keep preview when app terminates"
@@ -41816,16 +41816,16 @@
             "value" : "측면 이동 중에도 미리보기 표시 유지"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Keep previews visible during lateral movement"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Houd previews zichtbaar tijdens zijwaartse beweging"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Keep previews visible during lateral movement"
           }
         },
         "pl" : {
@@ -41901,6 +41901,9 @@
           }
         }
       }
+    },
+    "Keep traffic Lights" : {
+
     },
     "Keyboard Shortcut" : {
       "extractionState" : "stale",
@@ -42007,16 +42010,16 @@
             "value" : "키보드 단축키"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Keyboard Shortcut"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sneltoets"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Keyboard Shortcut"
           }
         },
         "pl" : {
@@ -42197,13 +42200,13 @@
             "value" : "Language"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Language"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Language"
@@ -42389,16 +42392,16 @@
             "value" : "크게"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Large"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Groot"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Large"
           }
         },
         "pl" : {
@@ -42580,16 +42583,16 @@
             "value" : "대형(1/2)"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Large (1/2)"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Groot (1/2)"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Large (1/2)"
           }
         },
         "pl" : {
@@ -42770,16 +42773,16 @@
             "value" : "마지막으로 확인함: %@"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Last checked: %@"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Laatst Gecontroleerd: %@"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Last checked: %@"
           }
         },
         "pl" : {
@@ -42960,16 +42963,16 @@
             "value" : "로그인할 때 DockDoor 실행"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Launch DockDoor at login"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Start DockDoor bij het inloggen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Launch DockDoor at login"
           }
         },
         "pl" : {
@@ -43151,16 +43154,16 @@
             "value" : "레이아웃 제한"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Layout Limits"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Lay-out grenzen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Layout Limits"
           }
         },
         "pl" : {
@@ -43341,16 +43344,16 @@
             "value" : "준비를 시작해봐요"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Let's set things up"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Laten we de dingen instellen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Let's set things up"
           }
         },
         "pl" : {
@@ -43531,16 +43534,16 @@
             "value" : "경량"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Lightweight"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Lichtgewicht"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Lightweight"
           }
         },
         "pl" : {
@@ -43721,13 +43724,13 @@
             "value" : "Limit Window Switcher to active app only"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Limit Window Switcher to active app only"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Limit Window Switcher to active app only"
@@ -43911,13 +43914,13 @@
             "value" : "가사 로드 중..."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Loading lyrics..."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Loading lyrics..."
@@ -44101,16 +44104,16 @@
             "value" : "미리 보기 로드 중..."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Loading preview..."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Preview aan het laden..."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Loading preview..."
           }
         },
         "pl" : {
@@ -44291,13 +44294,13 @@
             "value" : "Lock aspect ratio (16:10)"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Lock aspect ratio (16:10)"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Lock aspect ratio (16:10)"
@@ -44481,13 +44484,13 @@
             "value" : "Max Columns (Left/Right Dock)"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Max Columns (Left/Right Dock)"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Max Columns (Left/Right Dock)"
@@ -44671,13 +44674,13 @@
             "value" : "Max Rows"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Max Rows"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Max Rows"
@@ -44861,13 +44864,13 @@
             "value" : "Max Rows (Bottom Dock)"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Max Rows (Bottom Dock)"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Max Rows (Bottom Dock)"
@@ -45052,16 +45055,16 @@
             "value" : "스위처 미리보기의 최대 행 수"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Max Rows for Switcher Previews"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Maximaal aantal rijen voor Switcher voorbeelden"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Max Rows for Switcher Previews"
           }
         },
         "pl" : {
@@ -45243,16 +45246,16 @@
             "value" : "Dock 미리보기용 최대 스택"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Max Stacks for Dock Previews"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Maximale stapels voor Dock voorbeelden"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Max Stacks for Dock Previews"
           }
         },
         "pl" : {
@@ -45434,16 +45437,16 @@
             "value" : "최대 가로 행"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Maximum Horizontal Rows"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Maximaal aantal horizontale rijen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Maximum Horizontal Rows"
           }
         },
         "pl" : {
@@ -45624,16 +45627,16 @@
             "value" : "최대 색상 수(%lld)에 도달했습니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Maximum number of colors (%lld) reached."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Maximaal aantal kleuren (%lld) bereikt."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Maximum number of colors (%lld) reached."
           }
         },
         "pl" : {
@@ -45815,16 +45818,16 @@
             "value" : "최대 세로 열"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Maximum Vertical Columns"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Maximale verticale kolommen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Maximum Vertical Columns"
           }
         },
         "pl" : {
@@ -46007,15 +46010,15 @@
             "value" : "중간"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Medium"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Medium"
           }
         },
@@ -46198,16 +46201,16 @@
             "value" : "중간(1/%lld)"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Medium (1/%lld)"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Gemiddeld (1/%lld)"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Medium (1/%lld)"
           }
         },
         "pl" : {
@@ -46389,16 +46392,16 @@
             "value" : "메뉴바 아이콘 숨김"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Menu Bar Icon Hidden"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Menubalk pictogram verborgen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Menu Bar Icon Hidden"
           }
         },
         "pl" : {
@@ -46579,16 +46582,16 @@
             "value" : "최소화"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Minimize"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Minimaliseer"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Minimize"
           }
         },
         "pl" : {
@@ -46770,16 +46773,16 @@
             "value" : "모두 최소화"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Minimize All"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Minimaliseer alles"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Minimize All"
           }
         },
         "pl" : {
@@ -46961,16 +46964,16 @@
             "value" : "모든 창 최소화"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Minimize all windows"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Minimaliseer alle vensters"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Minimize all windows"
           }
         },
         "pl" : {
@@ -47152,16 +47155,16 @@
             "value" : "현재 창을 제외한 모든 창을 최소화합니다"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Minimize all windows except the current one"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Minimaliseer alle vensters behalve de huidige"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Minimize all windows except the current one"
           }
         },
         "pl" : {
@@ -47343,13 +47346,13 @@
             "value" : "Minimize windows"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Minimize windows"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Minimize windows"
@@ -47533,13 +47536,13 @@
             "value" : "Minimized"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Minimized"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Minimized"
@@ -47723,16 +47726,16 @@
             "value" : "도달한 최소 색상 수입니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Minimum number of colors reached."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Minimale aantal kleuren bereikt."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Minimum number of colors reached."
           }
         },
         "pl" : {
@@ -47913,13 +47916,13 @@
             "value" : "Name"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Name"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Name"
@@ -48103,16 +48106,16 @@
             "value" : "설정 → 개인정보 및 보안으로 이동합니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Navigate to Settings → Privacy & Security"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Navigeer naar Instellingen → Privacy & Veiligheid"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Navigate to Settings → Privacy & Security"
           }
         },
         "pl" : {
@@ -48294,16 +48297,16 @@
             "value" : "항상 보이지 않음"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Never visible"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Nooit zichtbaar"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Never visible"
           }
         },
         "pl" : {
@@ -48484,16 +48487,16 @@
             "value" : "새 윈도우"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "New Window"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Nieuw venster"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "New Window"
           }
         },
         "pl" : {
@@ -48674,16 +48677,16 @@
             "value" : "다음"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Next page"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Volgende pagina"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Next page"
           }
         },
         "pl" : {
@@ -48865,16 +48868,16 @@
             "value" : "동작 없음"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No action"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Geen Actie"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "No action"
           }
         },
         "pl" : {
@@ -49055,16 +49058,16 @@
             "value" : "아직 검색되거나 스캔된 애플리케이션이 없습니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No applications found or scanned yet."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Nog geen toepassingen gevonden of gescand."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "No applications found or scanned yet."
           }
         },
         "pl" : {
@@ -49245,13 +49248,13 @@
             "value" : "No apps in blacklist"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "No apps in blacklist"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "No apps in blacklist"
@@ -49435,13 +49438,13 @@
             "value" : "오디오 장치를 찾을 수 없습니다."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "No audio devices found"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "No audio devices found"
@@ -49625,16 +49628,16 @@
             "value" : "사용자 지정 디렉터리가 추가되지 않았습니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No custom directories added"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Geen aangepaste mappen toegevoegd"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "No custom directories added"
           }
         },
         "pl" : {
@@ -49815,13 +49818,13 @@
             "value" : "오늘은 예정된 이벤트가 없습니다!"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "No events scheduled for today!"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "No events scheduled for today!"
@@ -50005,13 +50008,13 @@
             "value" : "오늘은 이벤트 없음"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "No events today"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "No events today"
@@ -50196,16 +50199,16 @@
             "value" : "추가한 필터 없음"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No filters added"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Geen filters toegevoegd"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "No filters added"
           }
         },
         "pl" : {
@@ -50388,16 +50391,16 @@
             "value" : "호버 동작 없음"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No hover action"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Geen zweef actie"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "No hover action"
           }
         },
         "pl" : {
@@ -50578,13 +50581,13 @@
             "value" : "사용 가능한 가사 없음"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "No lyrics available"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "No lyrics available"
@@ -50768,16 +50771,16 @@
             "value" : "최근 확인사항 없음"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No recent checks"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Geen recente checks"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "No recent checks"
           }
         },
         "pl" : {
@@ -50958,13 +50961,13 @@
             "value" : "No Results"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "No Results"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "No Results"
@@ -51148,13 +51151,13 @@
             "value" : "No shortcut set"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "No shortcut set"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "No shortcut set"
@@ -51338,16 +51341,16 @@
             "value" : "창 제목 필터가 추가되지 않았습니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No window title filters added"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Geen venstertitel filters toegevoegd"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "No window title filters added"
           }
         },
         "pl" : {
@@ -51528,13 +51531,13 @@
             "value" : "No windows match your search"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "No windows match your search"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "No windows match your search"
@@ -51718,16 +51721,16 @@
             "value" : "%@ 아니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Not %@"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Niet %@"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Not %@"
           }
         },
         "pl" : {
@@ -51909,16 +51912,16 @@
             "value" : "허용되지 않음"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Not granted"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Niet toegekend"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Not granted"
           }
         },
         "pl" : {
@@ -52099,16 +52102,16 @@
             "value" : "확인"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "OK"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ok"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "OK"
           }
         },
         "pl" : {
@@ -52290,16 +52293,16 @@
             "value" : "창을 가리키면; 버튼이 가리킬 때까지 어둡게 표시됨"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "On window hover; Dimmed until button hover"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bij venster zweven; gedimd tot knop zweven"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "On window hover; Dimmed until button hover"
           }
         },
         "pl" : {
@@ -52481,16 +52484,16 @@
             "value" : "창에 마우스를 올렸을 때; 불투명도 최대"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "On window hover; Full opacity"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bij venster zweven; volledige ondoorzichtigheid"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "On window hover; Full opacity"
           }
         },
         "pl" : {
@@ -52671,13 +52674,13 @@
             "value" : "Only show windows from the currently active/frontmost application."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Only show windows from the currently active/frontmost application."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Only show windows from the currently active/frontmost application."
@@ -52862,16 +52865,16 @@
             "value" : "독 자동 숨기기가 활성화된 경우에만 적용됩니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Only takes effect when dock auto-hide is enabled"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Wordt alleen van kracht als automatisch verbergen van het dock is ingeschakeld"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Only takes effect when dock auto-hide is enabled"
           }
         },
         "pl" : {
@@ -53053,16 +53056,16 @@
             "value" : "손쉬운 사용 설정 열기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Open Accessibility Settings"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Open Toegankelijkheidsinstellingen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Open Accessibility Settings"
           }
         },
         "pl" : {
@@ -53244,16 +53247,16 @@
             "value" : "화면 기록 설정 열기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Open Screen Recording Settings"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Open Schermopname Instellingen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Open Screen Recording Settings"
           }
         },
         "pl" : {
@@ -53434,16 +53437,16 @@
             "value" : "설정 열기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Open Settings"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Open Instellingen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Open Settings"
           }
         },
         "pl" : {
@@ -53624,13 +53627,13 @@
             "value" : "시스템 개인 정보 설정 열기"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Open System Privacy Settings"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Open System Privacy Settings"
@@ -53814,13 +53817,13 @@
             "value" : "Option"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Option"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Option"
@@ -54005,15 +54008,15 @@
             "value" : "옵션 키 (⌥)"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Option (⌥)"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Option (⌥)"
           }
         },
@@ -54195,13 +54198,13 @@
             "value" : "Option ⌥"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Option ⌥"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Option ⌥"
@@ -54385,16 +54388,16 @@
             "value" : "성능 프로필"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Performance Profiles"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Prestatie profiel"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Performance Profiles"
           }
         },
         "pl" : {
@@ -54575,16 +54578,16 @@
             "value" : "성능 튜닝(dock 미리보기)"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Performance Tuning (Dock Previews)"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Prestatie tuning (Dock voorbeelden)"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Performance Tuning (Dock Previews)"
           }
         },
         "pl" : {
@@ -54766,16 +54769,16 @@
             "value" : "권한 오류"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Permission error"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Machtigingsprobleem"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Permission error"
           }
         },
         "pl" : {
@@ -54957,16 +54960,16 @@
             "value" : "권한"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Permissions"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Machtigingen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Permissions"
           }
         },
         "pl" : {
@@ -55148,16 +55151,16 @@
             "value" : "권한 설정"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Permissions settings"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Machtigingsinstellingen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Permissions settings"
           }
         },
         "pl" : {
@@ -55338,16 +55341,16 @@
             "value" : "화면에 고정"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pin to Screen"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Vastzetten aan scherm"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Pin to Screen"
           }
         },
         "pl" : {
@@ -55528,13 +55531,13 @@
             "value" : "화면에 고정(컴팩트)"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Pin to Screen (Compact)"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Pin to Screen (Compact)"
@@ -55718,13 +55721,13 @@
             "value" : "화면에 고정(전체)"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Pin to Screen (Full)"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Pin to Screen (Full)"
@@ -55909,16 +55912,16 @@
             "value" : "화면에 고정됨"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pinned to screen"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Vastgezet aan scherm"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Pinned to screen"
           }
         },
         "pl" : {
@@ -56099,16 +56102,16 @@
             "value" : "배치 방향"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Placement Strategy"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Plaatsingsstrategie"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Placement Strategy"
           }
         },
         "pl" : {
@@ -56289,13 +56292,13 @@
             "value" : "Places traffic light buttons and window titles directly inside the dock preview frames for a more compact and minimal appearance."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Places traffic light buttons and window titles directly inside the dock preview frames for a more compact and minimal appearance."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Places traffic light buttons and window titles directly inside the dock preview frames for a more compact and minimal appearance."
@@ -56480,16 +56483,16 @@
             "value" : "변경사항을 적용하기 위해 앱을 종료하세요! :)"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Please Quit the App to Apply Changes! :)"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sluit de app om de wijzigingen toe te passen! :)"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Please Quit the App to Apply Changes! :)"
           }
         },
         "pl" : {
@@ -56671,16 +56674,16 @@
             "value" : "변경사항을 적용하기 위해 앱을 껐다가 켜주세요! :)"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Please Restart the App to Apply Changes! :)"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Start de app opnieuw op om de wijzigingen toe te passen! :)"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Please Restart the App to Apply Changes! :)"
           }
         },
         "pl" : {
@@ -56861,16 +56864,16 @@
             "value" : "변경사항을 적용하기 위해 앱을 껐다 켜주세요. OK를 누르면 앱이 종료됩니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Please restart the application to apply your changes. Click OK to quit the app."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Herstart de app om je veranderingen op te slaan. Druk OK om de app af te sluiten."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Please restart the application to apply your changes. Click OK to quit the app."
           }
         },
         "pl" : {
@@ -57052,15 +57055,15 @@
             "value" : "팝오버"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Popover"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Popover"
           }
         },
@@ -57242,13 +57245,13 @@
             "value" : "Position Dock Preview Controls"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Position Dock Preview Controls"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Position Dock Preview Controls"
@@ -57432,16 +57435,16 @@
             "value" : "위치 창 컨트롤"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Position Window Controls"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Positie vensterbesturing"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Position Window Controls"
           }
         },
         "pl" : {
@@ -57623,16 +57626,16 @@
             "value" : "창의 전체 크기 미리 보기 표시"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Present a full size preview of the window"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Geef een voorbeeld van het venster op volledige grootte weer"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Present a full size preview of the window"
           }
         },
         "pl" : {
@@ -57814,16 +57817,16 @@
             "value" : "초기화 키를 누른 상태에서 아무 키 조합이나 눌러 키 바인딩을 설정하세요."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Press any key combination after holding the initialization key to set the keybind."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Om de sneltoetsencombinatie in te stellen: druk op een willekeurige toetsencombinatie nadat u de initialisatie toets ingedrukt hebt gehouden."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Press any key combination after holding the initialization key to set the keybind."
           }
         },
         "pl" : {
@@ -58005,16 +58008,16 @@
             "value" : "아무 키나 눌러서 단축키를 설정하세요"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Press any key to set the keybind."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Druk op een toets om de toetscombinatie in te stellen."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Press any key to set the keybind."
           }
         },
         "pl" : {
@@ -58196,16 +58199,16 @@
             "value" : "아무 키나 누르세요"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Press any key..."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Druk op een toets..."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Press any key..."
           }
         },
         "pl" : {
@@ -58387,16 +58390,16 @@
             "value" : "트리거 키만 누릅니다(예: Tab 키만 누름)."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Press ONLY the trigger key (e.g. just Tab)"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Druk ALLEEN op de trigger toets (bijv. alleen Tab)"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Press ONLY the trigger key (e.g. just Tab)"
           }
         },
         "pl" : {
@@ -58577,13 +58580,13 @@
             "value" : "Press shortcut…"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Press shortcut…"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Press shortcut…"
@@ -58768,16 +58771,16 @@
             "value" : "키 조합 입력..."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Press the key combination..."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Druk de toetscombinatie in..."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Press the key combination..."
           }
         },
         "pl" : {
@@ -58958,16 +58961,16 @@
             "value" : "미리보기 중에 도크가 숨겨지지 않도록 하기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Prevent dock from hiding during previews"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Voorkom dat het dock tijdens previews wordt verborgen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Prevent dock from hiding during previews"
           }
         },
         "pl" : {
@@ -59148,16 +59151,16 @@
             "value" : "창이 하나만 있는 앱이 미리 보기에 표시되지 않도록 합니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Prevents apps that only ever have a single window from appearing in previews."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Voorkomt dat apps die slechts één venster hebben, in voorvertoningen worden weergegeven."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Prevents apps that only ever have a single window from appearing in previews."
           }
         },
         "pl" : {
@@ -59339,16 +59342,16 @@
             "value" : "인접한 창으로 옆으로 이동할 때 미리보기가 사라지는 것을 방지합니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Prevents previews from disappearing when moving sideways to adjacent windows"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Voorkomt dat voorvertoningen verdwijnen wanneer u zijwaarts naar aangrenzende vensters beweegt"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Prevents previews from disappearing when moving sideways to adjacent windows"
           }
         },
         "pl" : {
@@ -59529,16 +59532,16 @@
             "value" : "모양 및 품질 미리보기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Preview Appearance & Quality"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Voorbeeld uiterlijk & kwaliteit"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Preview Appearance & Quality"
           }
         },
         "pl" : {
@@ -59720,16 +59723,16 @@
             "value" : "모양 및 품질 미리보기(독 미리보기)"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Preview Appearance & Quality (Dock Previews)"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Voorbeeld uiterlijk & kwaliteit (Dock voorbeeld)"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Preview Appearance & Quality (Dock Previews)"
           }
         },
         "pl" : {
@@ -59910,13 +59913,13 @@
             "value" : "Preview Height"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Preview Height"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Preview Height"
@@ -60101,16 +60104,16 @@
             "value" : "호버 동작 미리보기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Preview Hover Action"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Voorbeeld van Hover Actie"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Preview Hover Action"
           }
         },
         "pl" : {
@@ -60291,16 +60294,16 @@
             "value" : "미리보기 호버 동작 지연"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Preview Hover Action Delay"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Voorbeeld van Hover Actie vertraging"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Preview Hover Action Delay"
           }
         },
         "pl" : {
@@ -60482,16 +60485,16 @@
             "value" : "호버 딜레이 미리보기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Preview Hover Delay"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Voorbeeld van Hover Actie"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Preview Hover Delay"
           }
         },
         "pl" : {
@@ -60673,13 +60676,13 @@
             "value" : "레이아웃 미리보기(독)"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Preview Layout (Dock)"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Preview Layout (Dock)"
@@ -60863,13 +60866,13 @@
             "value" : "레이아웃 미리보기(스위쳐)"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Preview Layout (Switcher)"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Preview Layout (Switcher)"
@@ -61053,13 +61056,13 @@
             "value" : "품질 프로필 미리보기"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Preview Quality Profiles"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Preview Quality Profiles"
@@ -61244,16 +61247,16 @@
             "value" : "미리보기 크기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Preview Size"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Grootte voorvertoning"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Preview Size"
           }
         },
         "pl" : {
@@ -61434,13 +61437,13 @@
             "value" : "Preview Width"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Preview Width"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Preview Width"
@@ -61624,13 +61627,13 @@
             "value" : "미리보기 창 페이드 아웃 기간"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Preview Window Fade Out Duration"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Preview Window Fade Out Duration"
@@ -61814,13 +61817,13 @@
             "value" : "미리보기 창 비활성 타이머"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Preview Window Inactivity Timer"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Preview Window Inactivity Timer"
@@ -62004,13 +62007,13 @@
             "value" : "미리보기 창 열기 지연"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Preview Window Open Delay"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Preview Window Open Delay"
@@ -62195,13 +62198,13 @@
             "value" : "미리보기 창 크기는 화면 크기의 1/%lld로 조정됩니다."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Preview windows are sized to 1/%lld of your screen dimensions"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Preview windows are sized to 1/%lld of your screen dimensions"
@@ -62385,13 +62388,13 @@
             "value" : "Profile"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Profile"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Profile"
@@ -62575,15 +62578,15 @@
             "value" : "픽셀"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "px"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "px"
           }
         },
@@ -62765,16 +62768,16 @@
             "value" : "종료"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Quit"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Afsluiten"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Quit"
           }
         },
         "pl" : {
@@ -62956,16 +62959,16 @@
             "value" : "앱 종료"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Quit App"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sluit App"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Quit App"
           }
         },
         "pl" : {
@@ -63146,16 +63149,16 @@
             "value" : "DockDoor 종료"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Quit DockDoor"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sluit DockDoor"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Quit DockDoor"
           }
         },
         "pl" : {
@@ -63336,13 +63339,13 @@
             "value" : "Reading app information..."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Reading app information..."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Reading app information..."
@@ -63526,16 +63529,16 @@
             "value" : "모션 감소"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Reduce motion"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Beweging verminderen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reduce motion"
           }
         },
         "pl" : {
@@ -63716,16 +63719,16 @@
             "value" : "편안한"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Relaxed"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ontspannen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Relaxed"
           }
         },
         "pl" : {
@@ -63906,16 +63909,16 @@
             "value" : "스위처에서 창을 선택하려면 초기화 키에서 손을 떼세요."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Release initializer key to select window in Switcher"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Laat de initialisatie toets los om een ​​venster in Switcher te selecteren"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Release initializer key to select window in Switcher"
           }
         },
         "pl" : {
@@ -64096,16 +64099,16 @@
             "value" : "제거"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Remove"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Verwijderen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Remove"
           }
         },
         "pl" : {
@@ -64286,16 +64289,16 @@
             "value" : "모두 제거"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Remove All"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Alles verwijderen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Remove All"
           }
         },
         "pl" : {
@@ -64476,13 +64479,13 @@
             "value" : "Removes the background panel from individual window previews."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Removes the background panel from individual window previews."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Removes the background panel from individual window previews."
@@ -64666,13 +64669,13 @@
             "value" : "Removes the pill-shaped background styling from traffic light buttons in dock previews for a cleaner look."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Removes the pill-shaped background styling from traffic light buttons in dock previews for a cleaner look."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Removes the pill-shaped background styling from traffic light buttons in dock previews for a cleaner look."
@@ -64856,13 +64859,13 @@
             "value" : "Removes the pill-shaped background styling from window titles in dock previews for a cleaner look."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Removes the pill-shaped background styling from window titles in dock previews for a cleaner look."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Removes the pill-shaped background styling from window titles in dock previews for a cleaner look."
@@ -65046,16 +65049,16 @@
             "value" : "버그 제보하기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Report a Bug"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Een bug doorgeven"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Report a Bug"
           }
         },
         "pl" : {
@@ -65236,16 +65239,16 @@
             "value" : "새로운 기능 요청"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Request a Feature"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Vraag een nieuwe feature aan"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Request a Feature"
           }
         },
         "pl" : {
@@ -65426,16 +65429,16 @@
             "value" : "다른 앱의 창 미리 보기를 캡처하는 데 필요합니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Required for capturing window previews of other apps"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Vereist voor het vastleggen van venstervoorbeelden van andere apps"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Required for capturing window previews of other apps"
           }
         },
         "pl" : {
@@ -65616,16 +65619,16 @@
             "value" : "도크 호버 감지 및 창 전환기 핫키에 필요합니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Required for dock hover detection and window switcher hotkeys"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Vereist voor dock hover detectie en sneltoetsen voor vensterwisseling"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Required for dock hover detection and window switcher hotkeys"
           }
         },
         "pl" : {
@@ -65806,15 +65809,15 @@
             "value" : "초기화"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Reset"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Reset"
           }
         },
@@ -65997,16 +66000,16 @@
             "value" : "모든 설정 초기화"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Reset All Settings"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Reset Alle Instellingen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reset All Settings"
           }
         },
         "pl" : {
@@ -66187,16 +66190,16 @@
             "value" : "모든 설정을 기본값으로 초기화"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Reset All Settings to Defaults"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Reset Alle Instellingen naar Standaard"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reset All Settings to Defaults"
           }
         },
         "pl" : {
@@ -66377,16 +66380,16 @@
             "value" : "기본 설정으로 초기화"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Reset to Defaults"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Reset naar Standaard"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reset to Defaults"
           }
         },
         "pl" : {
@@ -66567,16 +66570,16 @@
             "value" : "앱 다시 시작하기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Restart app"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "App herstarten"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Restart app"
           }
         },
         "pl" : {
@@ -66758,16 +66761,16 @@
             "value" : "앱 다시 시작하기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Restart App"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Herstart app"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Restart App"
           }
         },
         "pl" : {
@@ -66948,16 +66951,16 @@
             "value" : "재시작 필요합니다"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Restart required"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Herstart nodig"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Restart required"
           }
         },
         "pl" : {
@@ -67138,13 +67141,13 @@
             "value" : "Return"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Return"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Return"
@@ -67328,16 +67331,16 @@
             "value" : "색을 우클릭하여 삭제하세요."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Right click a color to remove it."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Klik met je rechtermuisknop om een kleur te verwijderen."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Right click a color to remove it."
           }
         },
         "pl" : {
@@ -67518,13 +67521,13 @@
             "value" : "Round the corners of window preview images for a modern look."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Round the corners of window preview images for a modern look."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Round the corners of window preview images for a modern look."
@@ -67708,13 +67711,13 @@
             "value" : "Rounded corners"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Rounded corners"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Rounded corners"
@@ -67899,16 +67902,16 @@
             "value" : "둥근 이미지 모서리"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Rounded image corners"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Afbeelding met afgeronde hoeken"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Rounded image corners"
           }
         },
         "pl" : {
@@ -68090,16 +68093,16 @@
             "value" : "화면"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Screen"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Scherm"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Screen"
           }
         },
         "pl" : {
@@ -68281,16 +68284,16 @@
             "value" : "화면 기록:"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Screen Capturing:"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Scherm Vastleggen:"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Screen Capturing:"
           }
         },
         "pl" : {
@@ -68471,16 +68474,16 @@
             "value" : "화면 녹화"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Screen recording"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Schermopname"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Screen recording"
           }
         },
         "pl" : {
@@ -68662,16 +68665,16 @@
             "value" : "화면 기록 권한"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Screen Recording Permissions"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Schermopname Machtigingen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Screen Recording Permissions"
           }
         },
         "pl" : {
@@ -68853,16 +68856,16 @@
             "value" : "마지막으로 활성화된 창이 있는 화면"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Screen with last active window"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Scherm met laatst actieve venster"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Screen with last active window"
           }
         },
         "pl" : {
@@ -69044,16 +69047,16 @@
             "value" : "마우스가 있는 화면"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Screen with mouse"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Scherm met muis"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Screen with mouse"
           }
         },
         "pl" : {
@@ -69234,13 +69237,13 @@
             "value" : "Scroll long titles (marquee)"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Scroll long titles (marquee)"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Scroll long titles (marquee)"
@@ -69424,16 +69427,16 @@
             "value" : "초"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "seconds"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "seconden"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "seconds"
           }
         },
         "pl" : {
@@ -69616,16 +69619,16 @@
             "value" : "창 크게 보기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "See a large preview of the window"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Zie een grote voorvertoning van het scherm"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "See a large preview of the window"
           }
         },
         "pl" : {
@@ -69808,16 +69811,16 @@
             "value" : "창 미리보기 보기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "See a preview of the window"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Zie een voorvertoning van het scherm"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "See a preview of the window"
           }
         },
         "pl" : {
@@ -69998,16 +70001,16 @@
             "value" : "더 보기..."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "See more..."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Zie meer..."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "See more..."
           }
         },
         "pl" : {
@@ -70188,16 +70191,16 @@
             "value" : "프로필을 선택하면 일반적인 성능 설정을 빠르게 조정할 수 있습니다. 수동으로 제어하려면 '고급'을 선택합니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Select a profile to quickly adjust common performance settings. Choose \"Advanced\" for manual control."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Selecteer een profiel om snel algemene prestatie-instellingen aan te passen. Kies 'Geavanceerd' voor handmatige bediening."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Select a profile to quickly adjust common performance settings. Choose \"Advanced\" for manual control."
           }
         },
         "pl" : {
@@ -70378,13 +70381,13 @@
             "value" : "Select an application:"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Select an application:"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Select an application:"
@@ -70569,16 +70572,16 @@
             "value" : "초기화 키(예: Command ⌘)를 선택합니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Select an initialization key (e.g. Command ⌘)"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Selecteer een initialisatie sleutel (bijv. Command ⌘)"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Select an initialization key (e.g. Command ⌘)"
           }
         },
         "pl" : {
@@ -70760,16 +70763,16 @@
             "value" : "캡처하고 미리 볼 수 있는 애플리케이션을 선택합니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Select which applications can be captured and previewed"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Selecteer welke applicaties vastgelegd en vooraf bekeken kunnen worden"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Select which applications can be captured and previewed"
           }
         },
         "pl" : {
@@ -70950,16 +70953,16 @@
             "value" : "DockDoor에 미리보기를 표시할 애플리케이션을 선택합니다. 선택하지 않은 앱은 무시됩니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Select which applications DockDoor should show previews for. Unchecked apps will be ignored."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Selecteer voor welke apps DockDoor previews moet weergeven. Niet aangevinkte apps worden genegeerd."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Select which applications DockDoor should show previews for. Unchecked apps will be ignored."
           }
         },
         "pl" : {
@@ -71140,13 +71143,13 @@
             "value" : "Selected app:"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Selected app:"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Selected app:"
@@ -71331,16 +71334,16 @@
             "value" : "선택 하이라이트"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Selection Highlight"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Selectie markering"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Selection Highlight"
           }
         },
         "pl" : {
@@ -71522,16 +71525,16 @@
             "value" : "초기화 키와 키 바인딩 설정"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Set Initialization Key and Keybind"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Stel initialisatie sleutel en toetscombinatie in"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Set Initialization Key and Keybind"
           }
         },
         "pl" : {
@@ -71713,16 +71716,16 @@
             "value" : "무제한의 경우 0으로 설정"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Set to 0 for unlimited"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Instellen op 0 voor onbeperkt"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Set to 0 for unlimited"
           }
         },
         "pl" : {
@@ -71904,16 +71907,16 @@
             "value" : "트리거 키 설정"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Set Trigger Key"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Trigger toets instellen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Set Trigger Key"
           }
         },
         "pl" : {
@@ -72095,16 +72098,16 @@
             "value" : "미리보기에서 사용할 최대 행(하단/상단 독의 경우) 또는 열(측면 독의 경우)을 설정합니다. '0'은 동적으로 맞춤을 결정합니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Sets the max rows (for bottom/top Dock) or columns (for side Dock) previews will use. '0' dynamically determines fit."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Hiermee stelt u het maximum aantal rijen (voor onderste/bovenste Dock) of kolommen (voor zij-Dock) in dat voorvertoningen worden gebruikt. '0' bepaalt dynamisch de pasvorm."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Sets the max rows (for bottom/top Dock) or columns (for side Dock) previews will use. '0' dynamically determines fit."
           }
         },
         "pl" : {
@@ -72286,16 +72289,16 @@
             "value" : "창 전환기에서 사용할 최대 행 수를 설정합니다. '0'은 화면 높이에 따라 행을 동적으로 결정합니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Sets the maximum number of rows the Window Switcher will use. '0' dynamically determines rows based on screen height."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Hiermee stelt u het maximale aantal rijen in dat de venster wisselaar gebruikt. '0' bepaalt dynamisch het aantal rijen op basis van de schermhoogte."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Sets the maximum number of rows the Window Switcher will use. '0' dynamically determines rows based on screen height."
           }
         },
         "pl" : {
@@ -72477,16 +72480,16 @@
             "value" : "그림자"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Shadowed"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Schaduwen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shadowed"
           }
         },
         "pl" : {
@@ -72667,16 +72670,16 @@
             "value" : "고급 설정 표시"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Show Advanced Settings"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Toon geavanceerde instellingen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Show Advanced Settings"
           }
         },
         "pl" : {
@@ -72857,16 +72860,16 @@
             "value" : "앱 이름 표시"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Show App Name"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "App-naam weergeven"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Show App Name"
           }
         },
         "pl" : {
@@ -73047,16 +73050,16 @@
             "value" : "Dock 미리 보기에서 앱 이름 표시"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Show App Name in Dock Previews"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "App-naam in Dock Previews tonen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Show App Name in Dock Previews"
           }
         },
         "pl" : {
@@ -73237,13 +73240,13 @@
             "value" : "유효한 창이 없을 때 큰 컨트롤 표시"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Show big controls when no valid windows"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Show big controls when no valid windows"
@@ -73427,13 +73430,13 @@
             "value" : "도크 마우스오버 시 미디어/캘린더 컨트롤 보기"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Show media/calendar controls on Dock hover"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Show media/calendar controls on Dock hover"
@@ -73617,16 +73620,16 @@
             "value" : "메뉴 막대 아이콘 표시"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Show menu bar icon"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Menubalkpictogram weergeven"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Show menu bar icon"
           }
         },
         "pl" : {
@@ -73808,16 +73811,16 @@
             "value" : "메뉴 막대에 아이콘 표시"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Show Menu Bar Icon"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Laat Menu Bar Icon Zien"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Show Menu Bar Icon"
           }
         },
         "pl" : {
@@ -73998,16 +74001,16 @@
             "value" : "앱 레이블 위에 미리보기 표시"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Show preview above app labels"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Voorbeeld weergeven boven app-labels"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Show preview above app labels"
           }
         },
         "pl" : {
@@ -74188,13 +74191,13 @@
             "value" : "Show previews while holding Cmd+Tab."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Show previews while holding Cmd+Tab."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Show previews while holding Cmd+Tab."
@@ -74378,13 +74381,13 @@
             "value" : "Show window previews when hovering over Dock icons."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Show window previews when hovering over Dock icons."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Show window previews when hovering over Dock icons."
@@ -74568,16 +74571,16 @@
             "value" : "창 제목 표시"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Show Window Title"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Toon venstertitel"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Show Window Title"
           }
         },
         "pl" : {
@@ -74758,16 +74761,16 @@
             "value" : "창 제목 표시"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Show Window Title in"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Laat de Schermnaam Zien in"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Show Window Title in"
           }
         },
         "pl" : {
@@ -74949,16 +74952,16 @@
             "value" : "미리보기에서 창 제목 표시"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Show Window Title in Previews"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Laat de Schermnaam Zien in Voorvertoning"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Show Window Title in Previews"
           }
         },
         "pl" : {
@@ -75140,16 +75143,16 @@
             "value" : "창 제목 표시"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Show Window Titles"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Laat de Schermnaam Zien"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Show Window Titles"
           }
         },
         "pl" : {
@@ -75331,16 +75334,16 @@
             "value" : "미리보기에서 창 제목 표시"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Show Window Titles on Previews"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Toon venstertitels op previews"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Show Window Titles on Previews"
           }
         },
         "pl" : {
@@ -75521,16 +75524,16 @@
             "value" : "현재 창 대신 마지막으로 활성화된 창을 먼저 표시합니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Shows last active window first, instead of current window."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Toont het laatst actieve venster eerst, in plaats van het huidige venster."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shows last active window first, instead of current window."
           }
         },
         "pl" : {
@@ -75713,16 +75716,16 @@
             "value" : "클릭 시뮬레이션"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Simulate a click"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Simuleer een klik"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Simulate a click"
           }
         },
         "pl" : {
@@ -75904,16 +75907,16 @@
             "value" : "클릭 시뮬레이션(창 열기)"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Simulate a click (open the window)"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Simuleer een klik (open het scherm)"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Simulate a click (open the window)"
           }
         },
         "pl" : {
@@ -76096,16 +76099,16 @@
             "value" : "작게"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Small"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Klein"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Small"
           }
         },
         "pl" : {
@@ -76287,16 +76290,16 @@
             "value" : "소형(1/%lld)"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Small (1/%lld)"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Klein (1/%lld)"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Small (1/%lld)"
           }
         },
         "pl" : {
@@ -76477,16 +76480,16 @@
             "value" : "Snappy"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Snappy"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Vlug"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Snappy"
           }
         },
         "pl" : {
@@ -76668,16 +76671,16 @@
             "value" : "날짜별로 창 미리보기 정렬"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Sort Window Previews by Date"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sorteer venster voorvertoningen op datum"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Sort Window Previews by Date"
           }
         },
         "pl" : {
@@ -76858,16 +76861,16 @@
             "value" : "날짜별로 창 미리보기 정렬(여러 개일 경우)"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Sort Window Previews by Date (if multiple)"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sorteer venster voorvertoningen op datum (indien veelvoud)"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Sort Window Previews by Date (if multiple)"
           }
         },
         "pl" : {
@@ -77048,13 +77051,13 @@
             "value" : "Spacing Scale"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Spacing Scale"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Spacing Scale"
@@ -77238,13 +77241,13 @@
             "value" : "Stable"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Stable"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Stable"
@@ -77428,16 +77431,16 @@
             "value" : "표준"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Standard"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Standaard"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Standard"
           }
         },
         "pl" : {
@@ -77619,16 +77622,16 @@
             "value" : "키 바인드 기록 시작"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Start recording keybind"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Start opname toetscombinatie"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Start recording keybind"
           }
         },
         "pl" : {
@@ -77810,16 +77813,16 @@
             "value" : "키 입력 기록 시작"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Start Recording Keybind"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Start opname toetscombinatie"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Start Recording Keybind"
           }
         },
         "pl" : {
@@ -78001,16 +78004,16 @@
             "value" : "녹화 시작 키 설정"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Start recording trigger key"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Start opname trigger toets"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Start recording trigger key"
           }
         },
         "pl" : {
@@ -78193,16 +78196,16 @@
             "value" : "아원자"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Subatomic"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sub atomisch"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Subatomic"
           }
         },
         "pl" : {
@@ -78383,16 +78386,16 @@
             "value" : "DockDoor를 더욱 발전시키기 위한 새로운 기능을 제안해 주세요."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Suggest new features to make DockDoor even better."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Stel nieuwe functies voor om DockDoor nog beter te maken."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Suggest new features to make DockDoor even better."
           }
         },
         "pl" : {
@@ -78574,16 +78577,16 @@
             "value" : "지원"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Support"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ondersteuning"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Support"
           }
         },
         "pl" : {
@@ -78764,16 +78767,16 @@
             "value" : "지원 및 기여"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Support & Contributions"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ondersteuning & bijdragen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Support & Contributions"
           }
         },
         "pl" : {
@@ -78954,16 +78957,16 @@
             "value" : "소액 기부로 개발 지원"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Support development with a small donation"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ondersteun ontwikkeling met een kleine donatie"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Support development with a small donation"
           }
         },
         "pl" : {
@@ -79144,16 +79147,16 @@
             "value" : "DockDoor 지원"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Support DockDoor"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Steun DockDoor"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Support DockDoor"
           }
         },
         "pl" : {
@@ -79334,16 +79337,16 @@
             "value" : "지원 설정"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Support settings"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Instellingen voor ondersteuning"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Support settings"
           }
         },
         "pl" : {
@@ -79524,13 +79527,13 @@
             "value" : "Tab"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Tab"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Tab"
@@ -79714,16 +79717,16 @@
             "value" : "모든 기여자에게 감사합니다 ❤️"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Thank you to all contributors ❤️"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Dank aan alle bijdragers ❤️"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Thank you to all contributors ❤️"
           }
         },
         "pl" : {
@@ -79905,16 +79908,16 @@
             "value" : "DockDoor를 응원해 주셔서 감사합니다! 💖"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Thanks for supporting DockDoor! 💖"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bedankt voor het steunen van DockDoor! 💖"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Thanks for supporting DockDoor! 💖"
           }
         },
         "pl" : {
@@ -80095,16 +80098,16 @@
             "value" : "권한 변경 사항은 재시작 후 적용됩니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The changes to permissions will take effect after restarting."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "De gewijzigde machtigingen worden van kracht nadat u opnieuw bent opgestart."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "The changes to permissions will take effect after restarting."
           }
         },
         "pl" : {
@@ -80286,16 +80289,16 @@
             "value" : "신호등 버튼과 창 제목에 대해 선택한 위치가 겹치게 됩니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The selected positions for Traffic Light Buttons and Window Title will overlap."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "De geselecteerde posities voor verkeerslichtknoppen en venstertitels zullen elkaar overlappen."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "The selected positions for Traffic Light Buttons and Window Title will overlap."
           }
         },
         "pl" : {
@@ -80476,16 +80479,16 @@
             "value" : "창 전환기(보통 Alt/Cmd-Tab)를 사용하면 키보드 단축키로 열려 있는 앱 창 사이를 빠르게 전환할 수 있습니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The Window Switcher (often Alt/Cmd-Tab) lets you quickly cycle between open app windows with a keyboard shortcut."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Met de venster wisselaar (vaak Alt/Cmd-Tab) kunt u met een sneltoets schakelen tussen geopende app-vensters."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "The Window Switcher (often Alt/Cmd-Tab) lets you quickly cycle between open app windows with a keyboard shortcut."
           }
         },
         "pl" : {
@@ -80667,16 +80670,16 @@
             "value" : "이 디스플레이는 현재 연결이 끊어졌습니다. 선택한 디스플레이가 다시 연결될 때까지 창 전환기가 기본 디스플레이에 나타납니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This display is currently disconnected. The window switcher will appear on the main display until the selected display is reconnected."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Dit scherm is momenteel niet verbonden. De venster schakelaar blijft op het hoofdscherm zichtbaar totdat het geselecteerde scherm weer is verbonden."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "This display is currently disconnected. The window switcher will appear on the main display until the selected display is reconnected."
           }
         },
         "pl" : {
@@ -80857,13 +80860,13 @@
             "value" : "이 설정은 위에서 '창 미리보기가 있는 컨트롤 포함'이 활성화된 경우에만 적용됩니다."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "This setting only applies when \"Embed controls with window previews\" is enabled above."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "This setting only applies when \"Embed controls with window previews\" is enabled above."
@@ -81047,13 +81050,13 @@
             "value" : "This will add the app to the blacklist using its bundle identifier for reliable matching."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "This will add the app to the blacklist using its bundle identifier for reliable matching."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "This will add the app to the blacklist using its bundle identifier for reliable matching."
@@ -81238,16 +81241,16 @@
             "value" : "작은(1/%lld)"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Tiny (1/%lld)"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Klein (1/%lld)"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Tiny (1/%lld)"
           }
         },
         "pl" : {
@@ -81428,13 +81431,13 @@
             "value" : "오늘"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Today"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Today"
@@ -81618,16 +81621,16 @@
             "value" : "토글"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Toggle"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Omschakelen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Toggle"
           }
         },
         "pl" : {
@@ -81808,16 +81811,16 @@
             "value" : "전체화면 켜기/끄기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Toggle Full Screen"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Volledig scherm in-/uitschakelen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Toggle Full Screen"
           }
         },
         "pl" : {
@@ -81999,16 +82002,16 @@
             "value" : "왼쪽 상단"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Top Left"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Linksboven"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Top Left"
           }
         },
         "pl" : {
@@ -82190,16 +82193,16 @@
             "value" : "오른쪽 상단"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Top Right"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Rechtsboven"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Top Right"
           }
         },
         "pl" : {
@@ -82381,16 +82384,16 @@
             "value" : "신호등 버튼"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Traffic Light Buttons"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Verkeerslichtknoppen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Traffic Light Buttons"
           }
         },
         "pl" : {
@@ -82571,16 +82574,16 @@
             "value" : "미리보기의 신호등 버튼"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Traffic Light Buttons in Previews"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Verkeerslichtknoppen in previews"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Traffic Light Buttons in Previews"
           }
         },
         "pl" : {
@@ -82762,16 +82765,16 @@
             "value" : "신호등 버튼 위치"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Traffic Light Buttons Position"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Positie van verkeerslichtknoppen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Traffic Light Buttons Position"
           }
         },
         "pl" : {
@@ -82952,16 +82955,16 @@
             "value" : "신호등 버튼 가시성"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Traffic Light Buttons Visibility"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Zichtbaarheid van verkeerslichtknoppen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Traffic Light Buttons Visibility"
           }
         },
         "pl" : {
@@ -83142,13 +83145,13 @@
             "value" : "Translation Contributors"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Translation Contributors"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Translation Contributors"
@@ -83333,16 +83336,16 @@
             "value" : "트리거 키"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Trigger Key"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Trigger toets"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Trigger Key"
           }
         },
         "pl" : {
@@ -83524,16 +83527,16 @@
             "value" : "독 미리보기에서 창 위로 마우스를 가져가면 동작을 트리거합니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Triggers an action when hovering over a window in a dock preview"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Activeert een actie wanneer u met de muis over een venster in een dock voorbeeld beweegt"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Triggers an action when hovering over a window in a dock preview"
           }
         },
         "pl" : {
@@ -83715,16 +83718,16 @@
             "value" : "도크 미리보기에서 창을 드래그하는 동안 창을 흔들면 동작을 트리거합니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Triggers an action when shaking a window while it is being dragged from a dock preview"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Activeert een actie wanneer een venster wordt geschud terwijl het vanuit een dock voorbeeld wordt gesleept"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Triggers an action when shaking a window while it is being dragged from a dock preview"
           }
         },
         "pl" : {
@@ -83905,16 +83908,16 @@
             "value" : "최소화 해제"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Un-minimize"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Minimaliseren ongedaan maken"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Un-minimize"
           }
         },
         "pl" : {
@@ -84095,16 +84098,16 @@
             "value" : "알 수 없는 디스플레이"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unknown Display"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Onbekend display"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Unknown Display"
           }
         },
         "pl" : {
@@ -84285,13 +84288,13 @@
             "value" : "고정해제"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Unpin"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Unpin"
@@ -84475,13 +84478,13 @@
             "value" : "Unselected Content Opacity"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Unselected Content Opacity"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Unselected Content Opacity"
@@ -84665,16 +84668,16 @@
             "value" : "최신 버전입니다"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Up to date"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Actueel"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Up to date"
           }
         },
         "pl" : {
@@ -84855,16 +84858,16 @@
             "value" : "최신 버전입니다"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Up to Date"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Up-to-date"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Up to Date"
           }
         },
         "pl" : {
@@ -85045,16 +85048,16 @@
             "value" : "업데이트가 중단되었습니다: %@"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Update aborted: %@"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Update afgebroken: %@"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Update aborted: %@"
           }
         },
         "pl" : {
@@ -85235,16 +85238,16 @@
             "value" : "업데이트 사용 가능"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Update available"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Update beschikbaar"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Update available"
           }
         },
         "pl" : {
@@ -85425,13 +85428,13 @@
             "value" : "Update Channel"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Update Channel"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Update Channel"
@@ -85616,16 +85619,16 @@
             "value" : "업데이트 설정"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Update settings"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Instellingen bijwerken"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Update settings"
           }
         },
         "pl" : {
@@ -85806,16 +85809,16 @@
             "value" : "v%@ 업데이트 가능"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Update v%@ available"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Update v%@ beschikbaar"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Update v%@ available"
           }
         },
         "pl" : {
@@ -85996,16 +85999,16 @@
             "value" : "업데이터가 구성되지 않았습니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Updater not configured."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Updater niet geconfigureerd."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Updater not configured."
           }
         },
         "pl" : {
@@ -86187,15 +86190,15 @@
             "value" : "업데이트"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Updates"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Updates"
           }
         },
@@ -86378,16 +86381,16 @@
             "value" : "클래식 창 명령 사용"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Use classic window ordering"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Gebruik klassieke venster volgorde"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Use classic window ordering"
           }
         },
         "pl" : {
@@ -86569,16 +86572,16 @@
             "value" : "기본 MacOS 키 바인드 ⌘ + ⇥ 사용"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Use default MacOS keybind ⌘ + ⇥"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Gebruik standaard MacOS toetsencombinatie ⌘ + ⇥"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Use default MacOS keybind ⌘ + ⇥"
           }
         },
         "pl" : {
@@ -86759,13 +86762,13 @@
             "value" : "Use Liquid Glass (macOS 26+)"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Use Liquid Glass (macOS 26+)"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Use Liquid Glass (macOS 26+)"
@@ -86949,16 +86952,16 @@
             "value" : "단색 색상 사용"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Use Monochrome Colors"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Gebruik monochrome kleuren"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Use Monochrome Colors"
           }
         },
         "pl" : {
@@ -87140,16 +87143,16 @@
             "value" : "강조 표시를 위해 시스템 강조 색상 사용"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Use System Accent Color for Highlight"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Gebruik systeem accentkleur voor markering"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Use System Accent Color for Highlight"
           }
         },
         "pl" : {
@@ -87331,16 +87334,16 @@
             "value" : "균일한 이미지 미리보기 반경 사용"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Use Uniform Image Preview Radius"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Uniforme afbeelding voorvertoning-radius gebruiken"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Use Uniform Image Preview Radius"
           }
         },
         "pl" : {
@@ -87522,16 +87525,16 @@
             "value" : "Windows 스타일 창 순서 사용"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Use Windows-style window ordering"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Gebruik venstervolgorde in Windows-stijl"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Use Windows-style window ordering"
           }
         },
         "pl" : {
@@ -87712,16 +87715,16 @@
             "value" : "스위처에서 Windows 스타일 창 순서 사용"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Use Windows-style window ordering in Switcher"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Gebruik venstervolgorde in Windows-stijl in Switcher"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Use Windows-style window ordering in Switcher"
           }
         },
         "pl" : {
@@ -87903,16 +87906,16 @@
             "value" : "창 전환기에서 Windows 스타일 창 순서 사용"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Use Windows-style window ordering in the window switcher"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Gebruik Windows-stijl venstervolgorde in de vensterwisselaar"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Use Windows-style window ordering in the window switcher"
           }
         },
         "pl" : {
@@ -88094,16 +88097,16 @@
             "value" : "버전 %@"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Version %@"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Versie %@"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Version %@"
           }
         },
         "pl" : {
@@ -88284,13 +88287,13 @@
             "value" : "View"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "View"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "View"
@@ -88474,16 +88477,16 @@
             "value" : "직접 보고 싶으신가요? 소스 코드 살펴보기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Want to see for yourself? Review our source code"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Zelf zien? Bekijk onze broncode"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Want to see for yourself? Review our source code"
           }
         },
         "pl" : {
@@ -88665,16 +88668,16 @@
             "value" : "해당 언어로 앱을 보고 싶으신가요?"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Want to see the app in your language?"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Wilt u de app in uw taal bekijken?"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Want to see the app in your language?"
           }
         },
         "pl" : {
@@ -88856,16 +88859,16 @@
             "value" : "개발 후원하기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Want to support development?"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Wilt u ontwikkeling steunen?"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Want to support development?"
           }
         },
         "pl" : {
@@ -89046,16 +89049,16 @@
             "value" : "DockDoor에 오신 것을 환영합니다!"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Welcome to DockDoor!"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Welkom bij DockDoor!"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Welcome to DockDoor!"
           }
         },
         "pl" : {
@@ -89238,16 +89241,16 @@
             "value" : "이게 뭐야? 개미를 위한 창문인가?"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "What is this? A window for ANTS?"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Wat is dit? Een raam voor MIEREN?"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "What is this? A window for ANTS?"
           }
         },
         "pl" : {
@@ -89428,13 +89431,13 @@
             "value" : "When an app terminates, remove only its windows from the preview instead of hiding the entire preview."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "When an app terminates, remove only its windows from the preview instead of hiding the entire preview."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "When an app terminates, remove only its windows from the preview instead of hiding the entire preview."
@@ -89618,13 +89621,13 @@
             "value" : "When disabled, long titles remain static instead of scrolling."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "When disabled, long titles remain static instead of scrolling."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "When disabled, long titles remain static instead of scrolling."
@@ -89808,13 +89811,13 @@
             "value" : "임베디드 모드가 활성화된 경우, 모든 창이 최소화/숨겨져 있거나 창이 없는 경우 임베디드 컨트롤 대신 큰 컨트롤을 표시합니다."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "When embedded mode is enabled, show big controls instead of embedded ones if all windows are minimized/hidden or there are no windows."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "When embedded mode is enabled, show big controls instead of embedded ones if all windows are minimized/hidden or there are no windows."
@@ -89999,16 +90002,16 @@
             "value" : "활성화하면 모든 미리보기 이미지가 둥근 직사각형으로 잘립니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "When enabled, all preview images will be cropped to a rounded rectangle."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Wanneer deze optie is ingeschakeld, worden alle voorbeeldafbeeldingen bijgesneden tot een afgeronde rechthoek."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "When enabled, all preview images will be cropped to a rounded rectangle."
           }
         },
         "pl" : {
@@ -90190,16 +90193,16 @@
             "value" : "이 기능을 활성화하면 앱의 Dock 아이콘을 클릭하면 Windows 작업 표시줄 동작과 유사하게 해당 애플리케이션의 모든 창이 최소화됩니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "When enabled, clicking an app's Dock icon will minimize all windows of that application, similar to Windows taskbar behavior"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Als deze optie is ingeschakeld, worden alle vensters van die toepassing geminimaliseerd als u op het Dock pictogram van een app klikt, vergelijkbaar met het gedrag van de Windows taakbalk"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "When enabled, clicking an app's Dock icon will minimize all windows of that application, similar to Windows taskbar behavior"
           }
         },
         "pl" : {
@@ -90381,16 +90384,16 @@
             "value" : "활성화하면 현재 선택되어 있는 창을 제외한 모든 창을 어둡게 합니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "When enabled, dims all windows except those currently under selected."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Wanneer deze optie is ingeschakeld, worden alle vensters gedimd, behalve de vensters die op dat moment zijn geselecteerd."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "When enabled, dims all windows except those currently under selected."
           }
         },
         "pl" : {
@@ -90572,16 +90575,16 @@
             "value" : "활성화하면 현재 창 대신 마지막으로 활성화된 창을 먼저 표시합니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "When enabled, shows the last active window first instead of the current window"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Wanneer ingeschakeld, wordt het laatst actieve venster eerst weergegeven in plaats van het huidige venster"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "When enabled, shows the last active window first instead of the current window"
           }
         },
         "pl" : {
@@ -90762,13 +90765,13 @@
             "value" : "When enabled, shows visual indicators and dims minimized/hidden windows. When disabled, treats them as normal windows with full functionality."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "When enabled, shows visual indicators and dims minimized/hidden windows. When disabled, treats them as normal windows with full functionality."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "When enabled, shows visual indicators and dims minimized/hidden windows. When disabled, treats them as normal windows with full functionality."
@@ -90953,16 +90956,16 @@
             "value" : "미리보기 위로 마우스를 가져가면"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "When hovering over the preview"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Wanneer u met de muis over de voorvertoning beweegt"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "When hovering over the preview"
           }
         },
         "pl" : {
@@ -91145,16 +91148,16 @@
             "value" : "도크 타일 미리 보기를 표시할 때"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "When Showing Dock Tile Previews"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bij het tonen van Dock tegel previews"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "When Showing Dock Tile Previews"
           }
         },
         "pl" : {
@@ -91230,6 +91233,9 @@
           }
         }
       }
+    },
+    "When Toggled disable minimized text and keep traffic lights." : {
+
     },
     "When Using Window Switcher" : {
       "comment" : "Preview window title condition option",
@@ -91337,16 +91343,16 @@
             "value" : "윈도우 스위쳐를 사용하는 경우"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "When Using Window Switcher"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bij het gebruik van de vensterschakelaar"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "When Using Window Switcher"
           }
         },
         "pl" : {
@@ -91527,16 +91533,16 @@
             "value" : "아래 버튼을 클릭하면 DockDoor가 다시 시작되고 메뉴 표시줄로 이동하여 백그라운드에서 실행됩니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "When you click the button below, DockDoor will restart and move to the menu bar to run in the background."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Wanneer u op de onderstaande knop klikt, wordt DockDoor opnieuw opgestart en wordt de menubalk op de achtergrond uitgevoerd."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "When you click the button below, DockDoor will restart and move to the menu bar to run in the background."
           }
         },
         "pl" : {
@@ -91718,16 +91724,16 @@
             "value" : "권한이 필요한 이유"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Why we need permissions"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Waarom we toestemming nodig hebben"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Why we need permissions"
           }
         },
         "pl" : {
@@ -91908,13 +91914,13 @@
             "value" : "Window Background"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Window Background"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Window Background"
@@ -92099,16 +92105,16 @@
             "value" : "윈도우 버퍼"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Window Buffer"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Scherm Buffer"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Window Buffer"
           }
         },
         "pl" : {
@@ -92289,16 +92295,16 @@
             "value" : "독의 창 버퍼(픽셀)"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Window Buffer from Dock (pixels)"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Venster buffer van Dock (pixels)"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Window Buffer from Dock (pixels)"
           }
         },
         "pl" : {
@@ -92480,16 +92486,16 @@
             "value" : "윈도우 캐시 수명"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Window Cache Lifespan"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Levensduur venster cache"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Window Cache Lifespan"
           }
         },
         "pl" : {
@@ -92670,16 +92676,16 @@
             "value" : "창 이미지 캐시 수명"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Window Image Cache Lifespan"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Levensduur van de cache van de venster afbeelding"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Window Image Cache Lifespan"
           }
         },
         "pl" : {
@@ -92860,13 +92866,13 @@
             "value" : "Window Image Capture Quality"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Window Image Capture Quality"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Window Image Capture Quality"
@@ -93050,16 +93056,16 @@
             "value" : "창 이미지 해상도 스케일(1=최고)"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Window Image Resolution Scale (1=Best)"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Resolutieschaal van venster afbeelding (1=beste)"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Window Image Resolution Scale (1=Best)"
           }
         },
         "pl" : {
@@ -93241,16 +93247,16 @@
             "value" : "창 이미지 해상도 스케일(높을수록 해상도가 낮음)"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Window Image Resolution Scale (higher means lower resolution)"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Resolutieschaal van venster afbeelding (hoger betekent lagere resolutie)"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Window Image Resolution Scale (higher means lower resolution)"
           }
         },
         "pl" : {
@@ -93432,16 +93438,16 @@
             "value" : "창 미리보기 레이아웃"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Window Preview Layout"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Voorvertoning venster lay-out"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Window Preview Layout"
           }
         },
         "pl" : {
@@ -93623,16 +93629,16 @@
             "value" : "창 미리보기 레이아웃 제한"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Window Preview Layout Limits"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Voorvertoning venster lay-out limieten"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Window Preview Layout Limits"
           }
         },
         "pl" : {
@@ -93813,16 +93819,16 @@
             "value" : "창 미리보기 크기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Window Preview Size"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Voorvertoning venster grootte"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Window Preview Size"
           }
         },
         "pl" : {
@@ -94004,16 +94010,16 @@
             "value" : "창 선택 배경색"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Window Selection Background Color"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Achtergrondkleur van venster selectie"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Window Selection Background Color"
           }
         },
         "pl" : {
@@ -94195,16 +94201,16 @@
             "value" : "창 선택 배경 불투명도"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Window Selection Background Opacity"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Achtergrond dekking van venster selectie"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Window Selection Background Opacity"
           }
         },
         "pl" : {
@@ -94386,16 +94392,16 @@
             "value" : "창 크기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Window Size"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Scherm Formaat"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Window Size"
           }
         },
         "pl" : {
@@ -94577,16 +94583,16 @@
             "value" : "윈도우 스위쳐"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Window Switcher"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Scherm Wisselaar"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Window Switcher"
           }
         },
         "pl" : {
@@ -94767,16 +94773,16 @@
             "value" : "창 전환기 사용자 지정"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Window Switcher Customization"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Aanpassing van venster schakelaar"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Window Switcher Customization"
           }
         },
         "pl" : {
@@ -94958,16 +94964,16 @@
             "value" : "창 전환기 전용"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Window Switcher only"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Alleen Scherm Wisselaar"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Window Switcher only"
           }
         },
         "pl" : {
@@ -95148,16 +95154,16 @@
             "value" : "창 전환기 배치"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Window Switcher Placement"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Plaatsing van de venster schakelaar"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Window Switcher Placement"
           }
         },
         "pl" : {
@@ -95338,16 +95344,16 @@
             "value" : "창 전환기 설정"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Window Switcher Settings"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Scherm wisselaar instellingen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Window Switcher Settings"
           }
         },
         "pl" : {
@@ -95528,13 +95534,13 @@
             "value" : "Window Switcher Shortcut"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Window Switcher Shortcut"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Window Switcher Shortcut"
@@ -95719,16 +95725,16 @@
             "value" : "창 제목 필터"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Window title filters"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Venstertitel filters"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Window title filters"
           }
         },
         "pl" : {
@@ -95909,16 +95915,16 @@
             "value" : "창 제목 필터"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Window Title Filters"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Venster titel filters"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Window Title Filters"
           }
         },
         "pl" : {
@@ -96100,16 +96106,16 @@
             "value" : "창 제목 위치"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Window Title Position"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Schermnaam Positie"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Window Title Position"
           }
         },
         "pl" : {
@@ -96290,16 +96296,16 @@
             "value" : "창 제목 가시성"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Window Title Visibility"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Schermnaam Zichtbaarheid"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Window Title Visibility"
           }
         },
         "pl" : {
@@ -96481,16 +96487,16 @@
             "value" : "미리보기의 창 제목"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Window Titles in Previews"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Venstertitels in Previews"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Window Titles in Previews"
           }
         },
         "pl" : {
@@ -96672,16 +96678,16 @@
             "value" : "창 전환 설정"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Windows switching settings"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Scherm wisselaar instellingen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Windows switching settings"
           }
         },
         "pl" : {
@@ -96863,16 +96869,16 @@
             "value" : "DockDoor의 작동을 위해 손쉬운 사용 권한을 허용해야 합니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "You need to give DockDoor access to the accessibility API in order for it to function."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "U moet DockDoor toegang geven tot de toegankelijkheids-API om deze te laten functioneren."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You need to give DockDoor access to the accessibility API in order for it to function."
           }
         },
         "pl" : {
@@ -97053,16 +97059,16 @@
             "value" : "앱 버전: %@"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your app is on version %@"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Je hebt app versie %@"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Your app is on version %@"
           }
         },
         "pl" : {
@@ -97244,16 +97250,16 @@
             "value" : "단축키가 설정됩니다(예: ⌘ + Tab)."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your shortcut will be set (e.g. ⌘ + Tab)"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Uw sneltoets wordt ingesteld (bijv. ⌘ + Tab)"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Your shortcut will be set (e.g. ⌘ + Tab)"
           }
         },
         "pl" : {
@@ -97434,16 +97440,16 @@
             "value" : "신호등이 자동으로 비활성화되도록 설정됩니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your traffic lights will be set to disabled automatically."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Uw verkeerslichten worden automatisch uitgeschakeld."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Your traffic lights will be set to disabled automatically."
           }
         },
         "pl" : {
@@ -97624,15 +97630,15 @@
             "value" : "Z"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Z"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Z"
           }
         },

--- a/DockDoor/Views/Hover Window/WindowPreview.swift
+++ b/DockDoor/Views/Hover Window/WindowPreview.swift
@@ -34,6 +34,7 @@ struct WindowPreview: View {
     @Default(.disableDockStyleTitles) var disableDockStyleTitles
     @Default(.hidePreviewCardBackground) var hidePreviewCardBackground
     @Default(.showMinimizedHiddenLabels) var showMinimizedHiddenLabels
+    @Default(.trafficLightOrHidden) var trafficLightOrHidden
 
     @Default(.tapEquivalentInterval) var tapEquivalentInterval
     @Default(.previewHoverAction) var previewHoverAction
@@ -119,7 +120,7 @@ struct WindowPreview: View {
 
         let hasTrafficLights = windowInfo.closeButton != nil &&
             trafficLightButtonsVisibility != .never &&
-            (showMinimizedHiddenLabels ? (!windowInfo.isMinimized && !windowInfo.isHidden) : true)
+            (!trafficLightOrHidden ? (!windowInfo.isMinimized && !windowInfo.isHidden) : true)
 
         let titleContent = Group {
             if hasTitle, let title = titleToShow {
@@ -296,7 +297,7 @@ struct WindowPreview: View {
                     onWindowAction: handleWindowAction,
                     pillStyling: true, mockPreviewActive: mockPreviewActive
                 )
-            } else if windowInfo.isMinimized || windowInfo.isHidden, showMinimizedHiddenLabels {
+            } else if windowInfo.isMinimized || windowInfo.isHidden, false {
                 Text(windowInfo.isMinimized ? "Minimized" : "Hidden")
                     .font(.subheadline)
                     .italic()
@@ -370,7 +371,7 @@ struct WindowPreview: View {
 
         let hasTrafficLights = windowInfo.closeButton != nil &&
             trafficLightButtonsVisibility != .never &&
-            (showMinimizedHiddenLabels ? (!windowInfo.isMinimized && !windowInfo.isHidden) : true)
+            (!trafficLightOrHidden ? (!windowInfo.isMinimized && !windowInfo.isHidden) : true)
 
         let titleContent = Group {
             if hasTitle, let title = titleToShow {

--- a/DockDoor/Views/Settings/AppearanceSettingsView.swift
+++ b/DockDoor/Views/Settings/AppearanceSettingsView.swift
@@ -111,6 +111,7 @@ struct AppearanceSettingsView: View {
     @Default(.disableDockStyleTrafficLights) var disableDockStyleTrafficLights
     @Default(.disableDockStyleTitles) var disableDockStyleTitles
     @Default(.showMinimizedHiddenLabels) var showMinimizedHiddenLabels
+    @Default(.trafficLightOrHidden) var trafficLightOrHidden
     @Default(.enableTitleMarquee) var enableTitleMarquee
 
     @State private var showAdvancedAppearanceSettings: Bool = false
@@ -224,6 +225,15 @@ struct AppearanceSettingsView: View {
                                     Text("Distinguish minimized/hidden windows")
                                 }
                                 Text("When enabled, shows visual indicators and dims minimized/hidden windows. When disabled, treats them as normal windows with full functionality.")
+                                    .font(.footnote)
+                                    .foregroundColor(.gray)
+                                    .padding(.leading, 20)
+                            }
+                            VStack(alignment: .leading) {
+                                Toggle(isOn: $trafficLightOrHidden) {
+                                    Text("Keep traffic Lights")
+                                }
+                                Text("When Toggled disable minimized text and keep traffic lights.")
                                     .font(.footnote)
                                     .foregroundColor(.gray)
                                     .padding(.leading, 20)

--- a/DockDoor/consts.swift
+++ b/DockDoor/consts.swift
@@ -86,6 +86,7 @@ extension Defaults.Keys {
     static let enabledTrafficLightButtons = Key<Set<WindowAction>>("enabledTrafficLightButtons", default: [.quit, .close, .minimize, .toggleFullScreen])
     static let useMonochromeTrafficLights = Key<Bool>("useMonochromeTrafficLights", default: false)
     static let showMinimizedHiddenLabels = Key<Bool>("showMinimizedHiddenLabels", default: true)
+    static let trafficLightOrHidden = Key<Bool>("trafficLightOrHidden", default: false)
 
     static let previewMaxColumns = Key<Int>("previewMaxColumns", default: 2) // For left/right dock
     static let previewMaxRows = Key<Int>("previewMaxRows", default: 1) // For bottom dock only


### PR DESCRIPTION
## Describe your changes
Added an option to toggle on and of trafficlights for minimized windows instead of displaying the minimized/hidden text when the distinguish minimized windows are toggled


## Related issue number(s) and link(s)

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] If this change affects core functionality, I have added a description highlighting the changes
- [ ] I have followed conventional commit guidelines

## Core Functionality Changes
If this PR modifies core functionality, please provide a brief description of the changes and their impact below:
One button added in the appearance page aswell that changes the behavior of trafficklight when the differiente is toggled