### PR TITLE
feat: Add option to show windows from current Space only 

### DIFF
--- a/DockDoor/Localizable.xcstrings
+++ b/DockDoor/Localizable.xcstrings
@@ -15814,6 +15814,28 @@
         }
       }
     },
+    "Choose how windows are sorted in Cmd+Tab previews." : {
+
+    },
+    "Choose how windows are sorted in the preview." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选择预览中窗口的排序方式。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇預覽中視窗的排序方式。"
+          }
+        }
+      }
+    },
+    "Choose how windows are sorted in the window switcher." : {
+
+    },
     "Clear Logs" : {
 
     },
@@ -20381,6 +20403,23 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "控制視窗預覽的視覺細節和更新頻率。"
+          }
+        }
+      }
+    },
+    "Creation order (fixed)" : {
+      "comment" : "Window preview sort order option",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "创建顺序（固定）"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "創建順序（固定）"
           }
         }
       }
@@ -53338,6 +53377,22 @@
         }
       }
     },
+    "Only display windows that are in the current virtual desktop/Space." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "仅显示当前虚拟桌面/空间中的窗口。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "僅顯示當前虛擬桌面/空間中的視窗。"
+          }
+        }
+      }
+    },
     "Only show windows from the currently active/frontmost application." : {
       "localizations" : {
         "af" : {
@@ -64379,6 +64434,23 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "正在讀取App資訊…"
+          }
+        }
+      }
+    },
+    "Recently used" : {
+      "comment" : "Window preview sort order option",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最近使用"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最近使用"
           }
         }
       }
@@ -76568,7 +76640,24 @@
         }
       }
     },
+    "Show windows from current Space only" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "仅显示当前空间的窗口"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "僅顯示當前空間的視窗"
+          }
+        }
+      }
+    },
     "Shows last active window first, instead of current window." : {
+      "extractionState" : "stale",
       "localizations" : {
         "af" : {
           "stringUnit" : {
@@ -78664,6 +78753,9 @@
           }
         }
       }
+    },
+    "Start on second window in Switcher" : {
+
     },
     "Start recording keybind" : {
       "extractionState" : "stale",
@@ -88761,6 +88853,7 @@
       }
     },
     "Use Windows-style window ordering in Switcher" : {
+      "extractionState" : "stale",
       "localizations" : {
         "af" : {
           "stringUnit" : {
@@ -92571,6 +92664,9 @@
         }
       }
     },
+    "When opening the window switcher, highlight the second window instead of the first." : {
+
+    },
     "When Showing Dock Tile Previews" : {
       "comment" : "Preview window title condition option",
       "extractionState" : "stale",
@@ -96007,6 +96103,22 @@
         }
       }
     },
+    "Window sort order" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "窗口排序方式"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "視窗排序方式"
+          }
+        }
+      }
+    },
     "Window Switcher" : {
       "comment" : "Settings tab title",
       "localizations" : {
@@ -99246,5 +99358,5 @@
       }
     }
   },
-  "version" : "1.0"
+  "version" : "1.1"
 }

