### PR TITLE
refactor: Standardize feature sections, remove dead CSS & polish spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -639,7 +639,7 @@
     </section>
 
     <!-- Support Section -->
-    <section class="support-section section" id="support">
+    <section class="support-section section">
         <div class="container">
             <div class="support-content">
                 <h2 class="support-headline">Support Independent Development</h2>
@@ -650,7 +650,7 @@
                         <h3 class="support-title">Help Keep DockDoor Free & Growing</h3>
                         <p class="support-description">Your support funds new features, bug fixes, and ongoing maintenance. No subscriptions, no ads, no data selling. Just community support.</p>
                         <a href="donate.html" class="btn btn-coffee btn-large">Support Development</a>
-                        <p style="margin-top: 1rem; font-size: 0.9rem; opacity: 0.8;">Even $3 makes a huge difference</p>
+                        <p class="support-line">Even $3 makes a huge difference</p>
                     </div>
                 </div>
 

--- a/styles.css
+++ b/styles.css
@@ -1072,7 +1072,7 @@ header {
 .support-section {
     background: var(--primary);
     color: white;
-    padding: 6rem 0;
+    margin-top: 6rem;
 }
 
 .support-content {
@@ -1083,24 +1083,19 @@ header {
 
 .support-headline {
     font-size: 3.5rem;
-    font-weight: 700;
     line-height: 1.08;
-    color: white;
     margin-bottom: 1rem;
-    letter-spacing: -0.025em;
 }
 
 .support-subheadline {
     font-size: 1.375rem;
-    font-weight: 400;
-    line-height: 1.4;
-    color: rgba(255, 255, 255, 0.9);
+    color: var(--light-gray);
     margin-bottom: 4rem;
-    letter-spacing: -0.01em;
 }
 
 .support-actions {
     margin-bottom: 4rem;
+    text-wrap: balance;
 }
 
 .support-primary {
@@ -1110,17 +1105,19 @@ header {
 
 .support-title {
     font-size: 1.75rem;
-    font-weight: 600;
-    color: white;
     margin-bottom: 1rem;
-    letter-spacing: -0.015em;
 }
 
 .support-description {
     font-size: 1.0625rem;
     line-height: 1.47;
-    color: rgba(255, 255, 255, 0.9);
+    color: var(--light-gray);
     margin-bottom: 2rem;
+}
+
+.support-line {
+    margin-top: 2rem;
+    font-size: 0.9rem;
 }
 
 .support-alternatives {
@@ -1130,10 +1127,7 @@ header {
 
 .alternatives-title {
     font-size: 1.5rem;
-    font-weight: 600;
-    color: white;
     margin-bottom: 2rem;
-    letter-spacing: -0.015em;
 }
 
 .alternatives-grid {
@@ -1151,10 +1145,11 @@ header {
     color: white;
     transition: var(--transition);
     border-radius: var(--radius);
+    border: 1px solid rgba(255, 255, 255, 0.2);
 }
 
 .alternative-link:hover {
-    background: rgba(255, 255, 255, 0.1);
+    background: rgba(255, 255, 255, 0.2);
     color: white;
 }
 
@@ -1163,14 +1158,12 @@ header {
     font-size: 1.125rem;
     font-weight: 600;
     margin-bottom: 0.5rem;
-    letter-spacing: -0.01em;
 }
 
 .alternative-desc {
     display: block;
     font-size: 0.9375rem;
-    color: rgba(255, 255, 255, 0.8);
-    line-height: 1.4;
+    color: var(--light-gray);
 }
 
 /* Download Section - Apple Style */


### PR DESCRIPTION
## Describe your changes
This PR focuses on **codebase health, consistency, and UI standardization**. I've performed a comprehensive refactor of the CSS and HTML structure to reduce technical debt and ensure a unified look across all sections.

**1. Architecture & Standardization:**
* **Unified Class Naming:** Refactored separate style definitions for Features, Customization, Settings, and Controls into a unified naming convention. This dramatically reduces CSS duplication and improves semantic grouping.
* **Layout Consistency:** Enforced consistent spacing, padding, and alignment across the entire page layout.

**2. Code Cleanup:**
* **Deleted Unused CSS:** Removed a significant amount of legacy styles that were no longer in use (old card styles, unused grids, redundant media queries, and utility classes).

**3. Visual Polish:**
* **HTML Sections:** Cleaned up all sections, removed unused IDs, used text-wrap: balance where it needs and change some title colors to primary color.
* **Color & Typography:** Removed redundant font-weight and color properties, ensuring all elements inherit from the defined design system variables.

## Related issue number(s) and link(s)
N/A (Global Refactor & Cleanup)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] If this change affects core functionality, I have added a description highlighting the changes
- [x] I have followed conventional commit guidelines

## Core Functionality Changes
No logic changes. This is a purely visual and structural refactor.

Features Section - Before:
<img width="1918" height="867" alt="image" src="https://github.com/user-attachments/assets/d71b2d04-0a32-4007-96a5-e1c393a2e3e9" />

Features Section - After:
<img width="1915" height="795" alt="image" src="https://github.com/user-attachments/assets/7f7115e8-653f-4703-a114-3bd086d456b7" />

Keyboard Section - Before:
<img width="1916" height="854" alt="image" src="https://github.com/user-attachments/assets/4e48c7e4-ccbd-4d4a-826d-346a900312c6" />

Keyboard Section - After:
<img width="1917" height="842" alt="image" src="https://github.com/user-attachments/assets/b66bfd5c-3ea8-464c-b955-87a27ae007ee" />

Support Section - Before:
<img width="1916" height="933" alt="image" src="https://github.com/user-attachments/assets/ed87daea-13d4-4ad2-8bd7-8a3b333f9dbc" />

Support Section - After:
<img width="1916" height="955" alt="image" src="https://github.com/user-attachments/assets/31b74a8b-5946-4040-8fda-a30a8638702e" />