### PR TITLE
feat: add stream keep-alive option for live preview

### DIFF
--- a/DockDoor/Localizable.xcstrings
+++ b/DockDoor/Localizable.xcstrings
@@ -53131,6 +53131,9 @@
         }
       }
     },
+    "How long to keep video streams active after closing preview. Longer duration means faster reopening but uses more resources." : {
+
+    },
     "How to Set Up" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -54464,6 +54467,9 @@
           }
         }
       }
+    },
+    "Immediately close" : {
+
     },
     "Important: When recording, press ONLY the trigger key (e.g. just press Tab if you want command + Tab). Do not press the initialization key during recording." : {
       "extractionState" : "stale",
@@ -57133,6 +57139,9 @@
           }
         }
       }
+    },
+    "Keep Open" : {
+
     },
     "Keep preview when app terminates" : {
       "localizations" : {
@@ -101696,6 +101705,9 @@
           }
         }
       }
+    },
+    "Stream Keep-Alive Duration" : {
+
     },
     "Subatomic" : {
       "comment" : "Window size option",

--- a/DockDoor/Views/Hover Window/WindowPreviewHoverContainer.swift
+++ b/DockDoor/Views/Hover Window/WindowPreviewHoverContainer.swift
@@ -155,6 +155,15 @@ struct WindowPreviewHoverContainer: View {
         .padding(.top, (!previewStateCoordinator.windowSwitcherActive && appNameStyle == .popover && showAppTitleData) ? 30 : 0)
         .onAppear {
             loadAppIcon()
+            // Only use LiveCaptureManager when live preview AND keep-alive are both enabled
+            if Defaults[.enableLivePreview], Defaults[.livePreviewStreamKeepAlive] != 0 {
+                LiveCaptureManager.shared.panelOpened()
+            }
+        }
+        .onDisappear {
+            if Defaults[.enableLivePreview], Defaults[.livePreviewStreamKeepAlive] != 0 {
+                Task { await LiveCaptureManager.shared.panelClosed() }
+            }
         }
         .onChange(of: previewStateCoordinator.windowSwitcherActive) { isActive in
             if !isActive {

--- a/DockDoor/consts.swift
+++ b/DockDoor/consts.swift
@@ -42,6 +42,7 @@ extension Defaults.Keys {
     static let windowSwitcherLivePreviewQuality = Key<LivePreviewQuality>("windowSwitcherLivePreviewQuality", default: .low)
     static let windowSwitcherLivePreviewFrameRate = Key<LivePreviewFrameRate>("windowSwitcherLivePreviewFrameRate", default: .fps10)
     static let windowSwitcherLivePreviewScope = Key<WindowSwitcherLivePreviewScope>("windowSwitcherLivePreviewScope", default: .selectedAppWindows)
+    static let livePreviewStreamKeepAlive = Key<Int>("livePreviewStreamKeepAlive", default: 0)
 
     static let uniformCardRadius = Key<Bool>("uniformCardRadius", default: true)
     static let allowDynamicImageSizing = Key<Bool>("allowDynamicImageSizing", default: false)


### PR DESCRIPTION
![1](https://github.com/user-attachments/assets/a0b00b34-e21f-4370-b16d-4da4405c89bf)

https://github.com/user-attachments/assets/3d0983a3-6e1d-4601-911d-8a9c16eea33f

When hovering over dock icons or reactivating window switcher quickly, live preview had noticeable stutter because streams were starting fresh each time. This adds a keep-alive option that keeps streams running briefly after the preview closes.

**What it does:**
- Three modes in settings:
  - **Immediately close** - stops stream right away (default, same as current behavior)
  - **X seconds** - keeps stream alive briefly for quick re-hover (dock) or reactivation (switcher)
  - **Keep Open** - streams stay alive indefinitely
- Dock: If you hover the same app again within the keep-alive period, preview appears instantly
- Window Switcher: If you reactivate switcher within the keep-alive period, previews appear instantly

**Architecture:**

| Mode | View | State Management | Stop Logic |
|------|------|------------------|------------|
| Immediately close | `LivePreviewImageFresh` | Per-view `@StateObject` | `onDisappear → stopCapture()` |
| X seconds / Keep Open | `LivePreviewImageCached` | `LiveCaptureManager` singleton | Debounced via `stopGeneration` |

- **Immediately close:** Uses the exact same pattern as current main - each view creates its own `WindowLiveCapture` instance with `@StateObject`, stream stops on `onDisappear`
- **Keep-alive modes:** Uses `LiveCaptureManager` singleton to persist `WindowLiveCapture` instances across hover events. When panel closes, `panelClosed()` starts a debounce timer. If panel reopens before timer fires (`panelOpened()` increments `stopGeneration`), the pending stop is cancelled and stream continues

**Other improvements:**
- VideoToolbox (`VTCreateCGImageFromCVPixelBuffer`) instead of CIContext for faster image conversion
- HDR (`captureDynamicRange = .hdrLocalDisplay`) and Display P3 color space on macOS 15+
- `captureResolution = .best` on macOS 14+

**Use case:**
Great for users with powerful hardware who want the smoothest experience, or for those who need to constantly monitor background videos/streams through dock previews. I personally use "Keep Open" mode while plugged in.

**No breaking changes** - default is "Immediately close" which behaves exactly like current main.