--- a/DockDoor/Utilities/DockObserver+CmdTab.swift
+++ b/DockDoor/Utilities/DockObserver+CmdTab.swift
@@ -131,7 +131,12 @@ extension DockObserver {
             do {
                 var windows: [WindowInfo] = []
                 if let app = resolvedApp {
-                    windows = try await WindowUtil.getActiveWindows(of: app)
+                    windows = try await WindowUtil.getActiveWindows(of: app, context: .cmdTab)
+
+                    // Filter by current space if enabled
+                    if Defaults[.showWindowsFromCurrentSpaceOnlyInCmdTab] {
+                        windows = await WindowUtil.filterWindowsByCurrentSpace(windows)
+                    }
                 }
 
                 let elementPos = try? selectedItem.element.position()

--- a/DockDoor/Utilities/DockObserver.swift
+++ b/DockDoor/Utilities/DockObserver.swift
@@ -201,6 +201,11 @@ final class DockObserver {
                     combinedWindows.append(contentsOf: windowsForInstance)
                 }
 
+                // Filter windows to only show those in the current Space if the setting is enabled
+                if Defaults[.showWindowsFromCurrentSpaceOnly] {
+                    combinedWindows = await WindowUtil.filterWindowsByCurrentSpace(combinedWindows)
+                }
+
                 lastHoveredPID = currentApp.processIdentifier
                 lastHoveredAppWasFrontmost = NSWorkspace.shared.frontmostApplication?.processIdentifier == currentApp.processIdentifier
                 lastHoveredAppNeedsRestore = currentApp.isHidden || combinedWindows.contains(where: \.isMinimized)

--- a/DockDoor/Utilities/KeybindHelper.swift
+++ b/DockDoor/Utilities/KeybindHelper.swift
@@ -52,7 +52,10 @@ private class WindowSwitchingCoordinator {
     private func initializeWindowSwitching(
         previewCoordinator: SharedPreviewWindowCoordinator
     ) async {
-        let windows = WindowUtil.getAllWindowsOfAllApps()
+        var windows = WindowUtil.getAllWindowsOfAllApps()
+        if Defaults[.showWindowsFromCurrentSpaceOnlyInSwitcher] {
+            windows = await WindowUtil.filterWindowsByCurrentSpace(windows)
+        }
         guard !windows.isEmpty else { return }
 
         currentSessionId = UUID()

--- a/DockDoor/Views/Settings/MainSettingsView.swift
+++ b/DockDoor/Views/Settings/MainSettingsView.swift
@@ -85,6 +85,12 @@ struct MainSettingsView: View {
     @Default(.enableWindowSwitcher) var enableWindowSwitcher
     @Default(.enableWindowSwitcherSearch) var enableWindowSwitcherSearch
     @Default(.enableDockPreviews) var enableDockPreviews
+    @Default(.showWindowsFromCurrentSpaceOnly) var showWindowsFromCurrentSpaceOnly
+    @Default(.windowPreviewSortOrder) var windowPreviewSortOrder
+    @Default(.showWindowsFromCurrentSpaceOnlyInSwitcher) var showWindowsFromCurrentSpaceOnlyInSwitcher
+    @Default(.windowSwitcherSortOrder) var windowSwitcherSortOrder
+    @Default(.showWindowsFromCurrentSpaceOnlyInCmdTab) var showWindowsFromCurrentSpaceOnlyInCmdTab
+    @Default(.cmdTabSortOrder) var cmdTabSortOrder
     @Default(.keepPreviewOnAppTerminate) var keepPreviewOnAppTerminate
     @Default(.enableCmdTabEnhancements) var enableCmdTabEnhancements
     @Default(.scrollToMouseHoverInSwitcher) var scrollToMouseHoverInSwitcher
@@ -389,6 +395,27 @@ struct MainSettingsView: View {
                         .foregroundColor(.secondary)
                         .padding(.leading, 20)
                     if enableDockPreviews {
+                        Toggle(isOn: $showWindowsFromCurrentSpaceOnly) { Text("Show windows from current Space only") }
+                            .padding(.leading, 20)
+                        Text("Only display windows that are in the current virtual desktop/Space.")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                            .padding(.leading, 40)
+
+                        Text("Window sort order")
+                            .padding(.leading, 20)
+                        Picker("", selection: $windowPreviewSortOrder) {
+                            ForEach(WindowPreviewSortOrder.allCases) { order in
+                                Text(order.localizedName).tag(order)
+                            }
+                        }
+                        .pickerStyle(.menu)
+                        .padding(.leading, 40)
+                        Text("Choose how windows are sorted in the preview.")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                            .padding(.leading, 40)
+
                         Toggle(isOn: $keepPreviewOnAppTerminate) { Text("Keep preview when app terminates") }
                             .padding(.leading, 20)
                         Text("When an app terminates, remove only its windows from the preview instead of hiding the entire preview.")
@@ -420,14 +447,33 @@ struct MainSettingsView: View {
                                 .font(.caption)
                                 .foregroundColor(.secondary)
                                 .padding(.leading, 20)
-                            Toggle(isOn: $useClassicWindowOrdering) { Text("Use Windows-style window ordering in Switcher") }
-                            Text("Shows last active window first, instead of current window.")
+                            Toggle(isOn: $useClassicWindowOrdering) { Text("Start on second window in Switcher") }
+                            Text("When opening the window switcher, highlight the second window instead of the first.")
                                 .font(.caption)
                                 .foregroundColor(.secondary)
                                 .padding(.leading, 20)
 
                             Toggle(isOn: $limitSwitcherToFrontmostApp) { Text("Limit Window Switcher to active app only") }
                             Text("Only show windows from the currently active/frontmost application.")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                                .padding(.leading, 20)
+
+                            Toggle(isOn: $showWindowsFromCurrentSpaceOnlyInSwitcher) { Text("Show windows from current Space only") }
+                            Text("Only display windows that are in the current virtual desktop/Space.")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                                .padding(.leading, 20)
+
+                            Text("Window sort order")
+                            Picker("", selection: $windowSwitcherSortOrder) {
+                                ForEach(WindowPreviewSortOrder.allCases) { order in
+                                    Text(order.localizedName).tag(order)
+                                }
+                            }
+                            .pickerStyle(.menu)
+                            .padding(.leading, 20)
+                            Text("Choose how windows are sorted in the window switcher.")
                                 .font(.caption)
                                 .foregroundColor(.secondary)
                                 .padding(.leading, 20)
@@ -449,6 +495,29 @@ struct MainSettingsView: View {
                     .font(.caption)
                     .foregroundColor(.secondary)
                     .padding(.leading, 20)
+
+                    if enableCmdTabEnhancements {
+                        Toggle(isOn: $showWindowsFromCurrentSpaceOnlyInCmdTab) { Text("Show windows from current Space only") }
+                            .padding(.leading, 20)
+                        Text("Only display windows that are in the current virtual desktop/Space.")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                            .padding(.leading, 40)
+
+                        Text("Window sort order")
+                            .padding(.leading, 20)
+                        Picker("", selection: $cmdTabSortOrder) {
+                            ForEach(WindowPreviewSortOrder.allCases) { order in
+                                Text(order.localizedName).tag(order)
+                            }
+                        }
+                        .pickerStyle(.menu)
+                        .padding(.leading, 40)
+                        Text("Choose how windows are sorted in Cmd+Tab previews.")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                            .padding(.leading, 40)
+                    }
                 }
 
                 HStack {

--- a/DockDoor/consts.swift
+++ b/DockDoor/consts.swift
@@ -52,6 +52,12 @@ extension Defaults.Keys {
     static let gradientColorPalette = Key<GradientColorPaletteSettings>("gradientColorPalette", default: .init())
     static let enableWindowSwitcher = Key<Bool>("enableWindowSwitcher", default: true)
     static let enableDockPreviews = Key<Bool>("enableDockPreviews", default: true)
+    static let showWindowsFromCurrentSpaceOnly = Key<Bool>("showWindowsFromCurrentSpaceOnly", default: false)
+    static let windowPreviewSortOrder = Key<WindowPreviewSortOrder>("windowPreviewSortOrder", default: .recentlyUsed)
+    static let showWindowsFromCurrentSpaceOnlyInSwitcher = Key<Bool>("showWindowsFromCurrentSpaceOnlyInSwitcher", default: false)
+    static let windowSwitcherSortOrder = Key<WindowPreviewSortOrder>("windowSwitcherSortOrder", default: .recentlyUsed)
+    static let showWindowsFromCurrentSpaceOnlyInCmdTab = Key<Bool>("showWindowsFromCurrentSpaceOnlyInCmdTab", default: false)
+    static let cmdTabSortOrder = Key<WindowPreviewSortOrder>("cmdTabSortOrder", default: .recentlyUsed)
     static let enableCmdTabEnhancements = Key<Bool>("enableCmdTabEnhancements", default: false)
     static let scrollToMouseHoverInSwitcher = Key<Bool>("scrollToMouseHoverInSwitcher", default: false)
     static let keepPreviewOnAppTerminate = Key<Bool>("keepPreviewOnAppTerminate", default: false)
@@ -337,6 +343,22 @@ enum DockClickAction: String, CaseIterable, Defaults.Serializable {
             String(localized: "Minimize windows", comment: "Dock click action option")
         case .hide:
             String(localized: "Hide application", comment: "Dock click action option")
+        }
+    }
+}
+
+enum WindowPreviewSortOrder: String, CaseIterable, Defaults.Serializable, Identifiable {
+    case recentlyUsed
+    case creationOrder
+
+    var id: String { rawValue }
+
+    var localizedName: String {
+        switch self {
+        case .recentlyUsed:
+            String(localized: "Recently used", comment: "Window preview sort order option")
+        case .creationOrder:
+            String(localized: "Creation order (fixed)", comment: "Window preview sort order option")
         }
     }
 }


### PR DESCRIPTION
## Description
Add a new option to show only windows from the current Space (virtual desktop) when hovering over Dock icons.

## Changes
- Added new setting "Show windows from current Space only" under Dock Previews, window switcher, and cmd tab section
- Windows are filtered based on their Space ID
- Minimized/hidden windows are also filtered by their associated Space


## How to test
1. Enable "Show windows from current Space only" in Settings > Dock Previews
2. Open windows of the same app in different Spaces
3. Hover over the app icon in Dock
4. Only windows from the current Space should be shown