### PR TITLE
feat: add granular live preview settings for Dock and Window Switcher

### DIFF
--- a/DockDoor/Localizable.xcstrings
+++ b/DockDoor/Localizable.xcstrings
@@ -4793,6 +4793,18 @@
         }
       }
     },
+    "5 FPS" : {
+
+    },
+    "10 FPS" : {
+
+    },
+    "15 FPS" : {
+
+    },
+    "24 FPS" : {
+
+    },
     "30 FPS" : {
 
     },
@@ -7861,6 +7873,12 @@
     },
     "All Windows" : {
       "comment" : "Switcher invocation mode"
+    },
+    "All windows from the selected app get live preview" : {
+
+    },
+    "All windows get live preview (may cause lag with many windows)" : {
+
     },
     "Allow dynamic image sizing" : {
       "localizations" : {
@@ -25816,6 +25834,9 @@
         }
       }
     },
+    "Dock Frame Rate" : {
+
+    },
     "Dock Preview Aero Shake Action" : {
       "localizations" : {
         "af" : {
@@ -27721,6 +27742,9 @@
           }
         }
       }
+    },
+    "Dock Quality" : {
+
     },
     "DockDoor does not record your screen or audio. It only captures static window previews. No information is stored or shared; all processing occurs privately on your device." : {
       "localizations" : {
@@ -30006,6 +30030,12 @@
       }
     },
     "Enable dock scroll gestures" : {
+
+    },
+    "Enable for Dock Preview" : {
+
+    },
+    "Enable for Window Switcher" : {
 
     },
     "Enable gestures in window switcher" : {
@@ -39781,10 +39811,10 @@
         }
       }
     },
-    "High" : {
+    "High (960px)" : {
 
     },
-    "Higher quality and frame rate use more CPU/GPU resources." : {
+    "Higher quality and frame rate use more CPU/GPU resources. Use lower settings for Window Switcher if you experience lag." : {
 
     },
     "Highlight Gradient Colors" : {
@@ -45905,12 +45935,6 @@
         }
       }
     },
-    "Live Preview Frame Rate" : {
-
-    },
-    "Live Preview Quality" : {
-
-    },
     "Loading lyrics..." : {
       "localizations" : {
         "af" : {
@@ -46480,6 +46504,9 @@
           }
         }
       }
+    },
+    "Low (480px)" : {
+
     },
     "Lower values make gestures more sensitive. Higher values require longer swipes. Applies to both dock previews and window switcher." : {
 
@@ -50120,6 +50147,9 @@
           }
         }
       }
+    },
+    "Native (Best)" : {
+
     },
     "Navigate to Settings → Privacy & Security" : {
       "localizations" : {
@@ -55262,6 +55292,9 @@
           }
         }
       }
+    },
+    "Only the currently selected window gets live preview" : {
+
     },
     "Open Accessibility Settings" : {
       "extractionState" : "stale",
@@ -69750,7 +69783,7 @@
         }
       }
     },
-    "Retina (Best)" : {
+    "Retina (1280px)" : {
 
     },
     "Return" : {
@@ -74146,6 +74179,12 @@
           }
         }
       }
+    },
+    "Selected App's Windows" : {
+
+    },
+    "Selected Window Only" : {
+
     },
     "Selection Highlight" : {
       "extractionState" : "stale",
@@ -80664,6 +80703,9 @@
         }
       }
     },
+    "Standard (640px)" : {
+
+    },
     "Start on second window in Switcher" : {
       "localizations" : {
         "af" : {
@@ -82767,6 +82809,15 @@
     "Swipe up or down on window previews in the keyboard-activated window switcher. Only vertical swipes are recognized." : {
 
     },
+    "Switcher Frame Rate" : {
+
+    },
+    "Switcher Live Preview Scope" : {
+
+    },
+    "Switcher Quality" : {
+
+    },
     "Tab" : {
       "localizations" : {
         "af" : {
@@ -84486,6 +84537,9 @@
           }
         }
       }
+    },
+    "Thumbnail (320px)" : {
+
     },
     "Tiny (1/%lld)" : {
       "extractionState" : "stale",

--- a/DockDoor/Views/Hover Window/Shared Components/FullSizePreviewView.swift
+++ b/DockDoor/Views/Hover Window/Shared Components/FullSizePreviewView.swift
@@ -6,13 +6,16 @@ struct FullSizePreviewView: View {
     let windowSize: CGSize
     @Default(.uniformCardRadius) var uniformCardRadius
     @Default(.enableLivePreview) var enableLivePreview
+    @Default(.enableLivePreviewForDock) var enableLivePreviewForDock
+    @Default(.dockLivePreviewQuality) var dockLivePreviewQuality
+    @Default(.dockLivePreviewFrameRate) var dockLivePreviewFrameRate
 
     var body: some View {
-        let useLivePreview = enableLivePreview && !windowInfo.isMinimized && !windowInfo.isHidden
+        let useLivePreview = enableLivePreview && enableLivePreviewForDock && !windowInfo.isMinimized && !windowInfo.isHidden
 
         Group {
             if useLivePreview {
-                LivePreviewImage(windowID: windowInfo.id, fallbackImage: windowInfo.image)
+                LivePreviewImage(windowID: windowInfo.id, fallbackImage: windowInfo.image, quality: dockLivePreviewQuality, frameRate: dockLivePreviewFrameRate)
                     .aspectRatio(windowSize, contentMode: .fit)
             } else if let image = windowInfo.image {
                 Image(decorative: image, scale: 1.0)

--- a/DockDoor/Views/Hover Window/WindowPreview.swift
+++ b/DockDoor/Views/Hover Window/WindowPreview.swift
@@ -17,6 +17,7 @@ struct WindowPreview: View {
     let showAppIconOnly: Bool
     let mockPreviewActive: Bool
     let onHoverIndexChange: ((Int?) -> Void)?
+    var isEligibleForLivePreview: Bool = true
 
     @Default(.windowTitlePosition) var windowTitlePosition
     @Default(.showWindowTitle) var showWindowTitle
@@ -41,6 +42,12 @@ struct WindowPreview: View {
     @Default(.showActiveWindowBorder) var showActiveWindowBorder
     @Default(.activeAppIndicatorColor) var activeAppIndicatorColor
     @Default(.enableLivePreview) var enableLivePreview
+    @Default(.enableLivePreviewForDock) var enableLivePreviewForDock
+    @Default(.enableLivePreviewForWindowSwitcher) var enableLivePreviewForWindowSwitcher
+    @Default(.dockLivePreviewQuality) var dockLivePreviewQuality
+    @Default(.dockLivePreviewFrameRate) var dockLivePreviewFrameRate
+    @Default(.windowSwitcherLivePreviewQuality) var windowSwitcherLivePreviewQuality
+    @Default(.windowSwitcherLivePreviewFrameRate) var windowSwitcherLivePreviewFrameRate
 
     @State private var isHoveringOverDockPeekPreview = false
     @State private var isHoveringOverWindowSwitcherPreview = false
@@ -82,11 +89,14 @@ struct WindowPreview: View {
     @ViewBuilder
     private func windowContent(isMinimized: Bool, isHidden: Bool, isSelected: Bool) -> some View {
         let inactive = (isMinimized || isHidden) && showMinimizedHiddenLabels
-        let useLivePreview = enableLivePreview && !isMinimized && !isHidden
+        let livePreviewEnabledForContext = windowSwitcherActive ? enableLivePreviewForWindowSwitcher : enableLivePreviewForDock
+        let useLivePreview = enableLivePreview && livePreviewEnabledForContext && isEligibleForLivePreview && !isMinimized && !isHidden
+        let quality = windowSwitcherActive ? windowSwitcherLivePreviewQuality : dockLivePreviewQuality
+        let frameRate = windowSwitcherActive ? windowSwitcherLivePreviewFrameRate : dockLivePreviewFrameRate
 
         Group {
             if useLivePreview {
-                LivePreviewImage(windowID: windowInfo.id, fallbackImage: windowInfo.image)
+                LivePreviewImage(windowID: windowInfo.id, fallbackImage: windowInfo.image, quality: quality, frameRate: frameRate)
                     .scaledToFit()
             } else if let cgImage = windowInfo.image {
                 Image(decorative: cgImage, scale: 1.0)

--- a/DockDoor/Views/Settings/MainSettingsView.swift
+++ b/DockDoor/Views/Settings/MainSettingsView.swift
@@ -122,8 +122,13 @@ struct MainSettingsView: View {
     @Default(.windowPreviewImageScale) var windowPreviewImageScale
     @Default(.windowImageCaptureQuality) var windowImageCaptureQuality
     @Default(.enableLivePreview) var enableLivePreview
-    @Default(.livePreviewQuality) var livePreviewQuality
-    @Default(.livePreviewFrameRate) var livePreviewFrameRate
+    @Default(.enableLivePreviewForDock) var enableLivePreviewForDock
+    @Default(.enableLivePreviewForWindowSwitcher) var enableLivePreviewForWindowSwitcher
+    @Default(.dockLivePreviewQuality) var dockLivePreviewQuality
+    @Default(.dockLivePreviewFrameRate) var dockLivePreviewFrameRate
+    @Default(.windowSwitcherLivePreviewQuality) var windowSwitcherLivePreviewQuality
+    @Default(.windowSwitcherLivePreviewFrameRate) var windowSwitcherLivePreviewFrameRate
+    @Default(.windowSwitcherLivePreviewScope) var windowSwitcherLivePreviewScope
     @Default(.bufferFromDock) var bufferFromDock
     @Default(.shouldHideOnDockItemClick) var shouldHideOnDockItemClick
     @Default(.dockClickAction) var dockClickAction
@@ -709,23 +714,72 @@ struct MainSettingsView: View {
                         .padding(.leading, 20)
 
                     if enableLivePreview {
-                        Picker("Live Preview Quality", selection: $livePreviewQuality) {
-                            ForEach(LivePreviewQuality.allCases, id: \.self) { quality in
-                                Text(quality.localizedName).tag(quality)
-                            }
-                        }
-                        .pickerStyle(MenuPickerStyle())
-                        .padding(.leading, 20)
+                        // MARK: - Dock Live Preview Settings
 
-                        Picker("Live Preview Frame Rate", selection: $livePreviewFrameRate) {
-                            ForEach(LivePreviewFrameRate.allCases, id: \.self) { fps in
-                                Text(fps.localizedName).tag(fps)
-                            }
-                        }
-                        .pickerStyle(MenuPickerStyle())
-                        .padding(.leading, 20)
+                        Toggle(isOn: $enableLivePreviewForDock) { Text("Enable for Dock Preview") }
+                            .padding(.leading, 20)
 
-                        Text("Higher quality and frame rate use more CPU/GPU resources.")
+                        if enableLivePreviewForDock {
+                            Picker("Dock Quality", selection: $dockLivePreviewQuality) {
+                                ForEach(LivePreviewQuality.allCases, id: \.self) { quality in
+                                    Text(quality.localizedName).tag(quality)
+                                }
+                            }
+                            .pickerStyle(MenuPickerStyle())
+                            .padding(.leading, 40)
+
+                            Picker("Dock Frame Rate", selection: $dockLivePreviewFrameRate) {
+                                ForEach(LivePreviewFrameRate.allCases, id: \.self) { fps in
+                                    Text(fps.localizedName).tag(fps)
+                                }
+                            }
+                            .pickerStyle(MenuPickerStyle())
+                            .padding(.leading, 40)
+                        }
+
+                        Divider()
+                            .padding(.leading, 20)
+
+                        // MARK: - Window Switcher Live Preview Settings
+
+                        Toggle(isOn: $enableLivePreviewForWindowSwitcher) { Text("Enable for Window Switcher") }
+                            .padding(.leading, 20)
+
+                        if enableLivePreviewForWindowSwitcher {
+                            Picker("Switcher Quality", selection: $windowSwitcherLivePreviewQuality) {
+                                ForEach(LivePreviewQuality.allCases, id: \.self) { quality in
+                                    Text(quality.localizedName).tag(quality)
+                                }
+                            }
+                            .pickerStyle(MenuPickerStyle())
+                            .padding(.leading, 40)
+
+                            Picker("Switcher Frame Rate", selection: $windowSwitcherLivePreviewFrameRate) {
+                                ForEach(LivePreviewFrameRate.allCases, id: \.self) { fps in
+                                    Text(fps.localizedName).tag(fps)
+                                }
+                            }
+                            .pickerStyle(MenuPickerStyle())
+                            .padding(.leading, 40)
+
+                            Picker("Switcher Live Preview Scope", selection: $windowSwitcherLivePreviewScope) {
+                                ForEach(WindowSwitcherLivePreviewScope.allCases, id: \.self) { scope in
+                                    Text(scope.localizedName).tag(scope)
+                                }
+                            }
+                            .pickerStyle(MenuPickerStyle())
+                            .padding(.leading, 40)
+
+                            Text(windowSwitcherLivePreviewScope.localizedDescription)
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                                .padding(.leading, 40)
+                        }
+
+                        Divider()
+                            .padding(.leading, 20)
+
+                        Text("Higher quality and frame rate use more CPU/GPU resources. Use lower settings for Window Switcher if you experience lag.")
                             .font(.caption)
                             .foregroundColor(.secondary)
                             .padding(.leading, 20)

--- a/DockDoor/consts.swift
+++ b/DockDoor/consts.swift
@@ -34,8 +34,13 @@ extension Defaults.Keys {
     static let windowImageCaptureQuality = Key<WindowImageCaptureQuality>("windowImageCaptureQuality", default: .nominal)
 
     static let enableLivePreview = Key<Bool>("enableLivePreview", default: false)
-    static let livePreviewQuality = Key<LivePreviewQuality>("livePreviewQuality", default: .retina)
-    static let livePreviewFrameRate = Key<LivePreviewFrameRate>("livePreviewFrameRate", default: .fps30)
+    static let enableLivePreviewForDock = Key<Bool>("enableLivePreviewForDock", default: true)
+    static let enableLivePreviewForWindowSwitcher = Key<Bool>("enableLivePreviewForWindowSwitcher", default: false)
+    static let dockLivePreviewQuality = Key<LivePreviewQuality>("dockLivePreviewQuality", default: .high)
+    static let dockLivePreviewFrameRate = Key<LivePreviewFrameRate>("dockLivePreviewFrameRate", default: .fps24)
+    static let windowSwitcherLivePreviewQuality = Key<LivePreviewQuality>("windowSwitcherLivePreviewQuality", default: .low)
+    static let windowSwitcherLivePreviewFrameRate = Key<LivePreviewFrameRate>("windowSwitcherLivePreviewFrameRate", default: .fps10)
+    static let windowSwitcherLivePreviewScope = Key<WindowSwitcherLivePreviewScope>("windowSwitcherLivePreviewScope", default: .selectedAppWindows)
 
     static let uniformCardRadius = Key<Bool>("uniformCardRadius", default: true)
     static let allowDynamicImageSizing = Key<Bool>("allowDynamicImageSizing", default: false)
@@ -482,40 +487,67 @@ enum SwitcherInvocationMode: String, CaseIterable, Defaults.Serializable, Identi
 }
 
 enum LivePreviewQuality: String, CaseIterable, Defaults.Serializable, Identifiable {
+    case thumbnail
+    case low
     case standard
     case high
     case retina
+    case native
 
     var id: String { rawValue }
 
     var scaleFactor: Int {
         switch self {
+        case .thumbnail: 1
+        case .low: 1
         case .standard: 1
         case .high: 1
         case .retina: 2
+        case .native: 2
         }
     }
 
     var useFullResolution: Bool {
         switch self {
-        case .standard: false
-        case .high, .retina: true
+        case .thumbnail, .low: false
+        case .standard, .high, .retina, .native: true
+        }
+    }
+
+    var maxDimension: Int {
+        switch self {
+        case .thumbnail: 320
+        case .low: 480
+        case .standard: 640
+        case .high: 960
+        case .retina: 1280
+        case .native: 0 // No limit
         }
     }
 
     var localizedName: String {
         switch self {
+        case .thumbnail:
+            String(localized: "Thumbnail (320px)")
+        case .low:
+            String(localized: "Low (480px)")
         case .standard:
-            String(localized: "Standard")
+            String(localized: "Standard (640px)")
         case .high:
-            String(localized: "High")
+            String(localized: "High (960px)")
         case .retina:
-            String(localized: "Retina (Best)")
+            String(localized: "Retina (1280px)")
+        case .native:
+            String(localized: "Native (Best)")
         }
     }
 }
 
 enum LivePreviewFrameRate: String, CaseIterable, Defaults.Serializable, Identifiable {
+    case fps5
+    case fps10
+    case fps15
+    case fps24
     case fps30
     case fps60
     case fps120
@@ -524,6 +556,10 @@ enum LivePreviewFrameRate: String, CaseIterable, Defaults.Serializable, Identifi
 
     var frameRate: Int32 {
         switch self {
+        case .fps5: 5
+        case .fps10: 10
+        case .fps15: 15
+        case .fps24: 24
         case .fps30: 30
         case .fps60: 60
         case .fps120: 120
@@ -532,6 +568,14 @@ enum LivePreviewFrameRate: String, CaseIterable, Defaults.Serializable, Identifi
 
     var localizedName: String {
         switch self {
+        case .fps5:
+            String(localized: "5 FPS")
+        case .fps10:
+            String(localized: "10 FPS")
+        case .fps15:
+            String(localized: "15 FPS")
+        case .fps24:
+            String(localized: "24 FPS")
         case .fps30:
             String(localized: "30 FPS")
         case .fps60:
@@ -636,6 +680,37 @@ enum CompactModeItemSize: Int, CaseIterable, Defaults.Serializable, Identifiable
         case .xLarge: 56
         case .xxLarge: 64
         case .xxxLarge: 72
+        }
+    }
+}
+
+/// Window Switcher live preview scope - determines which windows get live preview
+enum WindowSwitcherLivePreviewScope: String, CaseIterable, Defaults.Serializable, Identifiable {
+    case selectedWindowOnly
+    case selectedAppWindows
+    case allWindows
+
+    var id: String { rawValue }
+
+    var localizedName: String {
+        switch self {
+        case .selectedWindowOnly:
+            String(localized: "Selected Window Only")
+        case .selectedAppWindows:
+            String(localized: "Selected App's Windows")
+        case .allWindows:
+            String(localized: "All Windows")
+        }
+    }
+
+    var localizedDescription: String {
+        switch self {
+        case .selectedWindowOnly:
+            String(localized: "Only the currently selected window gets live preview")
+        case .selectedAppWindows:
+            String(localized: "All windows from the selected app get live preview")
+        case .allWindows:
+            String(localized: "All windows get live preview (may cause lag with many windows)")
         }
     }
 }


### PR DESCRIPTION
## Summary

Adds separate live preview controls for Dock and Window Switcher contexts, allowing users to optimize performance based on their hardware and preferences.

## Changes

### New Settings (Settings → Appearance → Window Preview Quality)

| Setting | Dock Default | Switcher Default |
|---------|--------------|------------------|
| Enabled | ✅ On | ❌ Off |
| Quality | High | Low |
| Frame Rate | 24 FPS | 10 FPS |

### Quality Options
Thumbnail (320px), Low (480px), Standard (640px), High (960px), Retina (1280px), Native (Best)

### Frame Rate Options
5, 10, 15, 24, 30, 60, 120 FPS

### Window Switcher Live Preview Scope
| Option | Description |
|--------|-------------|
| Selected Window Only | Only the selected window gets live preview |
| Selected App's Windows | All windows from selected app get live preview (default) |
| All Windows | Every window gets live preview |

## Why Conservative Defaults for Switcher?

Window Switcher can display many windows simultaneously. Live preview for all windows can cause performance issues on some hardware. By defaulting to disabled with low quality/fps settings, users get a smooth experience out of the box and can enable it if their system handles it well.

## Files Changed

- `consts.swift` - New settings keys and enums
- `LiveWindowCapture.swift` - Quality/FPS parameters
- `FullSizePreviewView.swift` - Dock-specific settings
- `WindowPreview.swift` - Context-aware quality/fps selection
- `WindowPreviewHoverContainer.swift` - Scope calculation
- `MainSettingsView.swift` - UI for new settings

## Related

This is a split from #896 per review feedback. Mouse hover improvements will be submitted separately.