### PR TITLE
refactor: add context-based settings for Dock and Window Switcher appearance

### DIFF
--- a/DockDoor/Localizable.xcstrings
+++ b/DockDoor/Localizable.xcstrings
@@ -13919,6 +13919,12 @@
         }
       }
     },
+    "App Icon" : {
+      "comment" : "Window switcher header bar toggle"
+    },
+    "App Name" : {
+      "comment" : "Window switcher header bar toggle"
+    },
     "App Name + Window Title" : {
       "localizations" : {
         "af" : {
@@ -14300,6 +14306,7 @@
       }
     },
     "App Name Style" : {
+      "extractionState" : "stale",
       "localizations" : {
         "af" : {
           "stringUnit" : {
@@ -18678,6 +18685,7 @@
     },
     "Bottom Left" : {
       "comment" : "Preview window title position option\nTraffic light buttons position option",
+      "extractionState" : "stale",
       "localizations" : {
         "af" : {
           "stringUnit" : {
@@ -18869,6 +18877,7 @@
     },
     "Bottom Right" : {
       "comment" : "Preview window title position option\nTraffic light buttons position option",
+      "extractionState" : "stale",
       "localizations" : {
         "af" : {
           "stringUnit" : {
@@ -28007,6 +28016,9 @@
         }
       }
     },
+    "Controls Position" : {
+      "comment" : "Dock preview settings section title\nWindow switcher settings section title"
+    },
     "Controls the visual detail and update frequency of window previews." : {
       "localizations" : {
         "af" : {
@@ -31817,7 +31829,14 @@
         }
       }
     },
+    "Dimmed until hover" : {
+      "comment" : "Window title visibility option"
+    },
+    "Disable Button Hover Effects" : {
+
+    },
     "Disable dock styling on traffic light buttons" : {
+      "comment" : "Traffic light buttons setting toggle",
       "localizations" : {
         "af" : {
           "stringUnit" : {
@@ -32008,6 +32027,7 @@
       }
     },
     "Disable dock styling on window titles" : {
+      "comment" : "Dock preview setting toggle\nWindow switcher setting toggle",
       "localizations" : {
         "af" : {
           "stringUnit" : {
@@ -35436,6 +35456,7 @@
     },
     "Dock Previews & Window Switcher" : {
       "comment" : "Preview window title display condition option",
+      "extractionState" : "stale",
       "localizations" : {
         "af" : {
           "stringUnit" : {
@@ -35627,6 +35648,7 @@
     },
     "Dock Previews only" : {
       "comment" : "Preview window title condition display option",
+      "extractionState" : "stale",
       "localizations" : {
         "af" : {
           "stringUnit" : {
@@ -37151,6 +37173,7 @@
       }
     },
     "Embed controls in preview frames" : {
+      "comment" : "Dock preview setting: embed mode toggle\nWindow switcher setting: embed mode toggle",
       "localizations" : {
         "af" : {
           "stringUnit" : {
@@ -37721,6 +37744,9 @@
           }
         }
       }
+    },
+    "Embedded Title" : {
+      "comment" : "Window switcher settings section title"
     },
     "Enable automatic checking for updates" : {
       "localizations" : {
@@ -40582,6 +40608,7 @@
       }
     },
     "Enabled Buttons" : {
+      "comment" : "Traffic light buttons setting section title",
       "localizations" : {
         "af" : {
           "stringUnit" : {
@@ -49732,6 +49759,9 @@
         }
       }
     },
+    "Header Bar" : {
+      "comment" : "Window switcher settings section title"
+    },
     "Help" : {
       "comment" : "Settings tab title",
       "extractionState" : "stale",
@@ -50875,6 +50905,9 @@
           }
         }
       }
+    },
+    "Hidden until hover" : {
+      "comment" : "Traffic light buttons visibility option"
     },
     "Hide Advanced Settings" : {
       "localizations" : {
@@ -56024,6 +56057,9 @@
           }
         }
       }
+    },
+    "Info shown above each window preview. Visibility options apply based on hover." : {
+      "comment" : "Window switcher settings section description"
     },
     "Initialization Key" : {
       "extractionState" : "stale",
@@ -65558,7 +65594,7 @@
       }
     },
     "Never visible" : {
-      "comment" : "Traffic light buttons visibility option",
+      "comment" : "Traffic light buttons visibility option\nWindow title visibility option",
       "localizations" : {
         "af" : {
           "stringUnit" : {
@@ -74517,6 +74553,7 @@
       }
     },
     "Places traffic light buttons and window titles directly inside the dock preview frames for a more compact and minimal appearance." : {
+      "comment" : "Dock preview setting: embed mode description",
       "localizations" : {
         "af" : {
           "stringUnit" : {
@@ -74705,6 +74742,9 @@
           }
         }
       }
+    },
+    "Places traffic light buttons and window titles directly inside the window switcher preview frames for a more compact and minimal appearance." : {
+      "comment" : "Window switcher setting: embed mode description"
     },
     "Please Quit the App to Apply Changes! :)" : {
       "extractionState" : "stale",
@@ -75469,7 +75509,11 @@
         }
       }
     },
+    "Position" : {
+
+    },
     "Position Dock Preview Controls" : {
+      "extractionState" : "stale",
       "localizations" : {
         "af" : {
           "stringUnit" : {
@@ -75851,6 +75895,7 @@
       }
     },
     "Position Window Controls" : {
+      "extractionState" : "stale",
       "localizations" : {
         "af" : {
           "stringUnit" : {
@@ -83847,6 +83892,7 @@
       }
     },
     "Removes the pill-shaped background styling from traffic light buttons in dock previews for a cleaner look." : {
+      "comment" : "Traffic light buttons setting description",
       "localizations" : {
         "af" : {
           "stringUnit" : {
@@ -84036,7 +84082,11 @@
         }
       }
     },
+    "Removes the pill-shaped background styling from window titles for a cleaner look." : {
+      "comment" : "Dock preview setting description"
+    },
     "Removes the pill-shaped background styling from window titles in dock previews for a cleaner look." : {
+      "extractionState" : "stale",
       "localizations" : {
         "af" : {
           "stringUnit" : {
@@ -84225,6 +84275,9 @@
           }
         }
       }
+    },
+    "Removes the pill-shaped background styling from window titles in window switcher previews for a cleaner look." : {
+      "comment" : "Window switcher setting description"
     },
     "Report a Bug" : {
       "localizations" : {
@@ -94523,6 +94576,9 @@
     "Show All" : {
 
     },
+    "Show App Icon" : {
+
+    },
     "Show App Name" : {
       "localizations" : {
         "af" : {
@@ -94714,6 +94770,7 @@
       }
     },
     "Show App Name in Dock Previews" : {
+      "extractionState" : "stale",
       "localizations" : {
         "af" : {
           "stringUnit" : {
@@ -95092,6 +95149,9 @@
           }
         }
       }
+    },
+    "Show Embedded Title" : {
+      "comment" : "Window switcher setting toggle"
     },
     "Show media/calendar controls on Dock hover" : {
       "localizations" : {
@@ -96425,6 +96485,7 @@
       }
     },
     "Show Window Title" : {
+      "comment" : "Dock preview setting toggle",
       "localizations" : {
         "af" : {
           "stringUnit" : {
@@ -96615,6 +96676,7 @@
       }
     },
     "Show Window Title in" : {
+      "extractionState" : "stale",
       "localizations" : {
         "af" : {
           "stringUnit" : {
@@ -106711,6 +106773,9 @@
         }
       }
     },
+    "Title displayed inside the preview frame when embedded mode is enabled." : {
+      "comment" : "Window switcher settings section description"
+    },
     "Title Format" : {
       "localizations" : {
         "af" : {
@@ -107474,6 +107539,7 @@
     },
     "Top Left" : {
       "comment" : "Preview window title position option\nTraffic light buttons position option",
+      "extractionState" : "stale",
       "localizations" : {
         "af" : {
           "stringUnit" : {
@@ -107665,6 +107731,7 @@
     },
     "Top Right" : {
       "comment" : "Preview window title position option\nTraffic light buttons position option",
+      "extractionState" : "stale",
       "localizations" : {
         "af" : {
           "stringUnit" : {
@@ -108427,6 +108494,7 @@
       }
     },
     "Traffic Light Buttons Visibility" : {
+      "extractionState" : "stale",
       "localizations" : {
         "af" : {
           "stringUnit" : {
@@ -114139,6 +114207,9 @@
           }
         }
       }
+    },
+    "Visibility" : {
+
     },
     "Want to see for yourself? Review our source code" : {
       "localizations" : {
@@ -122529,6 +122600,7 @@
     },
     "Window Switcher only" : {
       "comment" : "Preview window title condition display option",
+      "extractionState" : "stale",
       "localizations" : {
         "af" : {
           "stringUnit" : {
@@ -123669,6 +123741,9 @@
         }
       }
     },
+    "Window Title" : {
+      "comment" : "Dock preview settings section title\nWindow switcher header bar toggle"
+    },
     "Window title filters" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -124431,7 +124506,11 @@
         }
       }
     },
+    "Window title shown on each preview. Position changes based on embedded mode." : {
+      "comment" : "Dock preview settings section description"
+    },
     "Window Title Visibility" : {
+      "extractionState" : "stale",
       "localizations" : {
         "af" : {
           "stringUnit" : {

--- a/DockDoor/Views/Hover Window/Shared Components/SharedHoverAppTitle.swift
+++ b/DockDoor/Views/Hover Window/Shared Components/SharedHoverAppTitle.swift
@@ -6,9 +6,10 @@ struct SharedHoverAppTitle: View {
     let appName: String
     let appIcon: NSImage?
     let hoveringAppIcon: Bool
+    var showAppIcon: Bool = true
+    var showAppNameLabel: Bool = true
 
     @Default(.showAppName) var showAppTitleData
-    @Default(.showAppIconOnly) var showAppIconOnly
     @Default(.appNameStyle) var appNameStyle
     @Default(.showAnimations) var showAnimations
     @Default(.gradientColorPalette) private var defaultGradientColorPalette
@@ -19,15 +20,19 @@ struct SharedHoverAppTitle: View {
                 switch appNameStyle {
                 case .default:
                     HStack(alignment: .center) {
-                        if let appIcon {
-                            Image(nsImage: appIcon)
-                                .resizable()
-                                .scaledToFit()
-                                .zIndex(1)
-                                .frame(width: 24, height: 24)
-                        } else { ProgressView().frame(width: 24, height: 24) }
-                        hoverTitleLabelView()
-                            .animation(nil, value: hoveringAppIcon)
+                        if showAppIcon {
+                            if let appIcon {
+                                Image(nsImage: appIcon)
+                                    .resizable()
+                                    .scaledToFit()
+                                    .zIndex(1)
+                                    .frame(width: 24, height: 24)
+                            } else { ProgressView().frame(width: 24, height: 24) }
+                        }
+                        if showAppNameLabel {
+                            hoverTitleLabelView()
+                                .animation(nil, value: hoveringAppIcon)
+                        }
                     }
                     .padding(.top, 10)
                     .padding(.horizontal)
@@ -35,15 +40,19 @@ struct SharedHoverAppTitle: View {
 
                 case .shadowed:
                     HStack(spacing: 2) {
-                        if let appIcon {
-                            Image(nsImage: appIcon)
-                                .resizable()
-                                .scaledToFit()
-                                .zIndex(1)
-                                .frame(width: 24, height: 24)
-                        } else { ProgressView().frame(width: 24, height: 24) }
-                        hoverTitleLabelView()
-                            .animation(nil, value: hoveringAppIcon)
+                        if showAppIcon {
+                            if let appIcon {
+                                Image(nsImage: appIcon)
+                                    .resizable()
+                                    .scaledToFit()
+                                    .zIndex(1)
+                                    .frame(width: 24, height: 24)
+                            } else { ProgressView().frame(width: 24, height: 24) }
+                        }
+                        if showAppNameLabel {
+                            hoverTitleLabelView()
+                                .animation(nil, value: hoveringAppIcon)
+                        }
                     }
                     .padding(EdgeInsets(top: -11.5, leading: 15, bottom: -1.5, trailing: 1.5))
                     .animation(showAnimations ? .smooth(duration: 0.15) : nil, value: hoveringAppIcon)
@@ -52,15 +61,19 @@ struct SharedHoverAppTitle: View {
                     HStack {
                         Spacer()
                         HStack(alignment: .center, spacing: 2) {
-                            if let appIcon {
-                                Image(nsImage: appIcon)
-                                    .resizable()
-                                    .scaledToFit()
-                                    .zIndex(1)
-                                    .frame(width: 24, height: 24)
-                            } else { ProgressView().frame(width: 24, height: 24) }
-                            hoverTitleLabelView()
-                                .animation(nil, value: hoveringAppIcon)
+                            if showAppIcon {
+                                if let appIcon {
+                                    Image(nsImage: appIcon)
+                                        .resizable()
+                                        .scaledToFit()
+                                        .zIndex(1)
+                                        .frame(width: 24, height: 24)
+                                } else { ProgressView().frame(width: 24, height: 24) }
+                            }
+                            if showAppNameLabel {
+                                hoverTitleLabelView()
+                                    .animation(nil, value: hoveringAppIcon)
+                            }
                         }
                         .padding(.vertical, 5)
                         .padding(.horizontal, 10)
@@ -76,48 +89,46 @@ struct SharedHoverAppTitle: View {
 
     @ViewBuilder
     private func hoverTitleLabelView() -> some View {
-        if !showAppIconOnly {
-            let trimmedAppName = appName.trimmingCharacters(in: .whitespaces)
-            let baseText = Text(trimmedAppName).font(.subheadline).fontWeight(.medium)
-            let labelSize = measureString(trimmedAppName, fontSize: 14)
-            let rainbowGradientColors: [Color] = [.red, .orange, .yellow, .green, .blue, .purple, .pink]
-            let rainbowGradientHighlights: [Color] = [.white.opacity(0.45), .yellow.opacity(0.35), .pink.opacity(0.4)]
+        let trimmedAppName = appName.trimmingCharacters(in: .whitespaces)
+        let baseText = Text(trimmedAppName).font(.subheadline).fontWeight(.medium)
+        let labelSize = measureString(trimmedAppName, fontSize: 14)
+        let rainbowGradientColors: [Color] = [.red, .orange, .yellow, .green, .blue, .purple, .pink]
+        let rainbowGradientHighlights: [Color] = [.white.opacity(0.45), .yellow.opacity(0.35), .pink.opacity(0.4)]
 
-            Group {
-                switch appNameStyle {
-                case .shadowed:
-                    if trimmedAppName == "DockDoor" {
-                        FluidGradient(blobs: rainbowGradientColors, highlights: rainbowGradientHighlights, speed: 0.65, blur: 0.5)
-                            .frame(width: labelSize.width, height: labelSize.height)
-                            .mask(baseText)
-                            .fontWeight(.medium)
-                            .padding(.leading, 4)
-                            .shadow(stacked: 2, radius: 6)
-                            .background(
-                                ZStack {
-                                    MaterialBlurView(material: .hudWindow).mask(Ellipse().fill(LinearGradient(gradient: Gradient(colors: [Color.white.opacity(1.0), Color.white.opacity(0.35)]), startPoint: .top, endPoint: .bottom))).blur(radius: 5)
-                                }.frame(width: labelSize.width + 30)
-                            )
-                            .animation(showAnimations ? .easeInOut(duration: 0.2) : nil, value: trimmedAppName)
-                    } else {
-                        baseText.foregroundStyle(Color.primary).shadow(stacked: 2, radius: 6)
-                            .background(
-                                ZStack {
-                                    MaterialBlurView(material: .hudWindow).mask(Ellipse().fill(LinearGradient(gradient: Gradient(colors: [Color.white.opacity(1.0), Color.white.opacity(0.35)]), startPoint: .top, endPoint: .bottom))).blur(radius: 5)
-                                }.frame(width: labelSize.width + 30)
-                            )
-                            .animation(showAnimations ? .easeInOut(duration: 0.2) : nil, value: trimmedAppName)
-                    }
-                case .default, .popover:
-                    if trimmedAppName == "DockDoor" {
-                        FluidGradient(blobs: rainbowGradientColors, highlights: rainbowGradientHighlights, speed: 0.65, blur: 0.5)
-                            .frame(width: labelSize.width, height: labelSize.height)
-                            .mask(baseText)
-                            .animation(showAnimations ? .easeInOut(duration: 0.2) : nil, value: trimmedAppName)
-                    } else {
-                        baseText.foregroundStyle(Color.primary)
-                            .animation(showAnimations ? .easeInOut(duration: 0.2) : nil, value: trimmedAppName)
-                    }
+        Group {
+            switch appNameStyle {
+            case .shadowed:
+                if trimmedAppName == "DockDoor" {
+                    FluidGradient(blobs: rainbowGradientColors, highlights: rainbowGradientHighlights, speed: 0.65, blur: 0.5)
+                        .frame(width: labelSize.width, height: labelSize.height)
+                        .mask(baseText)
+                        .fontWeight(.medium)
+                        .padding(.leading, 4)
+                        .shadow(stacked: 2, radius: 6)
+                        .background(
+                            ZStack {
+                                MaterialBlurView(material: .hudWindow).mask(Ellipse().fill(LinearGradient(gradient: Gradient(colors: [Color.white.opacity(1.0), Color.white.opacity(0.35)]), startPoint: .top, endPoint: .bottom))).blur(radius: 5)
+                            }.frame(width: labelSize.width + 30)
+                        )
+                        .animation(showAnimations ? .easeInOut(duration: 0.2) : nil, value: trimmedAppName)
+                } else {
+                    baseText.foregroundStyle(Color.primary).shadow(stacked: 2, radius: 6)
+                        .background(
+                            ZStack {
+                                MaterialBlurView(material: .hudWindow).mask(Ellipse().fill(LinearGradient(gradient: Gradient(colors: [Color.white.opacity(1.0), Color.white.opacity(0.35)]), startPoint: .top, endPoint: .bottom))).blur(radius: 5)
+                            }.frame(width: labelSize.width + 30)
+                        )
+                        .animation(showAnimations ? .easeInOut(duration: 0.2) : nil, value: trimmedAppName)
+                }
+            case .default, .popover:
+                if trimmedAppName == "DockDoor" {
+                    FluidGradient(blobs: rainbowGradientColors, highlights: rainbowGradientHighlights, speed: 0.65, blur: 0.5)
+                        .frame(width: labelSize.width, height: labelSize.height)
+                        .mask(baseText)
+                        .animation(showAnimations ? .easeInOut(duration: 0.2) : nil, value: trimmedAppName)
+                } else {
+                    baseText.foregroundStyle(Color.primary)
+                        .animation(showAnimations ? .easeInOut(duration: 0.2) : nil, value: trimmedAppName)
                 }
             }
         }

--- a/DockDoor/Views/Hover Window/Shared Components/Traffic Light Buttons.swift
+++ b/DockDoor/Views/Hover Window/Shared Components/Traffic Light Buttons.swift
@@ -9,9 +9,10 @@ struct TrafficLightButtons: View {
     let onWindowAction: (WindowAction) -> Void
     let pillStyling: Bool
     let mockPreviewActive: Bool
+    let enabledButtons: Set<WindowAction>
+    let useMonochrome: Bool
+    let disableButtonHoverEffects: Bool
     @State private var isHovering = false
-    @Default(.enabledTrafficLightButtons) private var enabledButtons
-    @Default(.useMonochromeTrafficLights) private var useMonochrome
 
     var body: some View {
         let monochromeFillColor = colorScheme == .dark ? Color.gray.darker(by: 0.075) : Color.white
@@ -50,7 +51,6 @@ struct TrafficLightButtons: View {
                     }
                 }
                 .padding(4)
-                .opacity(opacity)
                 .allowsHitTesting(opacity != 0)
                 .simultaneousGesture(TapGesture())
                 .onHover { isHovering in
@@ -60,13 +60,16 @@ struct TrafficLightButtons: View {
                 }
             }
         }
-        .if(pillStyling && opacity > 0 && displayMode != .never && enabledButtons.count > 0) { view in
+        .if(pillStyling && displayMode != .never && enabledButtons.count > 0) { view in
             view.materialPill()
         }
+        .opacity(opacity)
     }
 
     private var opacity: Double {
         switch displayMode {
+        case .hiddenUntilHover:
+            hoveringOverParentWindow || mockPreviewActive ? 1.0 : 0
         case .dimmedOnPreviewHover:
             (hoveringOverParentWindow && isHovering) || mockPreviewActive ? 1.0 : 0.25
         case .fullOpacityOnPreviewHover:
@@ -79,6 +82,28 @@ struct TrafficLightButtons: View {
     }
 
     private func buttonFor(action: WindowAction, symbol: String, color: Color, fillColor: Color) -> some View {
+        TrafficLightButton(
+            action: action,
+            symbol: symbol,
+            color: color,
+            fillColor: fillColor,
+            disableHoverEffect: mockPreviewActive || disableButtonHoverEffects,
+            onWindowAction: onWindowAction
+        )
+    }
+}
+
+private struct TrafficLightButton: View {
+    let action: WindowAction
+    let symbol: String
+    let color: Color
+    let fillColor: Color
+    let disableHoverEffect: Bool
+    let onWindowAction: (WindowAction) -> Void
+
+    @State private var isHovering = false
+
+    var body: some View {
         ZStack {
             Image(systemName: "circle.fill")
                 .foregroundStyle(.secondary)
@@ -86,7 +111,20 @@ struct TrafficLightButtons: View {
         }
         .foregroundStyle(color, fillColor)
         .font(.headline)
+        .overlay {
+            if isHovering, !disableHoverEffect {
+                Circle()
+                    .fill(Color.black.opacity(0.25))
+            }
+        }
         .contentShape(Rectangle())
+        .onHover { hovering in
+            if !disableHoverEffect {
+                withAnimation(.easeInOut(duration: 0.1)) {
+                    isHovering = hovering
+                }
+            }
+        }
         .onTapGesture {
             onWindowAction(action)
         }
@@ -94,114 +132,149 @@ struct TrafficLightButtons: View {
 }
 
 extension AppearanceSettingsView {
-    struct TrafficLightButtonsSettingsView: View {
-        @Default(.enabledTrafficLightButtons) private var enabledButtons
-        @Default(.useMonochromeTrafficLights) private var useMonochrome
-        @Default(.trafficLightButtonsVisibility) private var trafficLightButtonsVisibility
+    private static let trafficLightButtonDescriptions: [(WindowAction, String)] = [
+        (.quit, String(localized: "Quit")),
+        (.close, String(localized: "Close")),
+        (.minimize, String(localized: "Minimize")),
+        (.toggleFullScreen, String(localized: "Fullscreen")),
+        (.maximize, String(localized: "Maximize")),
+        (.openNewWindow, String(localized: "New Window")),
+    ]
 
-        private let buttonDescriptions: [(WindowAction, String)] = [
-            (.quit, String(localized: "Quit")),
-            (.close, String(localized: "Close")),
-            (.minimize, String(localized: "Minimize")),
-            (.toggleFullScreen, String(localized: "Fullscreen")),
-            (.maximize, String(localized: "Maximize")),
-            (.openNewWindow, String(localized: "New Window")),
-        ]
+    struct ContextTrafficLightButtonsSettingsView: View {
+        @Binding var visibility: TrafficLightButtonsVisibility
+        @Binding var enabledButtons: Set<WindowAction>
+        @Binding var useMonochrome: Bool
+        var disableButtonHoverEffects: Binding<Bool>?
+        var disableDockStyle: Binding<Bool>?
+
+        @State private var isHoveringOverPreview: Bool = false
 
         var body: some View {
-            Picker("Traffic Light Buttons Visibility", selection: $trafficLightButtonsVisibility) {
-                ForEach(TrafficLightButtonsVisibility.allCases, id: \.self) { visibility in
-                    Text(visibility.localizedName)
-                        .tag(visibility)
+            Picker("Visibility", selection: $visibility) {
+                ForEach(TrafficLightButtonsVisibility.allCases, id: \.self) { vis in
+                    Text(vis.localizedName)
+                        .tag(vis)
                 }
             }
 
-            if trafficLightButtonsVisibility != .never {
+            if let disableDockStyle, visibility != .never {
+                VStack(alignment: .leading) {
+                    Toggle(isOn: disableDockStyle) {
+                        Text(String(localized: "Disable dock styling on traffic light buttons", comment: "Traffic light buttons setting toggle"))
+                    }
+                    Text(String(localized: "Removes the pill-shaped background styling from traffic light buttons in dock previews for a cleaner look.", comment: "Traffic light buttons setting description"))
+                        .font(.footnote)
+                        .foregroundColor(.gray)
+                        .padding(.leading, 20)
+                }
+            }
+
+            if visibility != .never {
                 Group {
-                    Text("Enabled Buttons")
-                    VStack(alignment: .leading) {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(String(localized: "Enabled Buttons", comment: "Traffic light buttons setting section title"))
                         if !enabledButtons.isEmpty {
                             TrafficLightButtons(
-                                displayMode: trafficLightButtonsVisibility == .never ? .dimmedOnPreviewHover : trafficLightButtonsVisibility,
-                                hoveringOverParentWindow: true,
+                                displayMode: visibility,
+                                hoveringOverParentWindow: isHoveringOverPreview,
                                 onWindowAction: { _ in },
-                                pillStyling: true,
-                                mockPreviewActive: false
+                                pillStyling: !(disableDockStyle?.wrappedValue ?? false),
+                                mockPreviewActive: false,
+                                enabledButtons: enabledButtons,
+                                useMonochrome: useMonochrome,
+                                disableButtonHoverEffects: disableButtonHoverEffects?.wrappedValue ?? false
                             )
-                        }
-
-                        VStack(alignment: .leading, spacing: 8) {
-                            HStack(spacing: 12) {
-                                ForEach(buttonDescriptions.prefix(3), id: \.0) { action, label in
-                                    Toggle(isOn: Binding(
-                                        get: { enabledButtons.contains(action) },
-                                        set: { isEnabled in
-                                            if isEnabled {
-                                                enabledButtons.insert(action)
-                                            } else {
-                                                enabledButtons.remove(action)
-
-                                                if enabledButtons.isEmpty {
-                                                    MessageUtil.showAlert(
-                                                        title: String(localized: "All buttons removed"),
-                                                        message: String(localized: "Your traffic lights will be set to disabled automatically."),
-                                                        actions: [.ok, .cancel]
-                                                    ) { action in
-                                                        switch action {
-                                                        case .ok:
-                                                            trafficLightButtonsVisibility = .never
-                                                        case .cancel:
-                                                            break
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    )) {
-                                        Text(label)
-                                    }
-                                    .toggleStyle(CheckboxToggleStyle())
-                                }
-                            }
-                            HStack(spacing: 12) {
-                                ForEach(buttonDescriptions.suffix(3), id: \.0) { action, label in
-                                    Toggle(isOn: Binding(
-                                        get: { enabledButtons.contains(action) },
-                                        set: { isEnabled in
-                                            if isEnabled {
-                                                enabledButtons.insert(action)
-                                            } else {
-                                                enabledButtons.remove(action)
-
-                                                if enabledButtons.isEmpty {
-                                                    MessageUtil.showAlert(
-                                                        title: String(localized: "All buttons removed"),
-                                                        message: String(localized: "Your traffic lights will be set to disabled automatically."),
-                                                        actions: [.ok, .cancel]
-                                                    ) { action in
-                                                        switch action {
-                                                        case .ok:
-                                                            trafficLightButtonsVisibility = .never
-                                                        case .cancel:
-                                                            break
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    )) {
-                                        Text(label)
-                                    }
-                                    .toggleStyle(CheckboxToggleStyle())
-                                }
+                            .onHover { hovering in
+                                isHoveringOverPreview = hovering
                             }
                         }
                     }
 
+                    ButtonToggleGrid(
+                        enabledButtons: $enabledButtons,
+                        visibility: $visibility,
+                        showAlertOnEmpty: true
+                    )
+
                     Toggle("Use Monochrome Colors", isOn: $useMonochrome)
                         .padding(.top, 4)
+
+                    if let disableHover = disableButtonHoverEffects {
+                        Toggle("Disable Button Hover Effects", isOn: disableHover)
+                            .padding(.top, 4)
+                    }
                 }
             }
+        }
+    }
+
+    struct EmbeddedButtonsSelector: View {
+        @Binding var enabledButtons: Set<WindowAction>
+
+        var body: some View {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(String(localized: "Enabled Buttons", comment: "Traffic light buttons setting section title"))
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+                ButtonToggleGrid(
+                    enabledButtons: $enabledButtons,
+                    visibility: .constant(.alwaysVisible),
+                    showAlertOnEmpty: false
+                )
+            }
+            .padding(.top, 4)
+        }
+    }
+
+    struct ButtonToggleGrid: View {
+        @Binding var enabledButtons: Set<WindowAction>
+        @Binding var visibility: TrafficLightButtonsVisibility
+        var showAlertOnEmpty: Bool = true
+
+        var body: some View {
+            VStack(alignment: .leading, spacing: 8) {
+                HStack(spacing: 12) {
+                    ForEach(trafficLightButtonDescriptions.prefix(3), id: \.0) { action, label in
+                        buttonToggle(action: action, label: label)
+                    }
+                }
+                HStack(spacing: 12) {
+                    ForEach(trafficLightButtonDescriptions.suffix(3), id: \.0) { action, label in
+                        buttonToggle(action: action, label: label)
+                    }
+                }
+            }
+        }
+
+        private func buttonToggle(action: WindowAction, label: String) -> some View {
+            Toggle(isOn: Binding(
+                get: { enabledButtons.contains(action) },
+                set: { isEnabled in
+                    if isEnabled {
+                        enabledButtons.insert(action)
+                    } else {
+                        enabledButtons.remove(action)
+                        if showAlertOnEmpty, enabledButtons.isEmpty {
+                            MessageUtil.showAlert(
+                                title: String(localized: "All buttons removed"),
+                                message: String(localized: "Your traffic lights will be set to disabled automatically."),
+                                actions: [.ok, .cancel]
+                            ) { alertAction in
+                                switch alertAction {
+                                case .ok:
+                                    visibility = .never
+                                case .cancel:
+                                    break
+                                }
+                            }
+                        }
+                    }
+                }
+            )) {
+                Text(label)
+            }
+            .toggleStyle(CheckboxToggleStyle())
         }
     }
 }

--- a/DockDoor/Views/Hover Window/Special Hover Windows/Media/MediaControlsFullView.swift
+++ b/DockDoor/Views/Hover Window/Special Hover Windows/Media/MediaControlsFullView.swift
@@ -21,8 +21,9 @@ struct MediaControlsFullView: View {
     let hoveringWindowTitle: Bool
 
     @Default(.showAppName) var showAppTitleData
-    @Default(.showAppIconOnly) var showAppIconOnly
     @Default(.appNameStyle) var appNameStyle
+    @Default(.showAppIconOnly) var dockShowHeaderAppIcon
+    @Default(.showAppName) var dockShowHeaderAppName
     @Default(.showAnimations) var showAnimations
 
     @State private var initialContentSize: CGSize = .zero
@@ -53,7 +54,9 @@ struct MediaControlsFullView: View {
                     SharedHoverAppTitle(
                         appName: appName,
                         appIcon: appIcon,
-                        hoveringAppIcon: hoveringAppIcon
+                        hoveringAppIcon: hoveringAppIcon,
+                        showAppIcon: dockShowHeaderAppIcon,
+                        showAppNameLabel: dockShowHeaderAppName
                     )
                     .padding([.top, .leading], 4)
                 }
@@ -84,7 +87,9 @@ struct MediaControlsFullView: View {
             SharedHoverAppTitle(
                 appName: appName,
                 appIcon: appIcon,
-                hoveringAppIcon: hoveringAppIcon
+                hoveringAppIcon: hoveringAppIcon,
+                showAppIcon: dockShowHeaderAppIcon,
+                showAppNameLabel: dockShowHeaderAppName
             )
             .padding([.top, .leading], 4)
         }

--- a/DockDoor/Views/Hover Window/Special Hover Windows/Media/MediaControlsView.swift
+++ b/DockDoor/Views/Hover Window/Special Hover Windows/Media/MediaControlsView.swift
@@ -56,7 +56,6 @@ struct MediaControlsView: View {
 
     @Default(.uniformCardRadius) var uniformCardRadius
     @Default(.showAppName) var showAppTitleData
-    @Default(.showAppIconOnly) var showAppIconOnly
     @Default(.appNameStyle) var appNameStyle
     @Default(.showAnimations) var showAnimations
 

--- a/DockDoor/Views/Hover Window/WindowPreview Supporting/PreviewStateCoordinator.swift
+++ b/DockDoor/Views/Hover Window/WindowPreview Supporting/PreviewStateCoordinator.swift
@@ -10,6 +10,9 @@ class PreviewStateCoordinator: ObservableObject {
     var initialHoverLocation: CGPoint?
     @Published var fullWindowPreviewActive: Bool = false
     @Published var windows: [WindowInfo] = []
+
+    /// When true, this coordinator is used for settings preview and should NOT interact with SharedPreviewWindowCoordinator
+    var isMockCoordinator: Bool = false
     @Published var shouldScrollToIndex: Bool = true
     @Published var searchQuery: String = "" {
         didSet {
@@ -101,7 +104,9 @@ class PreviewStateCoordinator: ObservableObject {
 
         if windows.isEmpty {
             currIndex = -1
-            SharedPreviewWindowCoordinator.activeInstance?.hideWindow()
+            if !isMockCoordinator {
+                SharedPreviewWindowCoordinator.activeInstance?.hideWindow()
+            }
             return
         }
 
@@ -159,7 +164,9 @@ class PreviewStateCoordinator: ObservableObject {
     func removeAllWindows() {
         windows.removeAll()
         currIndex = -1 // Reset to no selection
-        SharedPreviewWindowCoordinator.activeInstance?.hideWindow()
+        if !isMockCoordinator {
+            SharedPreviewWindowCoordinator.activeInstance?.hideWindow()
+        }
     }
 
     @MainActor

--- a/DockDoor/Views/Hover Window/WindowPreviewCompact.swift
+++ b/DockDoor/Views/Hover Window/WindowPreviewCompact.swift
@@ -10,14 +10,26 @@ struct WindowPreviewCompact: View {
     let currIndex: Int
     let windowSwitcherActive: Bool
     let mockPreviewActive: Bool
+    let disableActions: Bool
     let onTap: (() -> Void)?
     let onHoverIndexChange: ((Int?, CGPoint?) -> Void)?
 
     @Default(.previewWidth) private var previewWidth
     @Default(.compactModeTitleFormat) private var titleFormat
     @Default(.compactModeItemSize) private var itemSize
-    @Default(.trafficLightButtonsVisibility) private var trafficLightButtonsVisibility
     @Default(.selectionOpacity) private var selectionOpacity
+
+    // Dock traffic light settings
+    @Default(.trafficLightButtonsVisibility) private var dockTrafficLightButtonsVisibility
+    @Default(.enabledTrafficLightButtons) private var dockEnabledTrafficLightButtons
+    @Default(.useMonochromeTrafficLights) private var dockUseMonochromeTrafficLights
+    @Default(.disableButtonHoverEffects) private var dockDisableButtonHoverEffects
+
+    // Switcher traffic light settings
+    @Default(.switcherTrafficLightButtonsVisibility) private var switcherTrafficLightButtonsVisibility
+    @Default(.switcherEnabledTrafficLightButtons) private var switcherEnabledTrafficLightButtons
+    @Default(.switcherUseMonochromeTrafficLights) private var switcherUseMonochromeTrafficLights
+    @Default(.switcherDisableButtonHoverEffects) private var switcherDisableButtonHoverEffects
     @Default(.unselectedContentOpacity) private var unselectedContentOpacity
     @Default(.hoverHighlightColor) private var hoverHighlightColor
     @Default(.showMinimizedHiddenLabels) private var showMinimizedHiddenLabels
@@ -110,17 +122,25 @@ struct WindowPreviewCompact: View {
 
             Spacer(minLength: 0)
 
-            // Traffic light buttons
+            // Traffic light buttons - use context-based settings
+            let effectiveVisibility = windowSwitcherActive ? switcherTrafficLightButtonsVisibility : dockTrafficLightButtonsVisibility
+            let effectiveEnabledButtons = windowSwitcherActive ? switcherEnabledTrafficLightButtons : dockEnabledTrafficLightButtons
+            let effectiveMonochrome = windowSwitcherActive ? switcherUseMonochromeTrafficLights : dockUseMonochromeTrafficLights
+            let effectiveDisableHover = windowSwitcherActive ? switcherDisableButtonHoverEffects : dockDisableButtonHoverEffects
+
             if windowInfo.closeButton != nil,
-               trafficLightButtonsVisibility != .never,
+               effectiveVisibility != .never,
                !showMinimizedHiddenLabels || (!windowInfo.isMinimized && !windowInfo.isHidden)
             {
                 TrafficLightButtons(
-                    displayMode: trafficLightButtonsVisibility,
+                    displayMode: effectiveVisibility,
                     hoveringOverParentWindow: isSelected || isHovering,
                     onWindowAction: handleWindowAction,
                     pillStyling: true,
-                    mockPreviewActive: mockPreviewActive
+                    mockPreviewActive: mockPreviewActive,
+                    enabledButtons: effectiveEnabledButtons,
+                    useMonochrome: effectiveMonochrome,
+                    disableButtonHoverEffects: effectiveDisableHover
                 )
             }
         }

--- a/DockDoor/consts.swift
+++ b/DockDoor/consts.swift
@@ -56,8 +56,37 @@ extension Defaults.Keys {
     static let showSpecialAppControls = Key<Bool>("showSpecialAppControls", default: true)
     static let useEmbeddedMediaControls = Key<Bool>("useEmbeddedMediaControls", default: false)
     static let useEmbeddedDockPreviewElements = Key<Bool>("useEmbeddedDockPreviewElements", default: false)
+    static let useEmbeddedWindowSwitcherElements = Key<Bool>("useEmbeddedWindowSwitcherElements", default: false)
+
+    // Dock appearance settings (primary context - uses unprefixed keys)
+    static let showWindowTitle = Key<Bool>("showWindowTitle", default: true)
+    static let showAppIconOnly = Key<Bool>("showAppIconOnly", default: false)
+    static let windowTitleVisibility = Key<WindowTitleVisibility>("windowTitleVisibility", default: .alwaysVisible)
+    static let trafficLightButtonsVisibility = Key<TrafficLightButtonsVisibility>("trafficLightButtonsVisibility", default: .dimmedOnPreviewHover)
+    static let enabledTrafficLightButtons = Key<Set<WindowAction>>("enabledTrafficLightButtons", default: [.quit, .close, .minimize, .toggleFullScreen])
+    static let useMonochromeTrafficLights = Key<Bool>("useMonochromeTrafficLights", default: false)
     static let disableDockStyleTrafficLights = Key<Bool>("disableDockStyleTrafficLights", default: false)
     static let disableDockStyleTitles = Key<Bool>("disableDockStyleTitles", default: false)
+    static let disableButtonHoverEffects = Key<Bool>("disableButtonHoverEffects", default: false)
+
+    // Window Switcher header settings
+    static let switcherShowHeaderAppIcon = Key<Bool>("switcherShowHeaderAppIcon", default: true)
+    static let switcherShowHeaderAppName = Key<Bool>("switcherShowHeaderAppName", default: true)
+    static let switcherShowHeaderWindowTitle = Key<Bool>("switcherShowHeaderWindowTitle", default: true)
+    static let switcherHeaderAppIconVisibility = Key<WindowTitleVisibility>("switcherHeaderAppIconVisibility", default: .alwaysVisible)
+    static let switcherHeaderAppNameVisibility = Key<WindowTitleVisibility>("switcherHeaderAppNameVisibility", default: .alwaysVisible)
+    static let switcherHeaderTitleVisibility = Key<WindowTitleVisibility>("switcherHeaderTitleVisibility", default: .alwaysVisible)
+
+    // Window Switcher embedded mode settings
+    static let switcherShowWindowTitle = Key<Bool>("switcherShowWindowTitle", default: true)
+    static let switcherWindowTitleVisibility = Key<WindowTitleVisibility>("switcherWindowTitleVisibility", default: .alwaysVisible)
+    static let switcherTrafficLightButtonsVisibility = Key<TrafficLightButtonsVisibility>("switcherTrafficLightButtonsVisibility", default: .dimmedOnPreviewHover)
+    static let switcherEnabledTrafficLightButtons = Key<Set<WindowAction>>("switcherEnabledTrafficLightButtons", default: [.quit, .close, .minimize, .toggleFullScreen])
+    static let switcherUseMonochromeTrafficLights = Key<Bool>("switcherUseMonochromeTrafficLights", default: false)
+    static let switcherDisableDockStyleTrafficLights = Key<Bool>("switcherDisableDockStyleTrafficLights", default: false)
+    static let switcherDisableDockStyleTitles = Key<Bool>("switcherDisableDockStyleTitles", default: false)
+    static let switcherDisableButtonHoverEffects = Key<Bool>("switcherDisableButtonHoverEffects", default: false)
+
     static let showBigControlsWhenNoValidWindows = Key<Bool>("showBigControlsWhenNoValidWindows", default: true)
     static let enablePinning = Key<Bool>("enablePinning", default: true)
 
@@ -108,17 +137,8 @@ extension Defaults.Keys {
     static let hidePreviewCardBackground = Key<Bool>("hidePreviewCardBackground", default: false)
     static let showActiveWindowBorder = Key<Bool>("showActiveWindowBorder", default: false)
 
-    static let showWindowTitle = Key<Bool>("showWindowTitle", default: true)
-    static let showAppIconOnly = Key<Bool>("showAppIconOnly", default: false)
-    static let windowTitleDisplayCondition = Key<WindowTitleDisplayCondition>("windowTitleDisplayCondition", default: .all)
-    static let windowTitleVisibility = Key<WindowTitleVisibility>("windowTitleVisibility", default: .alwaysVisible)
-    static let windowTitlePosition = Key<WindowTitlePosition>("windowTitlePosition", default: .bottomLeft)
     static let enableTitleMarquee = Key<Bool>("enableTitleMarquee", default: true)
 
-    static let trafficLightButtonsVisibility = Key<TrafficLightButtonsVisibility>("trafficLightButtonsVisibility", default: .dimmedOnPreviewHover)
-    static let trafficLightButtonsPosition = Key<TrafficLightButtonsPosition>("trafficLightButtonsPosition", default: .topLeft)
-    static let enabledTrafficLightButtons = Key<Set<WindowAction>>("enabledTrafficLightButtons", default: [.quit, .close, .minimize, .toggleFullScreen])
-    static let useMonochromeTrafficLights = Key<Bool>("useMonochromeTrafficLights", default: false)
     static let showMinimizedHiddenLabels = Key<Bool>("showMinimizedHiddenLabels", default: true)
 
     static let previewMaxColumns = Key<Int>("previewMaxColumns", default: 2) // For left/right dock
@@ -215,43 +235,6 @@ enum WindowImageCaptureQuality: String, CaseIterable, Defaults.Serializable {
     }
 }
 
-enum WindowTitleDisplayCondition: String, CaseIterable, Defaults.Serializable {
-    case all
-    case dockPreviewsOnly
-    case windowSwitcherOnly
-
-    var localizedName: String {
-        switch self {
-        case .all:
-            String(localized: "Dock Previews & Window Switcher", comment: "Preview window title display condition option")
-        case .dockPreviewsOnly:
-            String(localized: "Dock Previews only", comment: "Preview window title condition display option")
-        case .windowSwitcherOnly:
-            String(localized: "Window Switcher only", comment: "Preview window title condition display option")
-        }
-    }
-}
-
-enum WindowTitlePosition: String, CaseIterable, Defaults.Serializable {
-    case bottomLeft
-    case bottomRight
-    case topRight
-    case topLeft
-
-    var localizedName: String {
-        switch self {
-        case .bottomLeft:
-            String(localized: "Bottom Left", comment: "Preview window title position option")
-        case .bottomRight:
-            String(localized: "Bottom Right", comment: "Preview window title position option")
-        case .topRight:
-            String(localized: "Top Right", comment: "Preview window title position option")
-        case .topLeft:
-            String(localized: "Top Left", comment: "Preview window title position option")
-        }
-    }
-}
-
 enum AppNameStyle: String, CaseIterable, Defaults.Serializable {
     case `default`
     case shadowed
@@ -271,12 +254,29 @@ enum AppNameStyle: String, CaseIterable, Defaults.Serializable {
 
 enum WindowTitleVisibility: String, CaseIterable, Defaults.Serializable {
     case whenHoveringPreview
+    case never
+    case hiddenUntilHover
+    case dimmedUntilHover
     case alwaysVisible
+
+    static var visibleCases: [WindowTitleVisibility] {
+        [.hiddenUntilHover, .dimmedUntilHover, .alwaysVisible]
+    }
+
+    static var headerCases: [WindowTitleVisibility] {
+        [.hiddenUntilHover, .alwaysVisible]
+    }
 
     var localizedName: String {
         switch self {
         case .whenHoveringPreview:
             String(localized: "When hovering over the preview", comment: "Window title visibility option")
+        case .never:
+            String(localized: "Never visible", comment: "Window title visibility option")
+        case .hiddenUntilHover:
+            String(localized: "When hovering over the preview", comment: "Window title visibility option")
+        case .dimmedUntilHover:
+            String(localized: "Dimmed until hover", comment: "Window title visibility option")
         case .alwaysVisible:
             String(localized: "Always visible", comment: "Window title visibility option")
         }
@@ -285,40 +285,27 @@ enum WindowTitleVisibility: String, CaseIterable, Defaults.Serializable {
 
 enum TrafficLightButtonsVisibility: String, CaseIterable, Defaults.Serializable {
     case never
+    case hiddenUntilHover
     case dimmedOnPreviewHover
     case fullOpacityOnPreviewHover
     case alwaysVisible
+
+    static var visibleCases: [TrafficLightButtonsVisibility] {
+        [.hiddenUntilHover, .dimmedOnPreviewHover, .fullOpacityOnPreviewHover, .alwaysVisible]
+    }
 
     var localizedName: String {
         switch self {
         case .never:
             String(localized: "Never visible", comment: "Traffic light buttons visibility option")
+        case .hiddenUntilHover:
+            String(localized: "Hidden until hover", comment: "Traffic light buttons visibility option")
         case .dimmedOnPreviewHover:
             String(localized: "On window hover; Dimmed until button hover", comment: "Traffic light buttons visibility option")
         case .fullOpacityOnPreviewHover:
             String(localized: "On window hover; Full opacity", comment: "Traffic light buttons visibility option")
         case .alwaysVisible:
             String(localized: "Always visible; Full opacity", comment: "Traffic light buttons visibility option")
-        }
-    }
-}
-
-enum TrafficLightButtonsPosition: String, CaseIterable, Defaults.Serializable {
-    case topLeft
-    case topRight
-    case bottomRight
-    case bottomLeft
-
-    var localizedName: String {
-        switch self {
-        case .topLeft:
-            String(localized: "Top Left", comment: "Traffic light buttons position option")
-        case .topRight:
-            String(localized: "Top Right", comment: "Traffic light buttons position option")
-        case .bottomRight:
-            String(localized: "Bottom Right", comment: "Traffic light buttons position option")
-        case .bottomLeft:
-            String(localized: "Bottom Left", comment: "Traffic light buttons position option")
         }
     }
 }


### PR DESCRIPTION
https://github.com/user-attachments/assets/de95bf88-7510-4acd-98ef-9356df755279

## Summary

Adds context-based appearance settings, allowing users to configure Dock previews and Window Switcher independently. Previously, many appearance options were global and applied to both contexts, limiting customization flexibility.

## Motivation

- Users couldn't configure Dock and Window Switcher appearances separately
- Some settings only made sense in one context but affected both
- Settings UI didn't provide live preview feedback for traffic light button changes
- The settings organization was confusing with mixed global/context options

## Changes

### New Settings Architecture

**Dock Preview Settings (10 new keys):**
- Header visibility: `dockShowHeaderAppIcon`, `dockShowHeaderAppName`
- Window title: `dockShowWindowTitle`, `dockWindowTitleVisibility`
- Traffic lights: `dockTrafficLightButtonsVisibility`, `dockEnabledTrafficLightButtons`
- Styling: `dockUseMonochromeTrafficLights`, `dockDisableDockStyleTrafficLights`, `dockDisableDockStyleTitles`, `dockDisableButtonHoverEffects`

**Window Switcher Settings (14 new keys):**
- Embedded mode: `useEmbeddedWindowSwitcherElements`
- Header toggles: `switcherShowHeaderAppIcon`, `switcherShowHeaderAppName`, `switcherShowHeaderWindowTitle`
- Header visibility: `switcherHeaderAppIconVisibility`, `switcherHeaderAppNameVisibility`, `switcherHeaderTitleVisibility`
- Embedded title: `switcherShowWindowTitle`, `switcherWindowTitleVisibility`
- Traffic lights: `switcherTrafficLightButtonsVisibility`, `switcherEnabledTrafficLightButtons`, `switcherUseMonochromeTrafficLights`, `switcherDisableDockStyleTrafficLights`, `switcherDisableDockStyleTitles`, `switcherDisableButtonHoverEffects`

### Removed Global Settings

| Removed | Replaced By |
|---------|-------------|
| `showWindowTitle` | `dockShowWindowTitle`, `switcherShowWindowTitle` |
| `showAppIconOnly` | `dockShowHeaderAppName`, `switcherShowHeaderAppName` |
| `windowTitleDisplayCondition` | Separate context settings |
| `windowTitleVisibility` | `dockWindowTitleVisibility`, `switcherWindowTitleVisibility` |
| `windowTitlePosition` | Removed (follows control position) |
| `trafficLightButtonsVisibility` | `dock/switcherTrafficLightButtonsVisibility` |
| `trafficLightButtonsPosition` | Removed (follows control position) |
| `enabledTrafficLightButtons` | `dock/switcherEnabledTrafficLightButtons` |
| `useMonochromeTrafficLights` | `dock/switcherUseMonochromeTrafficLights` |

### Removed Enums
- `WindowTitleDisplayCondition`
- `WindowTitlePosition`
- `TrafficLightButtonsPosition`

### New Visibility Options
- `WindowTitleVisibility`: added `.never`, `.hiddenUntilHover`, `.dimmedUntilHover`
- `TrafficLightButtonsVisibility`: added `.hiddenUntilHover`

### UI Improvements

- Settings preview now responds to hover (previously static)
- Traffic light buttons show actual hover effects in preview
- Reusable `ContextTrafficLightButtonsSettingsView` with live preview
- Per-button hover state tracking with dim overlay effect

### Bug Fixes
- Fixed settings preview interfering with active dock previews
- Added `isMockCoordinator` flag to prevent mock coordinators from hiding real previews

## Testing

- [x] Dock preview settings apply only to dock previews
- [x] Window Switcher settings apply only to switcher
- [x] Settings preview shows live changes
- [x] Traffic light button hover effects work
- [x] All visibility options work correctly
- [x] Embedded mode works for both contexts
- [x] Clean build with no warnings

## Breaking Changes

None. New settings have sensible defaults matching previous behavior.

closes #698 closes #911