### PR TITLE
feat: add granular live preview settings and improve mouse hover selection

### DIFF
--- a/DockDoor/Localizable.xcstrings
+++ b/DockDoor/Localizable.xcstrings
@@ -4787,6 +4787,18 @@
         }
       }
     },
+    "5 FPS (Battery Saver)" : {
+
+    },
+    "10 FPS" : {
+
+    },
+    "15 FPS" : {
+
+    },
+    "24 FPS (Film)" : {
+
+    },
     "30 FPS" : {
 
     },
@@ -7855,6 +7867,12 @@
     },
     "All Windows" : {
       "comment" : "Switcher invocation mode"
+    },
+    "All windows from the hovered app get live preview" : {
+
+    },
+    "All windows get live preview (may cause lag with many windows)" : {
+
     },
     "Allow dynamic image sizing" : {
       "localizations" : {
@@ -25804,6 +25822,9 @@
         }
       }
     },
+    "Dock Frame Rate" : {
+
+    },
     "Dock Preview Aero Shake Action" : {
       "localizations" : {
         "af" : {
@@ -27709,6 +27730,9 @@
           }
         }
       }
+    },
+    "Dock Quality" : {
+
     },
     "DockDoor does not record your screen or audio. It only captures static window previews. No information is stored or shared; all processing occurs privately on your device." : {
       "localizations" : {
@@ -29996,6 +30020,12 @@
     "Enable dock scroll gestures" : {
 
     },
+    "Enable for Dock Preview" : {
+
+    },
+    "Enable for Window Switcher" : {
+
+    },
     "Enable gestures in window switcher" : {
 
     },
@@ -30194,6 +30224,9 @@
       }
     },
     "Enable Live Preview (Video)" : {
+
+    },
+    "Enable mouse hover selection" : {
 
     },
     "Enable Pinning" : {
@@ -39768,10 +39801,10 @@
         }
       }
     },
-    "High" : {
+    "High (960px)" : {
 
     },
-    "Higher quality and frame rate use more CPU/GPU resources." : {
+    "Higher quality and frame rate use more CPU/GPU resources. Use lower settings for Window Switcher if you experience lag." : {
 
     },
     "Highlight Gradient Colors" : {
@@ -40348,6 +40381,12 @@
           }
         }
       }
+    },
+    "Hovered App's Windows" : {
+
+    },
+    "Hovered Window Only" : {
+
     },
     "How to Set Up" : {
       "extractionState" : "stale",
@@ -45890,12 +45929,6 @@
         }
       }
     },
-    "Live Preview Frame Rate" : {
-
-    },
-    "Live Preview Quality" : {
-
-    },
     "Loading lyrics..." : {
       "localizations" : {
         "af" : {
@@ -46465,6 +46498,9 @@
           }
         }
       }
+    },
+    "Low (480px)" : {
+
     },
     "Lower values make gestures more sensitive. Higher values require longer swipes. Applies to both dock previews and window switcher." : {
 
@@ -50106,6 +50142,9 @@
           }
         }
       }
+    },
+    "Native (Best)" : {
+
     },
     "Navigate to Settings → Privacy & Security" : {
       "localizations" : {
@@ -55248,6 +55287,9 @@
           }
         }
       }
+    },
+    "Only the window under the mouse gets live preview" : {
+
     },
     "Open Accessibility Settings" : {
       "extractionState" : "stale",
@@ -69731,7 +69773,7 @@
         }
       }
     },
-    "Retina (Best)" : {
+    "Retina (1280px)" : {
 
     },
     "Return" : {
@@ -73931,6 +73973,9 @@
           }
         }
       }
+    },
+    "Select windows by hovering with mouse." : {
+
     },
     "Selected app:" : {
       "localizations" : {
@@ -80633,6 +80678,9 @@
         }
       }
     },
+    "Standard (640px)" : {
+
+    },
     "Start on second window in Switcher" : {
       "localizations" : {
         "af" : {
@@ -82736,6 +82784,15 @@
     "Swipe up or down on window previews in the keyboard-activated window switcher. Only vertical swipes are recognized." : {
 
     },
+    "Switcher Frame Rate" : {
+
+    },
+    "Switcher Live Preview Scope" : {
+
+    },
+    "Switcher Quality" : {
+
+    },
     "Tab" : {
       "localizations" : {
         "af" : {
@@ -84455,6 +84512,9 @@
           }
         }
       }
+    },
+    "Thumbnail (320px)" : {
+
     },
     "Tiny (1/%lld)" : {
       "extractionState" : "stale",

--- a/DockDoor/Utilities/Window Management/WindowInfo.swift
+++ b/DockDoor/Utilities/Window Management/WindowInfo.swift
@@ -285,6 +285,14 @@ extension WindowInfo {
     }
 
     func bringToFront() {
+        // Must run on main thread - AX operations trigger AppKit calls that require it
+        guard Thread.isMainThread else {
+            DispatchQueue.main.async { [self] in
+                bringToFront()
+            }
+            return
+        }
+
         let maxRetries = 3
         var retryCount = 0
 
@@ -316,7 +324,7 @@ extension WindowInfo {
             }
             retryCount += 1
             if retryCount < maxRetries {
-                usleep(50000)
+                usleep(20000)
             }
         }
 

--- a/DockDoor/Utilities/WindowSwitcherStateManager.swift
+++ b/DockDoor/Utilities/WindowSwitcherStateManager.swift
@@ -70,6 +70,11 @@ final class WindowSwitcherStateManager: ObservableObject {
         }
     }
 
+    func setCurrentIndex(_ index: Int) {
+        guard index >= -1, index < windowIDs.count else { return }
+        currentIndex = index
+    }
+
     func cycleForward() {
         guard !windowIDs.isEmpty else { return }
 

--- a/DockDoor/Views/Hover Window/Shared Components/FullSizePreviewView.swift
+++ b/DockDoor/Views/Hover Window/Shared Components/FullSizePreviewView.swift
@@ -6,13 +6,16 @@ struct FullSizePreviewView: View {
     let windowSize: CGSize
     @Default(.uniformCardRadius) var uniformCardRadius
     @Default(.enableLivePreview) var enableLivePreview
+    @Default(.enableLivePreviewForDock) var enableLivePreviewForDock
+    @Default(.dockLivePreviewQuality) var dockLivePreviewQuality
+    @Default(.dockLivePreviewFrameRate) var dockLivePreviewFrameRate
 
     var body: some View {
-        let useLivePreview = enableLivePreview && !windowInfo.isMinimized && !windowInfo.isHidden
+        let useLivePreview = enableLivePreview && enableLivePreviewForDock && !windowInfo.isMinimized && !windowInfo.isHidden
 
         Group {
             if useLivePreview {
-                LivePreviewImage(windowID: windowInfo.id, fallbackImage: windowInfo.image)
+                LivePreviewImage(windowID: windowInfo.id, fallbackImage: windowInfo.image, quality: dockLivePreviewQuality, frameRate: dockLivePreviewFrameRate)
                     .aspectRatio(windowSize, contentMode: .fit)
             } else if let image = windowInfo.image {
                 Image(decorative: image, scale: 1.0)

--- a/DockDoor/Views/Hover Window/WindowPreview Supporting/PreviewStateCoordinator.swift
+++ b/DockDoor/Views/Hover Window/WindowPreview Supporting/PreviewStateCoordinator.swift
@@ -1,9 +1,21 @@
 import Defaults
 import SwiftUI
 
-// Pure UI state container for window preview presentation
+extension Notification.Name {
+    static let mouseHoverSelectionChanged = Notification.Name("mouseHoverSelectionChanged")
+}
+
+/// Pure UI state container for window preview presentation.
 class PreviewStateCoordinator: ObservableObject {
-    @Published var currIndex: Int = -1
+    // MARK: - Selection State
+
+    @Published var focusedIndex: Int = -1
+    @Published var hoveredIndex: Int?
+
+    var currIndex: Int { focusedIndex }
+
+    // MARK: - Window State
+
     @Published var windowSwitcherActive: Bool = false
     @Published var fullWindowPreviewActive: Bool = false
     @Published var windows: [WindowInfo] = []
@@ -22,9 +34,112 @@ class PreviewStateCoordinator: ObservableObject {
         !searchQuery.isEmpty
     }
 
+    // MARK: - Layout State
+
     @Published var overallMaxPreviewDimension: CGPoint = .zero
     @Published var windowDimensionsMap: [Int: WindowPreviewHoverContainer.WindowDimensions] = [:]
     private var lastKnownBestGuessMonitor: NSScreen?
+
+    // MARK: - Activity Tracking
+
+    enum ActivityType {
+        case none
+        case keyboard
+        case mouse
+    }
+
+    private(set) var lastActivityType: ActivityType = .none
+
+    private func postMouseHoverNotification() {
+        NotificationCenter.default.post(name: .mouseHoverSelectionChanged, object: nil)
+    }
+
+    // MARK: - Mouse Hover Tracking
+
+    private var initialMousePosition: CGPoint?
+    private(set) var isMouseHoverEnabled: Bool = false
+    private let mouseMovementThreshold: CGFloat = 0.001
+    private var pendingHoverIndex: Int?
+    private var mouseMovedMonitor: Any?
+    private var hasNotifiedMouseActivity: Bool = false
+
+    @MainActor
+    func recordInitialMousePosition() {
+        initialMousePosition = NSEvent.mouseLocation
+        isMouseHoverEnabled = false
+        pendingHoverIndex = nil
+        startMouseMovedMonitor()
+    }
+
+    @MainActor
+    private func startMouseMovedMonitor() {
+        stopMouseMovedMonitor()
+        mouseMovedMonitor = NSEvent.addLocalMonitorForEvents(matching: .mouseMoved) { [weak self] event in
+            self?.handleMouseMoved()
+            return event
+        }
+    }
+
+    @MainActor
+    private func stopMouseMovedMonitor() {
+        if let monitor = mouseMovedMonitor {
+            NSEvent.removeMonitor(monitor)
+            mouseMovedMonitor = nil
+        }
+    }
+
+    @MainActor
+    private func handleMouseMoved() {
+        guard windowSwitcherActive else {
+            stopMouseMovedMonitor()
+            return
+        }
+
+        if !isMouseHoverEnabled {
+            _ = checkAndEnableMouseHover()
+        } else if let hoverIdx = hoveredIndex, !hasNotifiedMouseActivity {
+            lastActivityType = .mouse
+            focusedIndex = hoverIdx
+            hasNotifiedMouseActivity = true
+            postMouseHoverNotification()
+        }
+    }
+
+    @MainActor
+    func checkAndEnableMouseHover() -> Bool {
+        guard !isMouseHoverEnabled else { return true }
+        guard let initial = initialMousePosition else {
+            isMouseHoverEnabled = true
+            return true
+        }
+
+        let current = NSEvent.mouseLocation
+        let dx = abs(current.x - initial.x)
+        let dy = abs(current.y - initial.y)
+
+        if dx > mouseMovementThreshold || dy > mouseMovementThreshold {
+            isMouseHoverEnabled = true
+            if let pending = pendingHoverIndex {
+                setIndex(to: pending, source: .mouse)
+                pendingHoverIndex = nil
+            }
+            return true
+        }
+        return false
+    }
+
+    @MainActor
+    func setPendingHoverIndex(_ index: Int?) {
+        pendingHoverIndex = index
+    }
+
+    @MainActor
+    func resetMouseHoverTracking() {
+        initialMousePosition = nil
+        isMouseHoverEnabled = false
+        pendingHoverIndex = nil
+        stopMouseMovedMonitor()
+    }
 
     enum WindowState {
         case windowSwitcher
@@ -47,7 +162,12 @@ class PreviewStateCoordinator: ObservableObject {
             return
         }
 
-        // If window switcher state changed and we have windows, recalculate dimensions
+        if !oldSwitcherState, windowSwitcherActive {
+            recordInitialMousePosition()
+        } else if oldSwitcherState, !windowSwitcherActive {
+            resetMouseHoverTracking()
+        }
+
         if oldSwitcherState != windowSwitcherActive, !windows.isEmpty {
             if let monitor = lastKnownBestGuessMonitor {
                 let dockPosition = DockUtils.getDockPosition()
@@ -57,12 +177,44 @@ class PreviewStateCoordinator: ObservableObject {
     }
 
     @MainActor
-    func setIndex(to: Int, shouldScroll: Bool = true) {
+    func setIndex(to: Int, shouldScroll: Bool = true, source: ActivityType = .keyboard) {
         shouldScrollToIndex = shouldScroll
-        if to >= 0, to < windows.count {
-            currIndex = to
-        } else {
-            currIndex = -1
+        lastActivityType = source
+
+        let validIndex = (to >= 0 && to < windows.count) ? to : -1
+
+        switch source {
+        case .keyboard, .none:
+            focusedIndex = validIndex
+            hasNotifiedMouseActivity = false
+        case .mouse:
+            focusedIndex = validIndex
+            hoveredIndex = validIndex >= 0 ? validIndex : nil
+            hasNotifiedMouseActivity = true
+            postMouseHoverNotification()
+        }
+    }
+
+    @MainActor
+    func setFocusedIndex(to: Int, shouldScroll: Bool = true) {
+        setIndex(to: to, shouldScroll: shouldScroll, source: .keyboard)
+    }
+
+    @MainActor
+    func setHoveredIndex(to: Int?) {
+        lastActivityType = .mouse
+        hoveredIndex = to
+        if let index = to {
+            focusedIndex = index
+            postMouseHoverNotification()
+        }
+    }
+
+    @MainActor
+    func clearHoveredIndex() {
+        hoveredIndex = nil
+        if lastActivityType == .mouse {
+            lastActivityType = .keyboard
         }
     }
 
@@ -71,8 +223,11 @@ class PreviewStateCoordinator: ObservableObject {
         windows = newWindows
         lastKnownBestGuessMonitor = bestGuessMonitor
 
-        if currIndex >= windows.count {
-            currIndex = windows.isEmpty ? -1 : windows.count - 1
+        if focusedIndex >= windows.count {
+            focusedIndex = windows.isEmpty ? -1 : windows.count - 1
+        }
+        if let hovered = hoveredIndex, hovered >= windows.count {
+            hoveredIndex = nil
         }
 
         recomputeAndPublishDimensions(dockPosition: dockPosition, bestGuessMonitor: bestGuessMonitor, isMockPreviewActive: isMockPreviewActive)
@@ -88,23 +243,33 @@ class PreviewStateCoordinator: ObservableObject {
     func removeWindow(at indexToRemove: Int) {
         guard indexToRemove >= 0, indexToRemove < windows.count else { return }
 
-        let oldCurrIndex = currIndex
+        let oldFocusedIndex = focusedIndex
         windows.remove(at: indexToRemove)
 
         if windows.isEmpty {
-            currIndex = -1
+            focusedIndex = -1
+            hoveredIndex = nil
             SharedPreviewWindowCoordinator.activeInstance?.hideWindow()
             return
         }
 
-        if oldCurrIndex == indexToRemove {
-            currIndex = min(indexToRemove, windows.count - 1)
-        } else if oldCurrIndex > indexToRemove {
-            currIndex = oldCurrIndex - 1
+        if oldFocusedIndex == indexToRemove {
+            focusedIndex = min(indexToRemove, windows.count - 1)
+        } else if oldFocusedIndex > indexToRemove {
+            focusedIndex = oldFocusedIndex - 1
         }
 
-        if currIndex >= windows.count {
-            currIndex = windows.count - 1
+        if focusedIndex >= windows.count {
+            focusedIndex = windows.count - 1
+        }
+
+        // Clear hovered index if it was the removed window
+        if let hovered = hoveredIndex {
+            if hovered == indexToRemove {
+                hoveredIndex = nil
+            } else if hovered > indexToRemove {
+                hoveredIndex = hovered - 1
+            }
         }
 
         // Recompute dimensions after removing window
@@ -150,7 +315,8 @@ class PreviewStateCoordinator: ObservableObject {
     @MainActor
     func removeAllWindows() {
         windows.removeAll()
-        currIndex = -1 // Reset to no selection
+        focusedIndex = -1
+        hoveredIndex = nil
         SharedPreviewWindowCoordinator.activeInstance?.hideWindow()
     }
 
@@ -184,13 +350,15 @@ class PreviewStateCoordinator: ObservableObject {
     @MainActor
     private func updateIndexForSearch() {
         if !hasActiveSearch {
-            if currIndex >= windows.count {
-                currIndex = windows.isEmpty ? -1 : 0
+            if focusedIndex >= windows.count {
+                focusedIndex = windows.isEmpty ? -1 : 0
             }
         } else {
             let filtered = filteredWindowIndices()
-            currIndex = filtered.first ?? -1
+            focusedIndex = filtered.first ?? -1
         }
+        // Clear hover when search changes
+        hoveredIndex = nil
     }
 
     /// Returns the indices of windows that match the current search query.

--- a/DockDoor/Views/Settings/MainSettingsView.swift
+++ b/DockDoor/Views/Settings/MainSettingsView.swift
@@ -96,6 +96,7 @@ struct MainSettingsView: View {
     @Default(.sortMinimizedToEnd) var sortMinimizedToEnd
     @Default(.keepPreviewOnAppTerminate) var keepPreviewOnAppTerminate
     @Default(.enableCmdTabEnhancements) var enableCmdTabEnhancements
+    @Default(.enableMouseHoverInSwitcher) var enableMouseHoverInSwitcher
     @Default(.scrollToMouseHoverInSwitcher) var scrollToMouseHoverInSwitcher
     @Default(.includeHiddenWindowsInSwitcher) var includeHiddenWindowsInSwitcher
     @Default(.useClassicWindowOrdering) var useClassicWindowOrdering
@@ -122,8 +123,13 @@ struct MainSettingsView: View {
     @Default(.windowPreviewImageScale) var windowPreviewImageScale
     @Default(.windowImageCaptureQuality) var windowImageCaptureQuality
     @Default(.enableLivePreview) var enableLivePreview
-    @Default(.livePreviewQuality) var livePreviewQuality
-    @Default(.livePreviewFrameRate) var livePreviewFrameRate
+    @Default(.enableLivePreviewForDock) var enableLivePreviewForDock
+    @Default(.enableLivePreviewForWindowSwitcher) var enableLivePreviewForWindowSwitcher
+    @Default(.dockLivePreviewQuality) var dockLivePreviewQuality
+    @Default(.dockLivePreviewFrameRate) var dockLivePreviewFrameRate
+    @Default(.windowSwitcherLivePreviewQuality) var windowSwitcherLivePreviewQuality
+    @Default(.windowSwitcherLivePreviewFrameRate) var windowSwitcherLivePreviewFrameRate
+    @Default(.windowSwitcherLivePreviewScope) var windowSwitcherLivePreviewScope
     @Default(.bufferFromDock) var bufferFromDock
     @Default(.shouldHideOnDockItemClick) var shouldHideOnDockItemClick
     @Default(.dockClickAction) var dockClickAction
@@ -459,7 +465,14 @@ struct MainSettingsView: View {
                                 get: { !preventSwitcherHide },
                                 set: { preventSwitcherHide = !$0 }
                             )) { Text("Release initializer key to select window in Switcher") }
+                            Toggle(isOn: $enableMouseHoverInSwitcher) { Text("Enable mouse hover selection") }
+                            Text("Select windows by hovering with mouse.")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                                .padding(.leading, 20)
+
                             Toggle(isOn: $scrollToMouseHoverInSwitcher) { Text("Scroll to window on mouse hover") }
+                                .disabled(!enableMouseHoverInSwitcher)
                             Text("Automatically scrolls the window switcher when hovering over windows with the mouse.")
                                 .font(.caption)
                                 .foregroundColor(.secondary)
@@ -707,23 +720,72 @@ struct MainSettingsView: View {
                         .padding(.leading, 20)
 
                     if enableLivePreview {
-                        Picker("Live Preview Quality", selection: $livePreviewQuality) {
-                            ForEach(LivePreviewQuality.allCases, id: \.self) { quality in
-                                Text(quality.localizedName).tag(quality)
-                            }
-                        }
-                        .pickerStyle(MenuPickerStyle())
-                        .padding(.leading, 20)
+                        // MARK: - Dock Live Preview Settings
 
-                        Picker("Live Preview Frame Rate", selection: $livePreviewFrameRate) {
-                            ForEach(LivePreviewFrameRate.allCases, id: \.self) { fps in
-                                Text(fps.localizedName).tag(fps)
-                            }
-                        }
-                        .pickerStyle(MenuPickerStyle())
-                        .padding(.leading, 20)
+                        Toggle(isOn: $enableLivePreviewForDock) { Text("Enable for Dock Preview") }
+                            .padding(.leading, 20)
 
-                        Text("Higher quality and frame rate use more CPU/GPU resources.")
+                        if enableLivePreviewForDock {
+                            Picker("Dock Quality", selection: $dockLivePreviewQuality) {
+                                ForEach(LivePreviewQuality.allCases, id: \.self) { quality in
+                                    Text(quality.localizedName).tag(quality)
+                                }
+                            }
+                            .pickerStyle(MenuPickerStyle())
+                            .padding(.leading, 40)
+
+                            Picker("Dock Frame Rate", selection: $dockLivePreviewFrameRate) {
+                                ForEach(LivePreviewFrameRate.allCases, id: \.self) { fps in
+                                    Text(fps.localizedName).tag(fps)
+                                }
+                            }
+                            .pickerStyle(MenuPickerStyle())
+                            .padding(.leading, 40)
+                        }
+
+                        Divider()
+                            .padding(.leading, 20)
+
+                        // MARK: - Window Switcher Live Preview Settings
+
+                        Toggle(isOn: $enableLivePreviewForWindowSwitcher) { Text("Enable for Window Switcher") }
+                            .padding(.leading, 20)
+
+                        if enableLivePreviewForWindowSwitcher {
+                            Picker("Switcher Quality", selection: $windowSwitcherLivePreviewQuality) {
+                                ForEach(LivePreviewQuality.allCases, id: \.self) { quality in
+                                    Text(quality.localizedName).tag(quality)
+                                }
+                            }
+                            .pickerStyle(MenuPickerStyle())
+                            .padding(.leading, 40)
+
+                            Picker("Switcher Frame Rate", selection: $windowSwitcherLivePreviewFrameRate) {
+                                ForEach(LivePreviewFrameRate.allCases, id: \.self) { fps in
+                                    Text(fps.localizedName).tag(fps)
+                                }
+                            }
+                            .pickerStyle(MenuPickerStyle())
+                            .padding(.leading, 40)
+
+                            Picker("Switcher Live Preview Scope", selection: $windowSwitcherLivePreviewScope) {
+                                ForEach(WindowSwitcherLivePreviewScope.allCases, id: \.self) { scope in
+                                    Text(scope.localizedName).tag(scope)
+                                }
+                            }
+                            .pickerStyle(MenuPickerStyle())
+                            .padding(.leading, 40)
+
+                            Text(windowSwitcherLivePreviewScope.localizedDescription)
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                                .padding(.leading, 40)
+                        }
+
+                        Divider()
+                            .padding(.leading, 20)
+
+                        Text("Higher quality and frame rate use more CPU/GPU resources. Use lower settings for Window Switcher if you experience lag.")
                             .font(.caption)
                             .foregroundColor(.secondary)
                             .padding(.leading, 20)


### PR DESCRIPTION
## Summary

This PR enhances Window Switcher performance and user experience by introducing granular live preview controls and improving mouse hover selection behavior.

## Why These Changes Are Combined

These features were developed and tested together because they are **interdependent**:

1. **Live preview scope** (`hoveredWindowOnly`, `hoveredAppWindows`, `allWindows`) directly uses `hoveredIndex` and `focusedIndex` from the mouse hover system
2. **Testing live preview performance** requires mouse hover functionality to switch between windows
3. **Both features address the same core issue**: Window Switcher can become laggy when live preview is enabled, and users need tools to find their optimal balance

**Without live preview:** Window Switcher runs smoothly and responsively.
**With live preview at high settings:** Mouse hover and Tab cycling can become laggy.

By providing granular controls, users can configure settings based on their hardware capabilities.

---

## Changes

### 🎬 Live Preview Enhancements

**Separate controls for Dock and Window Switcher:**

| Setting | Dock Default | Switcher Default |
|---------|--------------|------------------|
| Enabled | ✅ On | ❌ Off |
| Quality | High | Low |
| Frame Rate | 24 FPS | 10 FPS |

**Quality Options:** Thumbnail (320px), Low (480px), Standard (640px), High (960px), Retina (1280px), Native (Best)

**Frame Rate Options:** 5, 10, 15, 24, 30, 60, 120 FPS

**Window Switcher Live Preview Scope:**
| Option | Description | Performance Impact |
|--------|-------------|-------------------|
| Hovered Window Only | Only selected window gets live preview | Minimal |
| Hovered App's Windows | All windows from selected app get live preview | Moderate (default) |
| All Windows | Every window gets live preview | May cause lag with many windows |

---

### 🖱️ Mouse Hover Selection Improvements

**Problem from previous PR (#890):** Confusing dual selection states where both keyboard and mouse could highlight different windows simultaneously.

**New Behavior:**

| Scenario | Behavior |
|----------|----------|
| Switcher opens | Keyboard selection active, mouse hover disabled until movement detected |
| Mouse moves | Mouse hover becomes active, selection follows cursor |
| Mouse stops, Tab pressed | Keyboard takes over from current position |
| Mouse moves again | Mouse hover resumes |

**Key Improvements:**
- **Single selected window** - Only one window highlighted at a time, no confusion
- **Activity-based precedence** - Last input type (keyboard or mouse) determines active selection
- **Movement threshold detection** - Prevents accidental selection when switcher opens under cursor
- **Keyboard continuity** - When mouse stops, keyboard navigation continues from current position (index not reset)

---

### ⚡ Performance Optimizations

| Change | Before | After | Benefit |
|--------|--------|-------|---------|
| Hover transition animation | Always 0.175s | Respects `showAnimations` setting | Accessibility + snappier feel when disabled |
| `bringToFront` retry sleep | 50ms | 20ms | Faster window activation |
| Main thread safety | Not checked | AX operations check `Thread.isMainThread` | Prevents potential crashes |
| Switcher live preview | N/A | Disabled by default, Low quality, 10 FPS | Smooth out-of-box experience |

---

## Technical Notes

**Why `DispatchQueue.main.async` instead of `Task { @MainActor }`?**
- Lower overhead for Timer callbacks
- More predictable execution in event handling context

**Why NotificationCenter for mouse hover coordination?**
- Loose coupling between `KeybindHelper` and `PreviewStateCoordinator`
- Allows keyboard repeat timers to stop when mouse takes over without tight dependencies

**Why movement threshold of 0.001?**
- Detects any intentional mouse movement
- Prevents false activation when switcher appears under stationary cursor

---

## New Settings

| Key | Type | Default | Description |
|-----|------|---------|-------------|
| `enableMouseHoverInSwitcher` | Bool | `true` | Enable mouse hover selection in Window Switcher |
| `enableLivePreviewForDock` | Bool | `true` | Enable live preview for Dock hover |
| `enableLivePreviewForWindowSwitcher` | Bool | `false` | Enable live preview for Window Switcher |
| `dockLivePreviewQuality` | Enum | `.high` | Dock preview quality |
| `dockLivePreviewFrameRate` | Enum | `.fps24` | Dock preview frame rate |
| `windowSwitcherLivePreviewQuality` | Enum | `.low` | Switcher preview quality |
| `windowSwitcherLivePreviewFrameRate` | Enum | `.fps10` | Switcher preview frame rate |
| `windowSwitcherLivePreviewScope` | Enum | `.hoveredAppWindows` | Which windows get live preview |

---

## Testing Checklist

### Live Preview
- [ ] Dock live preview with different quality/FPS settings
- [ ] Window Switcher live preview disabled (default) - should be smooth
- [ ] Window Switcher live preview enabled with each scope option
- [ ] Quality/FPS combinations at different window counts

### Mouse Hover
- [ ] Open switcher, don't move mouse → keyboard navigation works
- [ ] Move mouse → selection follows cursor
- [ ] Stop mouse, press Tab → keyboard continues from current position
- [ ] Rapid Tab/Shift+Tab cycling performance
- [ ] Hold Tab / Hold Shift+Tab for continuous cycling

### Performance
- [ ] `showAnimations` disabled → no hover transition animations
- [ ] Many windows open → switcher remains responsive with conservative settings

---

## Related

- Supersedes mouse hover changes from #890
- Addresses performance concerns and animation feedback from #890 review

---

## Request

🙏 Would appreciate a timely review to avoid additional merge conflicts from ongoing main branch activity. These changes have been extensively tested and are ready for integration.