### PR TITLE
feat: Add CMD + Right Click to quit apps from dock

### DIFF
--- a/DockDoor/Utilities/DockObserver.swift
+++ b/DockDoor/Utilities/DockObserver.swift
@@ -549,9 +549,7 @@ final class DockObserver {
 
     private func handleCmdRightClickQuit(app: NSRunningApplication, event: CGEvent) {
         Task { @MainActor in
-            let shouldForceQuit = event.flags.contains(.maskAlternate)
-
-            if shouldForceQuit {
+            if event.flags.contains(.maskAlternate) {
                 app.forceTerminate()
             } else {
                 app.terminate()


### PR DESCRIPTION
Added new feature to allow users to quickly quit applications directly from the dock using CMD + Right Click on the app icon. This provides a faster alternative to opening the context menu and selecting quit (this was a feature that I used to love from HyperDock)

Features:
- CMD + Right Click on dock icon terminates the application
- CMD + Option + Right Click performs force quit
- Event is consumed to prevent context menu from appearing

Implementation:
- Modified event tap to capture both left and right mouse clicks
- Added handleCmdRightClickQuit() method to handle quit action
- Automatically purges app cache after termination

## Describe your changes

## Related issue number(s) and link(s)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] If this change affects core functionality, I have added a description highlighting the changes
- [x] I have followed conventional commit guidelines

## Core Functionality Changes
If this PR modifies core functionality, please provide a brief description of the changes and their impact below:
