### PR TITLE
feat: Add support for parallel title and controls in window previews

### DIFF
--- a/DockDoor/Localizable.xcstrings
+++ b/DockDoor/Localizable.xcstrings
@@ -105,13 +105,13 @@
             "value" : ""
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : ""
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : ""
@@ -295,13 +295,13 @@
             "value" : " "
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : " "
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : " "
@@ -486,16 +486,16 @@
             "value" : " - 비활성"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : " - Inactive"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : " - Inactief"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : " - Inactive"
           }
         },
         "pl" : {
@@ -676,13 +676,13 @@
             "value" : "-%@"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "-%@"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "-%@"
@@ -866,13 +866,13 @@
             "value" : "%@"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "%@"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "%@"
@@ -1062,13 +1062,13 @@
             "value" : "%1$@ — %2$@"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "%1$@ — %2$@"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "%1$@ — %2$@"
@@ -1252,13 +1252,13 @@
             "value" : "%lld"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "%lld"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "%lld"
@@ -1443,13 +1443,13 @@
             "value" : "%lld px"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "%lld px"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "%lld px"
@@ -1636,13 +1636,13 @@
             "value" : "%lld+ windows"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "%lld+ windows"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "%lld+ windows"
@@ -1827,16 +1827,16 @@
             "value" : "• 독(Dock)에서의 향상된 시각 정보를 위해 허용합니다"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "• Allows for enhanced visual information in the dock"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Zorgt voor verbeterde visuele informatie in het dock"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "• Allows for enhanced visual information in the dock"
           }
         },
         "pl" : {
@@ -2018,16 +2018,16 @@
             "value" : "• 독(Dock)에 있는 항목과의 실시간 상호작용을 가능하게 합니다"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "• Enables real-time interaction with dock items"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Maakt realtime interactie met dock items mogelijk"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "• Enables real-time interaction with dock items"
           }
         },
         "pl" : {
@@ -2209,16 +2209,16 @@
             "value" : "• 이미지와 창의 미리보기를 생성합니다"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "• To capture previews of images and windows"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Voorvertoningen van afbeeldingen en vensters vastleggen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "• To capture previews of images and windows"
           }
         },
         "pl" : {
@@ -2400,16 +2400,16 @@
             "value" : "• 독에 마우스를 올렸는지 감지합니다"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "• To detect when you hover over the dock"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Om te detecteren wanneer u boven het dock zweeft"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "• To detect when you hover over the dock"
           }
         },
         "pl" : {
@@ -2591,16 +2591,16 @@
             "value" : "• 하단의 도크 위로 마우스를 가져가면 창이 왼쪽에서 오른쪽으로 일렬로 흐릅니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "• When hovering over the Dock at the bottom, windows flow in rows from left to right"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Wanneer u met de muis over het Dock onderaan beweegt, vloeien de vensters in rijen van links naar rechts"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "• When hovering over the Dock at the bottom, windows flow in rows from left to right"
           }
         },
         "pl" : {
@@ -2782,16 +2782,16 @@
             "value" : "• 측면의 도크 위로 마우스를 가져가면 창이 위에서 아래로 기둥 모양으로 흐릅니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "• When hovering over the Dock on the sides, windows flow in columns from top to bottom"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Wanneer u met de muis over het Dock aan de zijkanten zweeft, vloeien de vensters in kolommen van boven naar beneden"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "• When hovering over the Dock on the sides, windows flow in columns from top to bottom"
           }
         },
         "pl" : {
@@ -2973,16 +2973,16 @@
             "value" : "• 창 전환기를 사용할 때 창은 항상 왼쪽에서 오른쪽으로 일렬로 흐릅니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "• When using the Window Switcher, windows always flow in rows from left to right"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bij gebruik van de Window Switcher lopen de vensters altijd in rijen van links naar rechts"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "• When using the Window Switcher, windows always flow in rows from left to right"
           }
         },
         "pl" : {
@@ -3163,15 +3163,15 @@
             "value" : "+"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "+"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "+"
           }
         },
@@ -3353,13 +3353,13 @@
             "value" : "+%lld more"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "+%lld more"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "+%lld more"
@@ -3543,13 +3543,13 @@
             "value" : "×"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "×"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "×"
@@ -3733,13 +3733,13 @@
             "value" : "⌘"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "⌘"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "⌘"
@@ -3924,15 +3924,15 @@
             "value" : "1."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "1."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "1."
           }
         },
@@ -4115,16 +4115,16 @@
             "value" : ""
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "1. Select \"Command (⌘)\" as the initialization key."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "1. Selecteer \"Command (⌘)\" als initialisatie toets."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "1. Select \"Command (⌘)\" as the initialization key."
           }
         },
         "pl" : {
@@ -4306,15 +4306,15 @@
             "value" : "1/%lldx"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "1/%lldx"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "1/%lldx"
           }
         },
@@ -4497,15 +4497,15 @@
             "value" : "2."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "2."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "2."
           }
         },
@@ -4688,16 +4688,16 @@
             "value" : "2. \"트리거 키 녹화 시작\"을 클릭합니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "2. Click \"Start Recording Trigger Key\"."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "2. Klik op \"Start opname sneltoets\"."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "2. Click \"Start Recording Trigger Key\"."
           }
         },
         "pl" : {
@@ -4879,13 +4879,13 @@
             "value" : "2X-Large"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "2X-Large"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "2X-Large"
@@ -5070,15 +5070,15 @@
             "value" : "3."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "3."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "3."
           }
         },
@@ -5261,16 +5261,16 @@
             "value" : "3. Tab 키만 누릅니다(Command+Tab이 아닌)."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "3. Press ONLY the Tab key (not Command+Tab)."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "3. Druk ALLEEN op de TAB toets (niet Command+Tab)."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "3. Press ONLY the Tab key (not Command+Tab)."
           }
         },
         "pl" : {
@@ -5452,13 +5452,13 @@
             "value" : "3X-Large"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "3X-Large"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "3X-Large"
@@ -5643,15 +5643,15 @@
             "value" : "4."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "4."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "4."
           }
         },
@@ -5834,16 +5834,16 @@
             "value" : ""
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "4. Your keybind will be set to Command+Tab."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "4. De sneltoets wordt ingesteld op Command+Tab."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "4. Your keybind will be set to Command+Tab."
           }
         },
         "pl" : {
@@ -6024,13 +6024,13 @@
             "value" : "5 FPS"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "5 FPS"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "5 FPS"
@@ -6214,13 +6214,13 @@
             "value" : "10 FPS"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "10 FPS"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "10 FPS"
@@ -6404,13 +6404,13 @@
             "value" : "15 FPS"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "15 FPS"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "15 FPS"
@@ -6594,13 +6594,13 @@
             "value" : "24 FPS"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "24 FPS"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "24 FPS"
@@ -6784,13 +6784,13 @@
             "value" : "30 FPS"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "30 FPS"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "30 FPS"
@@ -6974,13 +6974,13 @@
             "value" : "60 FPS"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "60 FPS"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "60 FPS"
@@ -7164,13 +7164,13 @@
             "value" : "120 FPS (ProMotion)"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "120 FPS (ProMotion)"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "120 FPS (ProMotion)"
@@ -7354,16 +7354,16 @@
             "value" : "손쉬운 사용"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Accessibility"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Toegankelijkheid"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Accessibility"
           }
         },
         "pl" : {
@@ -7545,16 +7545,16 @@
             "value" : "손쉬운 사용 권한"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Accessibility Permissions"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Toegankelijkheid rechten"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Accessibility Permissions"
           }
         },
         "pl" : {
@@ -7736,16 +7736,16 @@
             "value" : "손쉬운 사용:"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Accessibility:"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Toegankelijkheid:"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Accessibility:"
           }
         },
         "pl" : {
@@ -7926,13 +7926,13 @@
             "value" : "Acknowledgments"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Acknowledgments"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Acknowledgments"
@@ -8116,13 +8116,13 @@
             "value" : "Action performed when middle-clicking on a window preview."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Action performed when middle-clicking on a window preview."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Action performed when middle-clicking on a window preview."
@@ -8307,13 +8307,13 @@
             "value" : "Activate/Hide (same as other apps)"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Activate/Hide (same as other apps)"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Activate/Hide (same as other apps)"
@@ -8498,13 +8498,13 @@
             "value" : "Active App + Current Space"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Active App + Current Space"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Active App + Current Space"
@@ -8688,13 +8688,13 @@
             "value" : "Active App Indicator"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Active App Indicator"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Active App Indicator"
@@ -8879,13 +8879,13 @@
             "value" : "Active App Only"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Active App Only"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Active App Only"
@@ -9069,16 +9069,16 @@
             "value" : "추가"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Add"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Toevoegen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Add"
           }
         },
         "pl" : {
@@ -9260,16 +9260,16 @@
             "value" : "응용 프로그램을 검색할 경로를 추가하세요"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Add additional directories to scan for applications"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Voeg extra mappen toe om te scannen voor applicaties"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Add additional directories to scan for applications"
           }
         },
         "pl" : {
@@ -9450,16 +9450,16 @@
             "value" : "애플리케이션을 검색할 디렉터리를 추가합니다. 이 기능은 앱을 표준 위치 외부에 보관하는 경우에 유용합니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Add additional directories to scan for applications. This is useful if you keep apps outside standard locations."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Voeg extra mappen toe om naar applicaties te scannen. Dit is handig als u apps buiten de standaardlocaties bewaart."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Add additional directories to scan for applications. This is useful if you keep apps outside standard locations."
           }
         },
         "pl" : {
@@ -9640,13 +9640,13 @@
             "value" : "Add App"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Add App"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Add App"
@@ -9830,13 +9830,13 @@
             "value" : "Add App to Blacklist"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Add App to Blacklist"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Add App to Blacklist"
@@ -10020,16 +10020,16 @@
             "value" : "경로 추가"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Add Directory"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Map toevoegen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Add Directory"
           }
         },
         "pl" : {
@@ -10210,16 +10210,16 @@
             "value" : "필터 추가"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Add Filter"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Filter toevoegen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Add Filter"
           }
         },
         "pl" : {
@@ -10401,16 +10401,16 @@
             "value" : "프리뷰가 도크와 맞지 않으면 이것을 조정하세요"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Adjust this if the preview is misaligned with dock"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Pas aan als de uitlijning in de Dock niet goed is"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Adjust this if the preview is misaligned with dock"
           }
         },
         "pl" : {
@@ -10592,13 +10592,13 @@
             "value" : "Adjust volume"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Adjust volume"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Adjust volume"
@@ -10782,16 +10782,16 @@
             "value" : "상호 작용 중에 앱의 반응 속도와 동작을 조정합니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Adjusts how responsive the app feels and behaves during interaction."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Hiermee past u aan hoe responsief de app aanvoelt en zich gedraagt ​​tijdens interactie."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Adjusts how responsive the app feels and behaves during interaction."
           }
         },
         "pl" : {
@@ -10972,13 +10972,13 @@
             "value" : "Aero Shake"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Aero Shake"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Aero Shake"
@@ -11163,16 +11163,16 @@
             "value" : "에어로 쉐이크 액션"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Aero Shake Action"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Aero Schud Actie"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Aero Shake Action"
           }
         },
         "pl" : {
@@ -11353,16 +11353,16 @@
             "value" : "모든 버튼 제거"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "All buttons removed"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Alle knoppen verwijderd"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "All buttons removed"
           }
         },
         "pl" : {
@@ -11543,13 +11543,13 @@
             "value" : "All window previews show a gray background. When hovered, the background changes to the accent color or custom color below."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "All window previews show a gray background. When hovered, the background changes to the accent color or custom color below."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "All window previews show a gray background. When hovered, the background changes to the accent color or custom color below."
@@ -11734,13 +11734,13 @@
             "value" : "All Windows"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "All Windows"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "All Windows"
@@ -11924,13 +11924,13 @@
             "value" : "All windows from the selected app get live preview"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "All windows from the selected app get live preview"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "All windows from the selected app get live preview"
@@ -12114,13 +12114,13 @@
             "value" : "All windows get live preview (may cause lag with many windows)"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "All windows get live preview (may cause lag with many windows)"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "All windows get live preview (may cause lag with many windows)"
@@ -12304,13 +12304,13 @@
             "value" : "Allow dynamic image sizing"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Allow dynamic image sizing"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Allow dynamic image sizing"
@@ -12494,13 +12494,13 @@
             "value" : "오른쪽 클릭 메뉴를 통해 특별한 앱 컨트롤을 화면에 고정할 수 있습니다."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Allow special app controls to be pinned to the screen via right-click menu."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Allow special app controls to be pinned to the screen via right-click menu."
@@ -12684,13 +12684,13 @@
             "value" : "Allows window preview images to scale dynamically to reasonable dimensions, overriding fixed frame constraints."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Allows window preview images to scale dynamically to reasonable dimensions, overriding fixed frame constraints."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Allows window preview images to scale dynamically to reasonable dimensions, overriding fixed frame constraints."
@@ -12875,13 +12875,13 @@
             "value" : "Alphabetical by title"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Alphabetical by title"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Alphabetical by title"
@@ -13065,13 +13065,13 @@
             "value" : "Alternate Shortcut"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Alternate Shortcut"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Alternate Shortcut"
@@ -13257,16 +13257,16 @@
             "value" : "항상"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Always"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Altijd"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Always"
           }
         },
         "pl" : {
@@ -13447,13 +13447,13 @@
             "value" : "Always use compact mode"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Always use compact mode"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Always use compact mode"
@@ -13638,16 +13638,16 @@
             "value" : "항상 표시"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Always visible"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Altijd zichtbaar"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Always visible"
           }
         },
         "pl" : {
@@ -13829,16 +13829,16 @@
             "value" : "항상 보기; 불투명도 최대"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Always visible; Full opacity"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Altijd zichtbaar; volle doorzichtigheid"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Always visible; Full opacity"
           }
         },
         "pl" : {
@@ -14019,16 +14019,16 @@
             "value" : "금액"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "amount"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "aantal"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "amount"
           }
         },
         "pl" : {
@@ -14209,13 +14209,13 @@
             "value" : "An additional trigger key using the same modifier, invoking the switcher with a different filter mode."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "An additional trigger key using the same modifier, invoking the switcher with a different filter mode."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "An additional trigger key using the same modifier, invoking the switcher with a different filter mode."
@@ -14402,16 +14402,16 @@
             "value" : "애니메이션 속도"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Animation speed"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Animatie snelheid"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Animation speed"
           }
         },
         "pl" : {
@@ -14592,13 +14592,13 @@
             "value" : "App Header Style"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "App Header Style"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "App Header Style"
@@ -14782,13 +14782,13 @@
             "value" : "App Name + Window Title"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "App Name + Window Title"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "App Name + Window Title"
@@ -14972,13 +14972,13 @@
             "value" : "App Name Only"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "App Name Only"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "App Name Only"
@@ -15163,16 +15163,16 @@
             "value" : "앱명 스타일"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "App Name Style"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "App naam stijl"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "App Name Style"
           }
         },
         "pl" : {
@@ -15354,16 +15354,16 @@
             "value" : "모양"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Appearance"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Uiterlijk"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Appearance"
           }
         },
         "pl" : {
@@ -15545,16 +15545,16 @@
             "value" : "모양 설정"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Appearance settings"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Uiterlijk Instellingen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Appearance settings"
           }
         },
         "pl" : {
@@ -15735,16 +15735,16 @@
             "value" : "애플리케이션 기본 사항"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Application Basics"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Basisprincipes van de app"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Application Basics"
           }
         },
         "pl" : {
@@ -15926,16 +15926,16 @@
             "value" : "애플리케이션 필터"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Application filters"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Applicatie filter"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Application filters"
           }
         },
         "pl" : {
@@ -16116,16 +16116,16 @@
             "value" : "애플리케이션 필터"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Application Filters"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Applicatie filters"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Application Filters"
           }
         },
         "pl" : {
@@ -16306,13 +16306,13 @@
             "value" : "Apps in this list will not respond to window switcher shortcuts when in fullscreen mode."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Apps in this list will not respond to window switcher shortcuts when in fullscreen mode."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Apps in this list will not respond to window switcher shortcuts when in fullscreen mode."
@@ -16496,16 +16496,16 @@
             "value" : "계속 진행하겠습니까?"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Are you sure you want to proceed?"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Weet je zeker dat je wilt doorgaan?"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Are you sure you want to proceed?"
           }
         },
         "pl" : {
@@ -16687,16 +16687,16 @@
             "value" : "모든 설정을 기본값으로 초기화하시겠습니까?"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Are you sure you want to reset all settings to their default values?"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Weet je zeker dat je alle instellingen wil resetten naar de standaard waarden?"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Are you sure you want to reset all settings to their default values?"
           }
         },
         "pl" : {
@@ -16877,16 +16877,16 @@
             "value" : "모든 설정을 기본값으로 초기화하시겠습니까? 이렇게 하면 고급 설정도 초기화됩니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Are you sure you want to reset all settings to their default values? This will reset advanced settings as well."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Weet u zeker dat u alle instellingen wilt terugzetten naar de standaardwaarden? Hiermee worden ook de geavanceerde instellingen teruggezet."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Are you sure you want to reset all settings to their default values? This will reset advanced settings as well."
           }
         },
         "pl" : {
@@ -17067,16 +17067,16 @@
             "value" : "하단 - 왼쪽의 컨트롤, 오른쪽의 제목"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "At bottom - Controls on left, title on right"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Onderaan - Bedieningselementen links, titel rechts"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "At bottom - Controls on left, title on right"
           }
         },
         "pl" : {
@@ -17257,16 +17257,16 @@
             "value" : "하단 - 왼쪽은 제목, 오른쪽은 컨트롤"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "At bottom - Title on left, controls on right"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Onderaan - titel links, bediening rechts"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "At bottom - Title on left, controls on right"
           }
         },
         "pl" : {
@@ -17447,16 +17447,16 @@
             "value" : "상단 - 왼쪽의 컨트롤, 오른쪽의 제목"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "At top - Controls on left, title on right"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bovenaan - bediening links, titel rechts"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "At top - Controls on left, title on right"
           }
         },
         "pl" : {
@@ -17637,16 +17637,16 @@
             "value" : "상단 - 왼쪽의 제목, 오른쪽의 컨트롤"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "At top - Title on left, controls on right"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bovenaan - titel links, bediening rechts"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "At top - Title on left, controls on right"
           }
         },
         "pl" : {
@@ -17827,13 +17827,13 @@
             "value" : "Auto-scroll speed:"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Auto-scroll speed:"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Auto-scroll speed:"
@@ -18017,16 +18017,16 @@
             "value" : "자동 업데이트"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Automatic Updates"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Automatische Updates"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Automatic Updates"
           }
         },
         "pl" : {
@@ -18208,16 +18208,16 @@
             "value" : "자동으로 업데이트 확인"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Automatically check for updates"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Controleer automatisch voor updates"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Automatically check for updates"
           }
         },
         "pl" : {
@@ -18399,13 +18399,13 @@
             "value" : "Automatically scrolls the window switcher when hovering over windows with the mouse."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Automatically scrolls the window switcher when hovering over windows with the mouse."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Automatically scrolls the window switcher when hovering over windows with the mouse."
@@ -18589,13 +18589,13 @@
             "value" : "Automatically set height and offset"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Automatically set height and offset"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Automatically set height and offset"
@@ -18779,13 +18779,13 @@
             "value" : "Automatically set length"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Automatically set length"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Automatically set length"
@@ -18969,13 +18969,13 @@
             "value" : "Background Opacity"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Background Opacity"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Background Opacity"
@@ -19160,13 +19160,13 @@
             "value" : "Best quality (full resolution)"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Best quality (full resolution)"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Best quality (full resolution)"
@@ -19350,13 +19350,13 @@
             "value" : "Beta"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Beta"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Beta"
@@ -19540,16 +19540,16 @@
             "value" : "블러 정도"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Blur amount"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Blur hoeveelheid"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Blur amount"
           }
         },
         "pl" : {
@@ -19731,16 +19731,16 @@
             "value" : "왼쪽 하단"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Bottom Left"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Linksonderaan"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Bottom Left"
           }
         },
         "pl" : {
@@ -19922,16 +19922,16 @@
             "value" : "오른쪽 하단"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Bottom Right"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Rechtsonderaan"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Bottom Right"
           }
         },
         "pl" : {
@@ -20112,13 +20112,13 @@
             "value" : "Browse for .app file..."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Browse for .app file..."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Browse for .app file..."
@@ -20302,16 +20302,16 @@
             "value" : "커피 한 잔 사주세요"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Buy me a coffee"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Koop een kopje koffie voor me"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Buy me a coffee"
           }
         },
         "pl" : {
@@ -20493,16 +20493,16 @@
             "value" : "따듯한 커피 한 잔 감사합니다"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Buy me a coffee here, thank you!"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Koop hier een koffie voor me, bedankt!"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Buy me a coffee here, thank you!"
           }
         },
         "pl" : {
@@ -20683,13 +20683,13 @@
             "value" : "Calendar"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Calendar"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Calendar"
@@ -20873,13 +20873,13 @@
             "value" : "캘린더 액세스 필요"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Calendar Access Needed"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Calendar Access Needed"
@@ -21063,13 +21063,13 @@
             "value" : "Calendar Access Required"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Calendar Access Required"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Calendar Access Required"
@@ -21255,16 +21255,16 @@
             "value" : "이것도 볼 수 있나요?"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Can you even see this?"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Kan je dit zien?"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Can you even see this?"
           }
         },
         "pl" : {
@@ -21445,16 +21445,16 @@
             "value" : "취소"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Cancel"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Annuleer"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Cancel"
           }
         },
         "pl" : {
@@ -21635,16 +21635,16 @@
             "value" : "색상을 추가할 수 없습니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Cannot Add Color"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Kan kleur niet toevoegen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Cannot Add Color"
           }
         },
         "pl" : {
@@ -21825,16 +21825,16 @@
             "value" : "색상을 제거할 수 없습니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Cannot Remove Color"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Kan kleur niet verwijderen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Cannot Remove Color"
           }
         },
         "pl" : {
@@ -22016,13 +22016,13 @@
             "value" : "Center Window"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Center Window"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Center Window"
@@ -22206,13 +22206,13 @@
             "value" : "Change…"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Change…"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Change…"
@@ -22396,13 +22396,13 @@
             "value" : "Changes to permissions require an app restart to take effect."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Changes to permissions require an app restart to take effect."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Changes to permissions require an app restart to take effect."
@@ -22586,16 +22586,16 @@
             "value" : "업데이트 확인"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Check for Updates"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Controleer op Updates"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Check for Updates"
           }
         },
         "pl" : {
@@ -22776,13 +22776,13 @@
             "value" : "Choose how large window previews appear when hovering over dock icons. All window images are automatically scaled to fit within this size while maintaining their original proportions."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Choose how large window previews appear when hovering over dock icons. All window images are automatically scaled to fit within this size while maintaining their original proportions."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Choose how large window previews appear when hovering over dock icons. All window images are automatically scaled to fit within this size while maintaining their original proportions."
@@ -22966,13 +22966,13 @@
             "value" : "Choose how windows are sorted in Cmd+Tab previews."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Choose how windows are sorted in Cmd+Tab previews."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Choose how windows are sorted in Cmd+Tab previews."
@@ -23156,13 +23156,13 @@
             "value" : "Choose how windows are sorted in the preview."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Choose how windows are sorted in the preview."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Choose how windows are sorted in the preview."
@@ -23346,13 +23346,13 @@
             "value" : "Choose how windows are sorted in the window switcher."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Choose how windows are sorted in the window switcher."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Choose how windows are sorted in the window switcher."
@@ -23537,13 +23537,13 @@
             "value" : "Choose where the window switcher appears on screen."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Choose where the window switcher appears on screen."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Choose where the window switcher appears on screen."
@@ -23727,13 +23727,13 @@
             "value" : "Choose whether vertical or horizontal scrolling controls the media widget."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Choose whether vertical or horizontal scrolling controls the media widget."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Choose whether vertical or horizontal scrolling controls the media widget."
@@ -23917,13 +23917,13 @@
             "value" : "Clear"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Clear"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Clear"
@@ -24107,13 +24107,13 @@
             "value" : "Clear Logs"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Clear Logs"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Clear Logs"
@@ -24298,16 +24298,16 @@
             "value" : "\"트리거 키 설정\"을 클릭합니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Click \"Set Trigger Key\""
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Klik op \"Set Trigger Key\""
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Click \"Set Trigger Key\""
           }
         },
         "pl" : {
@@ -24488,16 +24488,16 @@
             "value" : "닫기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Close"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sluiten"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close"
           }
         },
         "pl" : {
@@ -24679,16 +24679,16 @@
             "value" : "모두 닫기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Close All"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sluit alles"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close All"
           }
         },
         "pl" : {
@@ -24870,13 +24870,13 @@
             "value" : "Close Window"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Close Window"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Close Window"
@@ -25060,13 +25060,13 @@
             "value" : "CMD + Right Click on dock icon to quit app"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "CMD + Right Click on dock icon to quit app"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "CMD + Right Click on dock icon to quit app"
@@ -25250,13 +25250,13 @@
             "value" : "Cmd+A cycles through previews (Shift+A cycles backward), Left/Right navigate, Down clears selection."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Cmd+A cycles through previews (Shift+A cycles backward), Left/Right navigate, Down clears selection."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Cmd+A cycles through previews (Shift+A cycles backward), Left/Right navigate, Down clears selection."
@@ -25441,13 +25441,13 @@
             "value" : "Cmd+A focuses previews, Left/Right navigate, Down clears selection."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Cmd+A focuses previews, Left/Right navigate, Down clears selection."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Cmd+A focuses previews, Left/Right navigate, Down clears selection."
@@ -25631,13 +25631,13 @@
             "value" : "Cmd+key shortcuts for quick actions on the selected window preview. These work in both the window switcher and Cmd+Tab enhancement mode."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Cmd+key shortcuts for quick actions on the selected window preview. These work in both the window switcher and Cmd+Tab enhancement mode."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Cmd+key shortcuts for quick actions on the selected window preview. These work in both the window switcher and Cmd+Tab enhancement mode."
@@ -25821,13 +25821,13 @@
             "value" : "Cmd+Tab"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Cmd+Tab"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Cmd+Tab"
@@ -26011,13 +26011,13 @@
             "value" : "Cmd+Tab Layout"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Cmd+Tab Layout"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Cmd+Tab Layout"
@@ -26201,13 +26201,13 @@
             "value" : "Cmd+Tab Settings"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Cmd+Tab Settings"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Cmd+Tab Settings"
@@ -26391,13 +26391,13 @@
             "value" : "Cmd+Tab Toolbar"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Cmd+Tab Toolbar"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Cmd+Tab Toolbar"
@@ -26582,13 +26582,13 @@
             "value" : "임베디드 모드로 축소"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Collapse to embedded mode"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Collapse to embedded mode"
@@ -26772,16 +26772,16 @@
             "value" : "색상 사용자 지정"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Color Customization"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Kleuraanpassing"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Color Customization"
           }
         },
         "pl" : {
@@ -26963,16 +26963,16 @@
             "value" : "색상"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Colors"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Kleuren"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Colors"
           }
         },
         "pl" : {
@@ -27153,13 +27153,13 @@
             "value" : "Command"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Command"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Command"
@@ -27344,15 +27344,15 @@
             "value" : "커맨드키 (⌘)"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Command (⌘)"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Command (⌘)"
           }
         },
@@ -27534,13 +27534,13 @@
             "value" : "Command ⌘"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Command ⌘"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Command ⌘"
@@ -27724,13 +27724,13 @@
             "value" : "Community Contributors"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Community Contributors"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Community Contributors"
@@ -27914,13 +27914,13 @@
             "value" : "Compact List Mode Only (Window Previews are Disabled)"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Compact List Mode Only (Window Previews are Disabled)"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Compact List Mode Only (Window Previews are Disabled)"
@@ -28104,13 +28104,13 @@
             "value" : "Compact Mode (Titles Only)"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Compact Mode (Titles Only)"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Compact Mode (Titles Only)"
@@ -28294,13 +28294,13 @@
             "value" : "Compact mode displays windows as a streamlined vertical list with app icons and titles."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Compact mode displays windows as a streamlined vertical list with app icons and titles."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Compact mode displays windows as a streamlined vertical list with app icons and titles."
@@ -28484,16 +28484,16 @@
             "value" : "확인"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Confirm"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bevestigen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Confirm"
           }
         },
         "pl" : {
@@ -28674,16 +28674,16 @@
             "value" : "번역 기여하기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Contribute translation"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bijdragen aan vertalingen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Contribute translation"
           }
         },
         "pl" : {
@@ -28865,16 +28865,16 @@
             "value" : "여기에서 번역에 기여하세요!"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Contribute translation here!"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Werk mee aan de vertaling!"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Contribute translation here!"
           }
         },
         "pl" : {
@@ -29055,13 +29055,13 @@
             "value" : "Contributions"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Contributions"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Contributions"
@@ -29245,13 +29245,13 @@
             "value" : "Control"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Control"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Control"
@@ -29436,15 +29436,15 @@
             "value" : "컨트롤키 (⌃)"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Control (⌃)"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Control (⌃)"
           }
         },
@@ -29626,13 +29626,13 @@
             "value" : "Control ⌃"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Control ⌃"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Control ⌃"
@@ -29816,13 +29816,13 @@
             "value" : "Control the transparency of the dock preview background. Lower values make the preview more transparent, which can help prevent it from blocking window content."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Control the transparency of the dock preview background. Lower values make the preview more transparent, which can help prevent it from blocking window content."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Control the transparency of the dock preview background. Lower values make the preview more transparent, which can help prevent it from blocking window content."
@@ -30006,13 +30006,13 @@
             "value" : "Controls how many rows of windows are shown in the window switcher. Windows are distributed across rows automatically."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Controls how many rows of windows are shown in the window switcher. Windows are distributed across rows automatically."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Controls how many rows of windows are shown in the window switcher. Windows are distributed across rows automatically."
@@ -30196,13 +30196,13 @@
             "value" : "Controls how many rows/columns of windows are shown in dock previews. Only the relevant setting applies based on dock position."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Controls how many rows/columns of windows are shown in dock previews. Only the relevant setting applies based on dock position."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Controls how many rows/columns of windows are shown in dock previews. Only the relevant setting applies based on dock position."
@@ -30386,16 +30386,16 @@
             "value" : "창 미리보기의 시각적 세부 사항과 업데이트 빈도를 제어합니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Controls the visual detail and update frequency of window previews."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bepaalt de visuele details en de updatefrequentie van venstervoorbeelden."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Controls the visual detail and update frequency of window previews."
           }
         },
         "pl" : {
@@ -30577,13 +30577,13 @@
             "value" : "Creation order (fixed)"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Creation order (fixed)"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Creation order (fixed)"
@@ -30767,13 +30767,13 @@
             "value" : "Current aspect ratio: %@"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Current aspect ratio: %@"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Current aspect ratio: %@"
@@ -30958,13 +30958,13 @@
             "value" : "Current Dock Size:"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Current Dock Size:"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Current Dock Size:"
@@ -31149,16 +31149,16 @@
             "value" : "현재 키 조합: %@"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Current Keybind: %@"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Huidige Toetscombinatie: %@"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Current Keybind: %@"
           }
         },
         "pl" : {
@@ -31340,16 +31340,16 @@
             "value" : "현재 바로 가기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Current Shortcut"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Huidige sneltoets"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Current Shortcut"
           }
         },
         "pl" : {
@@ -31531,13 +31531,13 @@
             "value" : "Current Space Only"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Current Space Only"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Current Space Only"
@@ -31721,16 +31721,16 @@
             "value" : "현재 버전"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Current Version"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Huidige Versie"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Current Version"
           }
         },
         "pl" : {
@@ -31912,16 +31912,16 @@
             "value" : "현재 버전: %@"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Current Version: %@"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Huidige Versie: %@"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Current Version: %@"
           }
         },
         "pl" : {
@@ -32102,16 +32102,16 @@
             "value" : "사용자 지정 애플리케이션 디렉토리"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Custom Application Directories"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Aangepaste applicatie mappen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Custom Application Directories"
           }
         },
         "pl" : {
@@ -32292,13 +32292,13 @@
             "value" : "Custom Hover Highlight Color"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Custom Hover Highlight Color"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Custom Hover Highlight Color"
@@ -32483,16 +32483,16 @@
             "value" : "기본값"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Default"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Standaard"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Default"
           }
         },
         "pl" : {
@@ -32675,16 +32675,16 @@
             "value" : "기본값(중간 크기)"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Default (Medium Large)"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Standaard (Medium Groot)"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Default (Medium Large)"
           }
         },
         "pl" : {
@@ -32865,13 +32865,13 @@
             "value" : "삭제"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Delete"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Delete"
@@ -33055,16 +33055,16 @@
             "value" : "상세한"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Detailed"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Gedetailleerd"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Detailed"
           }
         },
         "pl" : {
@@ -33245,13 +33245,13 @@
             "value" : "Diagonal - Title bottom left, controls top right"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Diagonal - Title bottom left, controls top right"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Diagonal - Title bottom left, controls top right"
@@ -33435,13 +33435,13 @@
             "value" : "Diagonal - Title bottom right, controls top left"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Diagonal - Title bottom right, controls top left"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Diagonal - Title bottom right, controls top left"
@@ -33625,13 +33625,13 @@
             "value" : "Diagonal - Title top left, controls bottom right"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Diagonal - Title top left, controls bottom right"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Diagonal - Title top left, controls bottom right"
@@ -33815,13 +33815,13 @@
             "value" : "Diagonal - Title top right, controls bottom left"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Diagonal - Title top right, controls bottom left"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Diagonal - Title top right, controls bottom left"
@@ -34006,16 +34006,16 @@
             "value" : "선택되지 않은 창 흐리게 표시"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Dim Unselected Windows"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Dim niet geselecteerd venster"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Dim Unselected Windows"
           }
         },
         "pl" : {
@@ -34196,13 +34196,13 @@
             "value" : "Disable dock styling on traffic light buttons"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Disable dock styling on traffic light buttons"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Disable dock styling on traffic light buttons"
@@ -34386,13 +34386,13 @@
             "value" : "Disable dock styling on window titles"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Disable dock styling on window titles"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Disable dock styling on window titles"
@@ -34576,13 +34576,13 @@
             "value" : "Disabled"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Disabled"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Disabled"
@@ -34766,16 +34766,16 @@
             "value" : "연결 해제된 디스플레이"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Disconnected Display"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Verbreek verbind met scherm"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Disconnected Display"
           }
         },
         "pl" : {
@@ -34956,16 +34956,16 @@
             "value" : "기능에 대해 토론하고 커뮤니티에서 도움 받기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Discuss features and get help from the community"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bespreek functies en krijg hulp van de community"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Discuss features and get help from the community"
           }
         },
         "pl" : {
@@ -35147,16 +35147,16 @@
             "value" : "표시 %u"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Display %u"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Weergave %u"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Display %u"
           }
         },
         "pl" : {
@@ -35338,13 +35338,13 @@
             "value" : "Displays a colored line below the currently active application's dock icon."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Displays a colored line below the currently active application's dock icon."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Displays a colored line below the currently active application's dock icon."
@@ -35528,13 +35528,13 @@
             "value" : "Distinguish minimized/hidden windows"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Distinguish minimized/hidden windows"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Distinguish minimized/hidden windows"
@@ -35718,13 +35718,13 @@
             "value" : "Dock Click Action"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Dock Click Action"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Dock Click Action"
@@ -35908,13 +35908,13 @@
             "value" : "Dock Frame Rate"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Dock Frame Rate"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Dock Frame Rate"
@@ -36098,13 +36098,13 @@
             "value" : "Dock Icon Scroll Gesture"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Dock Icon Scroll Gesture"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Dock Icon Scroll Gesture"
@@ -36289,16 +36289,16 @@
             "value" : "Dock 미리보기 에어로 쉐이크 액션"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Dock Preview Aero Shake Action"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Dock voorvertoning Aero Schud Actie"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Dock Preview Aero Shake Action"
           }
         },
         "pl" : {
@@ -36479,13 +36479,13 @@
             "value" : "Dock Preview Gestures"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Dock Preview Gestures"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Dock Preview Gestures"
@@ -36669,16 +36669,16 @@
             "value" : "Dock 미리보기 호버 액션"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Dock Preview Hover Action"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Dock voorvertoning Hover Action"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Dock Preview Hover Action"
           }
         },
         "pl" : {
@@ -36859,13 +36859,13 @@
             "value" : "Dock Preview Layout"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Dock Preview Layout"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Dock Preview Layout"
@@ -37049,16 +37049,16 @@
             "value" : "Dock 미리보기 설정"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Dock Preview Settings"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Dock voorbeeldinstellingen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Dock Preview Settings"
           }
         },
         "pl" : {
@@ -37239,13 +37239,13 @@
             "value" : "Dock Preview Toolbar"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Dock Preview Toolbar"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Dock Preview Toolbar"
@@ -37429,13 +37429,13 @@
             "value" : "Dock Preview Transparency"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Dock Preview Transparency"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Dock Preview Transparency"
@@ -37620,16 +37620,16 @@
             "value" : "Dock 미리보기 창 호버 액션"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Dock Preview Window Hover Action"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Venster van Dock voorvertoning Hover Action"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Dock Preview Window Hover Action"
           }
         },
         "pl" : {
@@ -37810,16 +37810,16 @@
             "value" : "독 미리 보기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Dock Previews"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Dock voorbeelden"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Dock Previews"
           }
         },
         "pl" : {
@@ -38001,16 +38001,16 @@
             "value" : "Dock 미리보기 & 창 전환"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Dock Previews & Window Switcher"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Dock Previews & Venster switcher"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Dock Previews & Window Switcher"
           }
         },
         "pl" : {
@@ -38192,16 +38192,16 @@
             "value" : "Dock 미리보기만"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Dock Previews only"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Alleen Dock voorbeelden"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Dock Previews only"
           }
         },
         "pl" : {
@@ -38382,13 +38382,13 @@
             "value" : "Dock Quality"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Dock Quality"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Dock Quality"
@@ -38572,16 +38572,16 @@
             "value" : "DockDoor는 컴퓨터의 화면 및 오디오를 녹화하지 않으며, 창 미리보기 화면만 띄웁니다. 모든 정보는 저장 및 공유하지 않으며, 모든 작업은 본 기기에서 안전하게 이루어집니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "DockDoor does not record your screen or audio. It only captures static window previews. No information is stored or shared; all processing occurs privately on your device."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "DockDoor neemt je scherm of audio niet op. Het legt alleen statische venstervoorbeelden vast. Er wordt geen informatie opgeslagen of gedeeld; alle verwerking vindt plaats op uw eigen apparaat."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "DockDoor does not record your screen or audio. It only captures static window previews. No information is stored or shared; all processing occurs privately on your device."
           }
         },
         "pl" : {
@@ -38762,13 +38762,13 @@
             "value" : "DockDoor needs access to your calendars to show events. Please enable Calendar access in System Settings > Privacy & Security > Calendars."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "DockDoor needs access to your calendars to show events. Please enable Calendar access in System Settings > Privacy & Security > Calendars."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "DockDoor needs access to your calendars to show events. Please enable Calendar access in System Settings > Privacy & Security > Calendars."
@@ -38952,13 +38952,13 @@
             "value" : "DockDoor가 캘린더에 액세스하려면 권한이 필요합니다."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "DockDoor needs permission to access your calendar."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "DockDoor needs permission to access your calendar."
@@ -39142,16 +39142,16 @@
             "value" : "DockDoor는 화면 녹화 권한이 필요합니다. macOS Sequoia를 사용하신다면, 새로운 시스템 보안 정책으로 인해 설치하신 모든 캡처 앱에서 이 창을 매주, 매달, 혹은 재부팅 후에 보시게 될 겁니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "DockDoor needs screen recording access. In macOS Sequoia, you'll see this prompt every week or month and after reboots. This is a new system-wide security policy for all screen capture apps."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Dockdoor heeft toestemming nodig om schermopname te maken. In macOS Sequoia, zie je deze pop-up elke week of maand wanneer het is heropgestart. Dit is een nieuw, systeem breed, veiligheids-beleid voor alle schermopnemende apps."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "DockDoor needs screen recording access. In macOS Sequoia, you'll see this prompt every week or month and after reboots. This is a new system-wide security policy for all screen capture apps."
           }
         },
         "pl" : {
@@ -39332,16 +39332,16 @@
             "value" : "색 편집"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Edit Color"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bewerk Kleur"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Edit Color"
           }
         },
         "pl" : {
@@ -39522,13 +39522,13 @@
             "value" : "Either left or right Command, Option, or Control keys work. You can also hold the modifier while pressing the trigger to capture both."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Either left or right Command, Option, or Control keys work. You can also hold the modifier while pressing the trigger to capture both."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Either left or right Command, Option, or Control keys work. You can also hold the modifier while pressing the trigger to capture both."
@@ -39713,16 +39713,16 @@
             "value" : "요소 중첩"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Elements Overlap"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Elementen overlappen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Elements Overlap"
           }
         },
         "pl" : {
@@ -39903,13 +39903,13 @@
             "value" : "Embed controls in preview frames"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Embed controls in preview frames"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Embed controls in preview frames"
@@ -40093,13 +40093,13 @@
             "value" : "창 미리보기가 있는 컨트롤 임베드(미리보기가 표시된 경우)"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Embed controls with window previews (if previews shown)"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Embed controls with window previews (if previews shown)"
@@ -40285,16 +40285,16 @@
             "value" : "임베디드"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Embedded"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ingesloten"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Embedded"
           }
         },
         "pl" : {
@@ -40475,16 +40475,16 @@
             "value" : "자동으로 업데이트 확인하기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Enable automatic checking for updates"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Automatisch controleren op updates inschakelen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Enable automatic checking for updates"
           }
         },
         "pl" : {
@@ -40665,13 +40665,13 @@
             "value" : "Enable Cmd+Tab Enhancements"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Enable Cmd+Tab Enhancements"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Enable Cmd+Tab Enhancements"
@@ -40855,13 +40855,13 @@
             "value" : "Enable Dock Previews"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Enable Dock Previews"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Enable Dock Previews"
@@ -41046,13 +41046,13 @@
             "value" : "Enable dock scroll gestures"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Enable dock scroll gestures"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Enable dock scroll gestures"
@@ -41236,13 +41236,13 @@
             "value" : "Enable for Dock Preview"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Enable for Dock Preview"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Enable for Dock Preview"
@@ -41426,13 +41426,13 @@
             "value" : "Enable for Window Switcher"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Enable for Window Switcher"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Enable for Window Switcher"
@@ -41616,13 +41616,13 @@
             "value" : "Enable gestures in window switcher"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Enable gestures in window switcher"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Enable gestures in window switcher"
@@ -41806,13 +41806,13 @@
             "value" : "Enable gestures on dock window previews"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Enable gestures on dock window previews"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Enable gestures on dock window previews"
@@ -41997,16 +41997,16 @@
             "value" : "호버 창 슬라이딩 애니메이션 활성화"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Enable Hover Window Sliding Animation"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Zwevend venster schuifanimatie inschakelen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Enable Hover Window Sliding Animation"
           }
         },
         "pl" : {
@@ -42187,13 +42187,13 @@
             "value" : "Enable Live Preview (Video)"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Enable Live Preview (Video)"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Enable Live Preview (Video)"
@@ -42377,13 +42377,13 @@
             "value" : "Enable mouse hover selection"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Enable mouse hover selection"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Enable mouse hover selection"
@@ -42567,13 +42567,13 @@
             "value" : "고정 사용"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Enable Pinning"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Enable Pinning"
@@ -42758,16 +42758,16 @@
             "value" : "창 미리보기 슬라이딩 애니메이션 활성화"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Enable Preview Window Sliding Animation"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Schuifanimatie van voorvertoningsvenster inschakelen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Enable Preview Window Sliding Animation"
           }
         },
         "pl" : {
@@ -42948,13 +42948,13 @@
             "value" : "Enable scroll gestures on dock icons"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Enable scroll gestures on dock icons"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Enable scroll gestures on dock icons"
@@ -43138,13 +43138,13 @@
             "value" : "Enable search while using Window Switcher"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Enable search while using Window Switcher"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Enable search while using Window Switcher"
@@ -43328,16 +43328,16 @@
             "value" : "윈도우 스위치 활성화"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Enable Window Switcher"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sta venster schakelaar toe"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Enable Window Switcher"
           }
         },
         "pl" : {
@@ -43518,16 +43518,16 @@
             "value" : "활성화됨"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Enabled"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Aan"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Enabled"
           }
         },
         "pl" : {
@@ -43708,16 +43708,16 @@
             "value" : "활성화된 버튼"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Enabled Buttons"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Activeer knoppen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Enabled Buttons"
           }
         },
         "pl" : {
@@ -43898,16 +43898,16 @@
             "value" : "도크 경험을 향상하세요!"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Enhance your dock experience!"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Verbeter je Dock ervaring!"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Enhance your dock experience!"
           }
         },
         "pl" : {
@@ -44088,13 +44088,13 @@
             "value" : "여유로운 하루를 즐기거나 캘린더에 이벤트를 추가하세요."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Enjoy your free day or add some events to your calendar."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Enjoy your free day or add some events to your calendar."
@@ -44278,13 +44278,13 @@
             "value" : "Enter"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Enter"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Enter"
@@ -44468,16 +44468,16 @@
             "value" : "필터링할 텍스트 입력"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Enter text to filter"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Voer tekst in om te filteren"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Enter text to filter"
           }
         },
         "pl" : {
@@ -44658,13 +44658,13 @@
             "value" : "Escape"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Escape"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Escape"
@@ -44848,16 +44848,16 @@
             "value" : "이제 모든 준비가 끝났어요!"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Everything is now set up!"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Alles is nu ingesteld!"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Everything is now set up!"
           }
         },
         "pl" : {
@@ -45039,16 +45039,16 @@
             "value" : "예제:"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Example:"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Voorbeeld:"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Example:"
           }
         },
         "pl" : {
@@ -45230,16 +45230,16 @@
             "value" : "제목의 특정 텍스트를 필터링하여 창을 캡처에서 제외하기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Exclude windows from capture by filtering specific text in their titles"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sluit vensters uit van vastlegging door specifieke tekst in hun titels te filteren"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Exclude windows from capture by filtering specific text in their titles"
           }
         },
         "pl" : {
@@ -45420,16 +45420,16 @@
             "value" : "제목의 특정 텍스트를 필터링하여 창을 캡처에서 제외합니다(대소문자 구분 없음)."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Exclude windows from capture by filtering specific text in their titles (case-insensitive)."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Vensters uitsluiten van vastlegging door specifieke tekst in hun titels te filteren (hoofdlettergevoelig)."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Exclude windows from capture by filtering specific text in their titles (case-insensitive)."
           }
         },
         "pl" : {
@@ -45611,13 +45611,13 @@
             "value" : "전체 모드로 확장"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Expand to full mode"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Expand to full mode"
@@ -45802,16 +45802,16 @@
             "value" : "실험적: 앱 레이블 위에 미리보기 표시"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "EXPERIMENTAL: Show preview above app labels"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "EXPERIMENTEEL: Voorbeeld weergeven boven app labels"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "EXPERIMENTAL: Show preview above app labels"
           }
         },
         "pl" : {
@@ -45992,13 +45992,13 @@
             "value" : "Export Logs"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Export Logs"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Export Logs"
@@ -46184,16 +46184,16 @@
             "value" : "매무 매우 작음"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Extra Extra Small"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Extra extra klein"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Extra Extra Small"
           }
         },
         "pl" : {
@@ -46376,16 +46376,16 @@
             "value" : "매우 작음"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Extra Small"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Extra Klein"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Extra Small"
           }
         },
         "pl" : {
@@ -46572,16 +46572,16 @@
             "value" : "v%1$@: %2$@을(를) 다운로드하지 못했습니다"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Failed to download v%1$@: %2$@"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Het downloaden van v%1$@ is mislukt: %2$@"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Failed to download v%1$@: %2$@"
           }
         },
         "pl" : {
@@ -46763,13 +46763,13 @@
             "value" : "Fill Bottom Half"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Fill Bottom Half"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Fill Bottom Half"
@@ -46954,13 +46954,13 @@
             "value" : "Fill Bottom Left"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Fill Bottom Left"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Fill Bottom Left"
@@ -47145,13 +47145,13 @@
             "value" : "Fill Bottom Right"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Fill Bottom Right"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Fill Bottom Right"
@@ -47336,13 +47336,13 @@
             "value" : "Fill Left Half"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Fill Left Half"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Fill Left Half"
@@ -47527,13 +47527,13 @@
             "value" : "Fill Right Half"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Fill Right Half"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Fill Right Half"
@@ -47718,13 +47718,13 @@
             "value" : "Fill Top Half"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Fill Top Half"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Fill Top Half"
@@ -47909,13 +47909,13 @@
             "value" : "Fill Top Left"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Fill Top Left"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Fill Top Left"
@@ -48100,13 +48100,13 @@
             "value" : "Fill Top Right"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Fill Top Right"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Fill Top Right"
@@ -48291,15 +48291,15 @@
             "value" : "필터"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Filters"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Filters"
           }
         },
@@ -48482,16 +48482,16 @@
             "value" : "필터 설정"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Filters settings"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Filterinstellingen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Filters settings"
           }
         },
         "pl" : {
@@ -48672,16 +48672,16 @@
             "value" : "시각적 세부 사항과 레이아웃 옵션을 미세 조정할 수 있습니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Fine-tune visual details and layout options."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Verfijn visuele details en lay-outopties."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Fine-tune visual details and layout options."
           }
         },
         "pl" : {
@@ -48862,13 +48862,13 @@
             "value" : "Focus and use previews"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Focus and use previews"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Focus and use previews"
@@ -49052,13 +49052,13 @@
             "value" : "지원되는 앱(음악, Spotify, 캘린더)의 경우 Dock 아이콘을 가리키면 창 미리보기 대신 대화형 컨트롤을 표시합니다."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "For supported apps (Music, Spotify, Calendar), show interactive controls instead of window previews when hovering their Dock icons."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "For supported apps (Music, Spotify, Calendar), show interactive controls instead of window previews when hovering their Dock icons."
@@ -49242,16 +49242,16 @@
             "value" : "강제 종료"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Force Quit"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Afsluiten forceren"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Force Quit"
           }
         },
         "pl" : {
@@ -49432,16 +49432,16 @@
             "value" : "버그가 있나요?"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Found a Bug?"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Een bug gevonden?"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Found a Bug?"
           }
         },
         "pl" : {
@@ -49622,16 +49622,16 @@
             "value" : "전체 화면"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Fullscreen"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Volledig scherm"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Fullscreen"
           }
         },
         "pl" : {
@@ -49812,13 +49812,13 @@
             "value" : "Fullscreen App Blacklist"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Fullscreen App Blacklist"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Fullscreen App Blacklist"
@@ -50003,16 +50003,16 @@
             "value" : "일반"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "General"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Algemeen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "General"
           }
         },
         "pl" : {
@@ -50193,16 +50193,16 @@
             "value" : "일반 모양"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "General Appearance"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Algemeen uiterlijk"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "General Appearance"
           }
         },
         "pl" : {
@@ -50384,16 +50384,16 @@
             "value" : "일반 제외 사항"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "General Exclusions"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Algemene uitsluitingen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "General Exclusions"
           }
         },
         "pl" : {
@@ -50575,16 +50575,16 @@
             "value" : "일반 설정"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "General settings"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Algemene Instellingen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "General settings"
           }
         },
         "pl" : {
@@ -50765,13 +50765,13 @@
             "value" : "Gesture Sensitivity"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Gesture Sensitivity"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Gesture Sensitivity"
@@ -50955,13 +50955,13 @@
             "value" : "Gesture Settings"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Gesture Settings"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Gesture Settings"
@@ -51146,13 +51146,13 @@
             "value" : "Gestures & Keybinds"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Gestures & Keybinds"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Gestures & Keybinds"
@@ -51336,16 +51336,16 @@
             "value" : "시작하기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Get Started"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Begin"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Get Started"
           }
         },
         "pl" : {
@@ -51527,13 +51527,13 @@
             "value" : "글로벌 패딩 스케일"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Global Padding Scale"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Global Padding Scale"
@@ -51717,16 +51717,16 @@
             "value" : "액세스 권한 부여"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Grant Access"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Toegang geven"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Grant Access"
           }
         },
         "pl" : {
@@ -51908,13 +51908,13 @@
             "value" : "Grant permission in System Settings to enable window previews."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Grant permission in System Settings to enable window previews."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Grant permission in System Settings to enable window previews."
@@ -52098,16 +52098,16 @@
             "value" : "허용"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Granted"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Toegekend"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Granted"
           }
         },
         "pl" : {
@@ -52288,13 +52288,13 @@
             "value" : "Group multiple app instances together"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Group multiple app instances together"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Group multiple app instances together"
@@ -52479,13 +52479,13 @@
             "value" : "Grouped by app name"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Grouped by app name"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Grouped by app name"
@@ -52669,16 +52669,16 @@
             "value" : "아이디어가 있나요?"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Have an Idea?"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Heb je een idee?"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Have an Idea?"
           }
         },
         "pl" : {
@@ -52861,16 +52861,16 @@
             "value" : "도움말"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Help"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Hulp"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Help"
           }
         },
         "pl" : {
@@ -53051,16 +53051,16 @@
             "value" : "도움말 및 지원"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Help & Support"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Hulp en ondersteuning"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Help & Support"
           }
         },
         "pl" : {
@@ -53242,16 +53242,16 @@
             "value" : "도움말 및 질문 설정"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Help and questions settings"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Instellingen voor hulp en vragen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Help and questions settings"
           }
         },
         "pl" : {
@@ -53432,16 +53432,16 @@
             "value" : "DockDoor를 귀하의 언어로 사용할 수 있도록 도와주세요"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Help make DockDoor available in your language"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Help DockDoor beschikbaar te maken in jouw taal"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Help make DockDoor available in your language"
           }
         },
         "pl" : {
@@ -53622,16 +53622,16 @@
             "value" : "버그와 같은 이슈들을 제보하여 DockDoor를 개선해 주세요."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Help us improve DockDoor by reporting any issues you encounter."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Help ons DockDoor verbeteren door problemen die je ervaart te rapporteren."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Help us improve DockDoor by reporting any issues you encounter."
           }
         },
         "pl" : {
@@ -53813,16 +53813,16 @@
             "value" : "숨김"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Hidden"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Verborgen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Hidden"
           }
         },
         "pl" : {
@@ -54003,16 +54003,16 @@
             "value" : "고급 설정 숨기기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Hide Advanced Settings"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Verberg geavanceerde instellingen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Hide Advanced Settings"
           }
         },
         "pl" : {
@@ -54193,13 +54193,13 @@
             "value" : "Hide All"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Hide All"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Hide All"
@@ -54383,16 +54383,16 @@
             "value" : "도크 아이콘 클릭 시 모든 앱 창 숨기기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Hide all app windows on dock icon click"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Verberg alle app vensters bij klikken op het dockpictogram"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Hide all app windows on dock icon click"
           }
         },
         "pl" : {
@@ -54574,16 +54574,16 @@
             "value" : "도크 아이콘을 클릭하면 모든 애플리케이션 창을 숨깁니다"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Hide all application windows when clicking on the dock icon"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Verberg alle applicatievensters wanneer u op het dockpictogram klikt"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Hide all application windows when clicking on the dock icon"
           }
         },
         "pl" : {
@@ -54765,13 +54765,13 @@
             "value" : "Hide App"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Hide App"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Hide App"
@@ -54956,13 +54956,13 @@
             "value" : "Hide application"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Hide application"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Hide application"
@@ -55146,13 +55146,13 @@
             "value" : "Hide preview card background"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Hide preview card background"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Hide preview card background"
@@ -55336,13 +55336,13 @@
             "value" : "High (960px)"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "High (960px)"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "High (960px)"
@@ -55526,13 +55526,13 @@
             "value" : "Higher quality and frame rate use more CPU/GPU resources. Use lower settings for Window Switcher if you experience lag."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Higher quality and frame rate use more CPU/GPU resources. Use lower settings for Window Switcher if you experience lag."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Higher quality and frame rate use more CPU/GPU resources. Use lower settings for Window Switcher if you experience lag."
@@ -55716,16 +55716,16 @@
             "value" : "하이라이트 그라데이션 색상"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Highlight Gradient Colors"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Markeer verloopkleuren"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Highlight Gradient Colors"
           }
         },
         "pl" : {
@@ -55906,13 +55906,13 @@
             "value" : "Highlights the currently focused window with a colored border."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Highlights the currently focused window with a colored border."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Highlights the currently focused window with a colored border."
@@ -56097,13 +56097,13 @@
             "value" : "Horizontal"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Horizontal"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Horizontal"
@@ -56287,13 +56287,13 @@
             "value" : "Horizontal scrolling may interfere with dock preview gestures."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Horizontal scrolling may interfere with dock preview gestures."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Horizontal scrolling may interfere with dock preview gestures."
@@ -56478,16 +56478,16 @@
             "value" : "호버 창 열기 지연"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Hover Window Open Delay"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Vertraging bij openen van zwevend venster"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Hover Window Open Delay"
           }
         },
         "pl" : {
@@ -56669,16 +56669,16 @@
             "value" : "호버 창 제목 스타일"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Hover Window Title Style"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Stijl van de zwevend venster titel"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Hover Window Title Style"
           }
         },
         "pl" : {
@@ -56859,13 +56859,13 @@
             "value" : "How long to keep video streams active after closing preview. Longer duration means faster reopening but uses more resources."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "How long to keep video streams active after closing preview. Longer duration means faster reopening but uses more resources."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "How long to keep video streams active after closing preview. Longer duration means faster reopening but uses more resources."
@@ -57050,16 +57050,16 @@
             "value" : "설정 방법"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "How to Set Up"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Hoe te configureren"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "How to Set Up"
           }
         },
         "pl" : {
@@ -57241,13 +57241,13 @@
             "value" : "비활성화하면 창 미리 보기를 사용할 수 없는 경우(예: 모든 창이 최소화됨)에만 특수 컨트롤이 나타납니다. 활성화하면 가능한 경우 컨트롤이 미리 보기와 통합됩니다."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "If disabled, special controls only appear if no window previews are available (e.g., all windows minimized). If enabled, controls integrate with previews when possible."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "If disabled, special controls only appear if no window previews are available (e.g., all windows minimized). If enabled, controls integrate with previews when possible."
@@ -57431,13 +57431,13 @@
             "value" : "활성화하면 가능한 경우 컨트롤이 미리 보기와 통합됩니다."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "If enabled, controls integrate with previews when possible."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "If enabled, controls integrate with previews when possible."
@@ -57621,16 +57621,16 @@
             "value" : "DockDoor를 유용하게 사용하고 계신다면, 저희 팀을 후원해 주세요!"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "If you find DockDoor useful, consider donating. Your support helps keep the project going!"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Vindt u DockDoor nuttig? Overweeg dan een donatie. Uw steun helpt het project gaande te houden!"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "If you find DockDoor useful, consider donating. Your support helps keep the project going!"
           }
         },
         "pl" : {
@@ -57812,16 +57812,16 @@
             "value" : "메뉴 막대의 아이콘에 접근하려면 앱을 실행하여 10초 간 노출시킬 수 있습니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "If you need to access the menu bar icon, launch the app to reveal it for 10 seconds."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Als u het menubalk pictogram nodig hebt, start u de app zodat het 10 seconden lang zichtbaar is."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "If you need to access the menu bar icon, launch the app to reveal it for 10 seconds."
           }
         },
         "pl" : {
@@ -58002,16 +58002,16 @@
             "value" : "하나의 창으로 앱 무시하기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Ignore apps with one window"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Negeer apps met één venster"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Ignore apps with one window"
           }
         },
         "pl" : {
@@ -58193,16 +58193,16 @@
             "value" : "하나의 창만 있는 앱 무시"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Ignore Apps with One Window"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Negeer apps met één venster"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Ignore Apps with One Window"
           }
         },
         "pl" : {
@@ -58383,13 +58383,13 @@
             "value" : "Immediately close"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Immediately close"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Immediately close"
@@ -58574,16 +58574,16 @@
             "value" : "중요: 녹화할 때는 트리거 키만 누르세요(예: 명령 + Tab을 원할 경우 Tab만 누르세요). 녹화 중에는 초기화 키를 누르지 마세요."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Important: When recording, press ONLY the trigger key (e.g. just press Tab if you want command + Tab). Do not press the initialization key during recording."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Belangrijk: druk tijdens het opnemen ALLEEN op de trigger-toets (druk bijvoorbeeld alleen op Tab als u Command + Tab wilt). Druk tijdens het opnemen niet op de initialisatietoets."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Important: When recording, press ONLY the trigger key (e.g. just press Tab if you want command + Tab). Do not press the initialization key during recording."
           }
         },
         "pl" : {
@@ -58765,13 +58765,13 @@
             "value" : "Improved performance (nominal)"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Improved performance (nominal)"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Improved performance (nominal)"
@@ -58956,16 +58956,16 @@
             "value" : "창 전환기에 숨김 및 최소화 창 포함하기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Include Hidden and Minimized Windows in the Window Switcher"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Verborgen en geminimaliseerde vensters opnemen in de venster wisselaar"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Include Hidden and Minimized Windows in the Window Switcher"
           }
         },
         "pl" : {
@@ -59146,16 +59146,16 @@
             "value" : "스위처에 숨김/최소화된 창 포함하기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Include hidden/minimized windows in Switcher"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Verborgen / geminimaliseerde vensters opnemen in de switcher"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Include hidden/minimized windows in Switcher"
           }
         },
         "pl" : {
@@ -59337,16 +59337,16 @@
             "value" : "스위처에 숨김/최소화된 창 포함하기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Include Hidden/Minimized Windows in Switcher"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Verborgen / geminimaliseerde vensters opnemen in de switcher"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Include Hidden/Minimized Windows in Switcher"
           }
         },
         "pl" : {
@@ -59528,13 +59528,13 @@
             "value" : "Indicator Color"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Indicator Color"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Indicator Color"
@@ -59719,13 +59719,13 @@
             "value" : "Indicator Height"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Indicator Height"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Indicator Height"
@@ -59910,13 +59910,13 @@
             "value" : "Indicator Length"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Indicator Length"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Indicator Length"
@@ -60101,16 +60101,16 @@
             "value" : "초기화 키"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Initialization Key"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Initialisatie sleutel"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Initialization Key"
           }
         },
         "pl" : {
@@ -60291,13 +60291,13 @@
             "value" : "Initializer"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Initializer"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Initializer"
@@ -60482,16 +60482,16 @@
             "value" : "지침"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Instructions"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Instructies"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Instructions"
           }
         },
         "pl" : {
@@ -60672,16 +60672,16 @@
             "value" : "상호작용 및 동작(Dock 미리보기)"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Interaction & Behavior (Dock Previews)"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Interactie en gedrag (Dock voorbeelden)"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Interaction & Behavior (Dock Previews)"
           }
         },
         "pl" : {
@@ -60862,13 +60862,13 @@
             "value" : "Item Size"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Item Size"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Item Size"
@@ -61052,16 +61052,16 @@
             "value" : "Discord 가입하기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Join our Discord"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Word lid van onze Discord"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Join our Discord"
           }
         },
         "pl" : {
@@ -61242,13 +61242,13 @@
             "value" : "Keep Open"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Keep Open"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Keep Open"
@@ -61432,13 +61432,13 @@
             "value" : "Keep preview when app terminates"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Keep preview when app terminates"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Keep preview when app terminates"
@@ -61623,16 +61623,16 @@
             "value" : "측면 이동 중에도 미리보기 표시 유지"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Keep previews visible during lateral movement"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Houd previews zichtbaar tijdens zijwaartse beweging"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Keep previews visible during lateral movement"
           }
         },
         "pl" : {
@@ -61814,16 +61814,16 @@
             "value" : "키보드 단축키"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Keyboard Shortcut"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sneltoets"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Keyboard Shortcut"
           }
         },
         "pl" : {
@@ -62004,13 +62004,13 @@
             "value" : "Language"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Language"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Language"
@@ -62195,16 +62195,16 @@
             "value" : "크게"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Large"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Groot"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Large"
           }
         },
         "pl" : {
@@ -62386,16 +62386,16 @@
             "value" : "대형(1/2)"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Large (1/2)"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Groot (1/2)"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Large (1/2)"
           }
         },
         "pl" : {
@@ -62576,16 +62576,16 @@
             "value" : "마지막으로 확인함: %@"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Last checked: %@"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Laatst Gecontroleerd: %@"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Last checked: %@"
           }
         },
         "pl" : {
@@ -62766,16 +62766,16 @@
             "value" : "로그인할 때 DockDoor 실행"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Launch DockDoor at login"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Start DockDoor bij het inloggen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Launch DockDoor at login"
           }
         },
         "pl" : {
@@ -62957,16 +62957,16 @@
             "value" : "레이아웃 제한"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Layout Limits"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Lay-out grenzen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Layout Limits"
           }
         },
         "pl" : {
@@ -63147,16 +63147,16 @@
             "value" : "준비를 시작해봐요"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Let's set things up"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Laten we de dingen instellen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Let's set things up"
           }
         },
         "pl" : {
@@ -63337,13 +63337,13 @@
             "value" : "Level 1 is exact match, level 5 is most lenient fuzzy matching."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Level 1 is exact match, level 5 is most lenient fuzzy matching."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Level 1 is exact match, level 5 is most lenient fuzzy matching."
@@ -63527,16 +63527,16 @@
             "value" : "경량"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Lightweight"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Lichtgewicht"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Lightweight"
           }
         },
         "pl" : {
@@ -63717,13 +63717,13 @@
             "value" : "Limit Window Switcher to active app only"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Limit Window Switcher to active app only"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Limit Window Switcher to active app only"
@@ -63907,13 +63907,13 @@
             "value" : "Loading applications..."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Loading applications..."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Loading applications..."
@@ -64097,13 +64097,13 @@
             "value" : "Loading calendars..."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Loading calendars..."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Loading calendars..."
@@ -64287,13 +64287,13 @@
             "value" : "가사 로드 중..."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Loading lyrics..."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Loading lyrics..."
@@ -64477,16 +64477,16 @@
             "value" : "미리 보기 로드 중..."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Loading preview..."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Preview aan het laden..."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Loading preview..."
           }
         },
         "pl" : {
@@ -64667,13 +64667,13 @@
             "value" : "Lock aspect ratio (16:10)"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Lock aspect ratio (16:10)"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Lock aspect ratio (16:10)"
@@ -64857,13 +64857,13 @@
             "value" : "Low (480px)"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Low (480px)"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Low (480px)"
@@ -65047,13 +65047,13 @@
             "value" : "Lower values make gestures more sensitive. Higher values require longer swipes. Applies to both dock previews and window switcher."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Lower values make gestures more sensitive. Higher values require longer swipes. Applies to both dock previews and window switcher."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Lower values make gestures more sensitive. Higher values require longer swipes. Applies to both dock previews and window switcher."
@@ -65237,13 +65237,13 @@
             "value" : "Make sure you have calendars set up in the Calendar app."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Make sure you have calendars set up in the Calendar app."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Make sure you have calendars set up in the Calendar app."
@@ -65427,13 +65427,13 @@
             "value" : "Max Columns (Left/Right Dock)"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Max Columns (Left/Right Dock)"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Max Columns (Left/Right Dock)"
@@ -65617,13 +65617,13 @@
             "value" : "Max Rows"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Max Rows"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Max Rows"
@@ -65807,13 +65807,13 @@
             "value" : "Max Rows (Bottom Dock)"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Max Rows (Bottom Dock)"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Max Rows (Bottom Dock)"
@@ -65998,16 +65998,16 @@
             "value" : "스위처 미리보기의 최대 행 수"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Max Rows for Switcher Previews"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Maximaal aantal rijen voor Switcher voorbeelden"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Max Rows for Switcher Previews"
           }
         },
         "pl" : {
@@ -66189,16 +66189,16 @@
             "value" : "Dock 미리보기용 최대 스택"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Max Stacks for Dock Previews"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Maximale stapels voor Dock voorbeelden"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Max Stacks for Dock Previews"
           }
         },
         "pl" : {
@@ -66380,13 +66380,13 @@
             "value" : "Maximize"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Maximize"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Maximize"
@@ -66571,16 +66571,16 @@
             "value" : "최대 가로 행"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Maximum Horizontal Rows"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Maximaal aantal horizontale rijen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Maximum Horizontal Rows"
           }
         },
         "pl" : {
@@ -66761,16 +66761,16 @@
             "value" : "최대 색상 수(%lld)에 도달했습니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Maximum number of colors (%lld) reached."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Maximaal aantal kleuren (%lld) bereikt."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Maximum number of colors (%lld) reached."
           }
         },
         "pl" : {
@@ -66952,16 +66952,16 @@
             "value" : "최대 세로 열"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Maximum Vertical Columns"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Maximale verticale kolommen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Maximum Vertical Columns"
           }
         },
         "pl" : {
@@ -67142,13 +67142,13 @@
             "value" : "Media"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Media"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Media"
@@ -67333,15 +67333,15 @@
             "value" : "중간"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Medium"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Medium"
           }
         },
@@ -67524,16 +67524,16 @@
             "value" : "중간(1/%lld)"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Medium (1/%lld)"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Gemiddeld (1/%lld)"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Medium (1/%lld)"
           }
         },
         "pl" : {
@@ -67715,16 +67715,16 @@
             "value" : "메뉴바 아이콘 숨김"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Menu Bar Icon Hidden"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Menubalk pictogram verborgen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Menu Bar Icon Hidden"
           }
         },
         "pl" : {
@@ -67905,13 +67905,13 @@
             "value" : "Middle Click"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Middle Click"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Middle Click"
@@ -68096,16 +68096,16 @@
             "value" : "최소화"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Minimize"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Minimaliseer"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Minimize"
           }
         },
         "pl" : {
@@ -68287,16 +68287,16 @@
             "value" : "모두 최소화"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Minimize All"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Minimaliseer alles"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Minimize All"
           }
         },
         "pl" : {
@@ -68478,16 +68478,16 @@
             "value" : "모든 창 최소화"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Minimize all windows"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Minimaliseer alle vensters"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Minimize all windows"
           }
         },
         "pl" : {
@@ -68669,16 +68669,16 @@
             "value" : "현재 창을 제외한 모든 창을 최소화합니다"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Minimize all windows except the current one"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Minimaliseer alle vensters behalve de huidige"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Minimize all windows except the current one"
           }
         },
         "pl" : {
@@ -68860,13 +68860,13 @@
             "value" : "Minimize windows"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Minimize windows"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Minimize windows"
@@ -69050,13 +69050,13 @@
             "value" : "Minimized"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Minimized"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Minimized"
@@ -69240,13 +69240,13 @@
             "value" : "Minimized and hidden windows will appear after all visible windows in previews and switcher."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Minimized and hidden windows will appear after all visible windows in previews and switcher."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Minimized and hidden windows will appear after all visible windows in previews and switcher."
@@ -69430,16 +69430,16 @@
             "value" : "도달한 최소 색상 수입니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Minimum number of colors reached."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Minimale aantal kleuren bereikt."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Minimum number of colors reached."
           }
         },
         "pl" : {
@@ -69620,13 +69620,13 @@
             "value" : "Mode"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Mode"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Mode"
@@ -69810,13 +69810,13 @@
             "value" : "Mouse Actions"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Mouse Actions"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Mouse Actions"
@@ -70000,13 +70000,13 @@
             "value" : "Music/Spotify behavior:"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Music/Spotify behavior:"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Music/Spotify behavior:"
@@ -70190,13 +70190,13 @@
             "value" : "Name"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Name"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Name"
@@ -70380,13 +70380,13 @@
             "value" : "Native (Best)"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Native (Best)"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Native (Best)"
@@ -70570,16 +70570,16 @@
             "value" : "설정 → 개인정보 및 보안으로 이동합니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Navigate to Settings → Privacy & Security"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Navigeer naar Instellingen → Privacy & Veiligheid"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Navigate to Settings → Privacy & Security"
           }
         },
         "pl" : {
@@ -70761,16 +70761,16 @@
             "value" : "항상 보이지 않음"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Never visible"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Nooit zichtbaar"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Never visible"
           }
         },
         "pl" : {
@@ -70951,16 +70951,16 @@
             "value" : "새 윈도우"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "New Window"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Nieuw venster"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "New Window"
           }
         },
         "pl" : {
@@ -71141,16 +71141,16 @@
             "value" : "다음"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Next page"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Volgende pagina"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Next page"
           }
         },
         "pl" : {
@@ -71332,16 +71332,16 @@
             "value" : "동작 없음"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No action"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Geen Actie"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "No action"
           }
         },
         "pl" : {
@@ -71523,13 +71523,13 @@
             "value" : "No Action"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "No Action"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "No Action"
@@ -71714,16 +71714,16 @@
             "value" : "아직 검색되거나 스캔된 애플리케이션이 없습니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No applications found or scanned yet."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Nog geen toepassingen gevonden of gescand."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "No applications found or scanned yet."
           }
         },
         "pl" : {
@@ -71904,13 +71904,13 @@
             "value" : "No applications found."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "No applications found."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "No applications found."
@@ -72094,13 +72094,13 @@
             "value" : "No apps in blacklist"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "No apps in blacklist"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "No apps in blacklist"
@@ -72284,13 +72284,13 @@
             "value" : "오디오 장치를 찾을 수 없습니다."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "No audio devices found"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "No audio devices found"
@@ -72474,13 +72474,13 @@
             "value" : "No calendars found"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "No calendars found"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "No calendars found"
@@ -72664,16 +72664,16 @@
             "value" : "사용자 지정 디렉터리가 추가되지 않았습니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No custom directories added"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Geen aangepaste mappen toegevoegd"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "No custom directories added"
           }
         },
         "pl" : {
@@ -72854,13 +72854,13 @@
             "value" : "오늘은 예정된 이벤트가 없습니다!"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "No events scheduled for today!"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "No events scheduled for today!"
@@ -73044,13 +73044,13 @@
             "value" : "오늘은 이벤트 없음"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "No events today"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "No events today"
@@ -73235,16 +73235,16 @@
             "value" : "추가한 필터 없음"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No filters added"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Geen filters toegevoegd"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "No filters added"
           }
         },
         "pl" : {
@@ -73427,16 +73427,16 @@
             "value" : "호버 동작 없음"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No hover action"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Geen zweef actie"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "No hover action"
           }
         },
         "pl" : {
@@ -73617,13 +73617,13 @@
             "value" : "사용 가능한 가사 없음"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "No lyrics available"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "No lyrics available"
@@ -73807,16 +73807,16 @@
             "value" : "최근 확인사항 없음"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No recent checks"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Geen recente checks"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "No recent checks"
           }
         },
         "pl" : {
@@ -73997,13 +73997,13 @@
             "value" : "No Results"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "No Results"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "No Results"
@@ -74187,16 +74187,16 @@
             "value" : "No shortcut set"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No shortcut set"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Geen snelkoppeling ingesteld"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "No shortcut set"
           }
         },
         "pl" : {
@@ -74377,16 +74377,16 @@
             "value" : "창 제목 필터가 추가되지 않았습니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No window title filters added"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Geen venstertitel filters toegevoegd"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "No window title filters added"
           }
         },
         "pl" : {
@@ -74567,13 +74567,13 @@
             "value" : "No windows match your search"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "No windows match your search"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "No windows match your search"
@@ -74757,16 +74757,16 @@
             "value" : "%@ 아니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Not %@"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Niet %@"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Not %@"
           }
         },
         "pl" : {
@@ -74948,16 +74948,16 @@
             "value" : "허용되지 않음"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Not granted"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Niet toegekend"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Not granted"
           }
         },
         "pl" : {
@@ -75141,16 +75141,16 @@
             "value" : "확인"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "OK"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ok"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "OK"
           }
         },
         "pl" : {
@@ -75332,16 +75332,16 @@
             "value" : "창을 가리키면; 버튼이 가리킬 때까지 어둡게 표시됨"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "On window hover; Dimmed until button hover"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bij venster zweven; gedimd tot knop zweven"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "On window hover; Dimmed until button hover"
           }
         },
         "pl" : {
@@ -75523,16 +75523,16 @@
             "value" : "창에 마우스를 올렸을 때; 불투명도 최대"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "On window hover; Full opacity"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bij venster zweven; volledige ondoorzichtigheid"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "On window hover; Full opacity"
           }
         },
         "pl" : {
@@ -75713,13 +75713,13 @@
             "value" : "Only display windows that are in the current virtual desktop/Space."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Only display windows that are in the current virtual desktop/Space."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Only display windows that are in the current virtual desktop/Space."
@@ -75903,13 +75903,13 @@
             "value" : "Only show windows from the currently active/frontmost application."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Only show windows from the currently active/frontmost application."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Only show windows from the currently active/frontmost application."
@@ -76094,16 +76094,16 @@
             "value" : "독 자동 숨기기가 활성화된 경우에만 적용됩니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Only takes effect when dock auto-hide is enabled"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Wordt alleen van kracht als automatisch verbergen van het dock is ingeschakeld"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Only takes effect when dock auto-hide is enabled"
           }
         },
         "pl" : {
@@ -76284,13 +76284,13 @@
             "value" : "Only the currently selected window gets live preview"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Only the currently selected window gets live preview"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Only the currently selected window gets live preview"
@@ -76474,13 +76474,13 @@
             "value" : "Only use delay for initial window opening"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Only use delay for initial window opening"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Only use delay for initial window opening"
@@ -76665,16 +76665,16 @@
             "value" : "손쉬운 사용 설정 열기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Open Accessibility Settings"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Open Toegankelijkheidsinstellingen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Open Accessibility Settings"
           }
         },
         "pl" : {
@@ -76856,13 +76856,13 @@
             "value" : "Open New Window"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Open New Window"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Open New Window"
@@ -77047,16 +77047,16 @@
             "value" : "화면 기록 설정 열기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Open Screen Recording Settings"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Open Schermopname Instellingen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Open Screen Recording Settings"
           }
         },
         "pl" : {
@@ -77237,16 +77237,16 @@
             "value" : "설정 열기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Open Settings"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Open Instellingen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Open Settings"
           }
         },
         "pl" : {
@@ -77427,13 +77427,13 @@
             "value" : "시스템 개인 정보 설정 열기"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Open System Privacy Settings"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Open System Privacy Settings"
@@ -77617,13 +77617,13 @@
             "value" : "Open System Settings"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Open System Settings"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Open System Settings"
@@ -77807,13 +77807,13 @@
             "value" : "Option"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Option"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Option"
@@ -77998,15 +77998,15 @@
             "value" : "옵션 키 (⌥)"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Option (⌥)"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Option (⌥)"
           }
         },
@@ -78188,13 +78188,13 @@
             "value" : "Option ⌥"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Option ⌥"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Option ⌥"
@@ -78273,6 +78273,18 @@
           }
         }
       }
+    },
+    "Parallel - Title bottom left, controls top left" : {
+
+    },
+    "Parallel - Title bottom right, controls top right" : {
+
+    },
+    "Parallel - Title top left, controls bottom left" : {
+
+    },
+    "Parallel - Title top right, controls bottom right" : {
+
     },
     "Performance Profiles" : {
       "localizations" : {
@@ -78378,16 +78390,16 @@
             "value" : "성능 프로필"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Performance Profiles"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Prestatie profiel"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Performance Profiles"
           }
         },
         "pl" : {
@@ -78568,16 +78580,16 @@
             "value" : "성능 튜닝(dock 미리보기)"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Performance Tuning (Dock Previews)"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Prestatie tuning (Dock voorbeelden)"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Performance Tuning (Dock Previews)"
           }
         },
         "pl" : {
@@ -78759,16 +78771,16 @@
             "value" : "권한 오류"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Permission error"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Machtigingsprobleem"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Permission error"
           }
         },
         "pl" : {
@@ -78950,16 +78962,16 @@
             "value" : "권한"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Permissions"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Machtigingen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Permissions"
           }
         },
         "pl" : {
@@ -79141,16 +79153,16 @@
             "value" : "권한 설정"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Permissions settings"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Machtigingsinstellingen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Permissions settings"
           }
         },
         "pl" : {
@@ -79335,16 +79347,16 @@
             "value" : "화면에 고정"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pin to Screen"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Vastzetten aan scherm"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Pin to Screen"
           }
         },
         "pl" : {
@@ -79525,13 +79537,13 @@
             "value" : "화면에 고정(컴팩트)"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Pin to Screen (Compact)"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Pin to Screen (Compact)"
@@ -79715,13 +79727,13 @@
             "value" : "화면에 고정(전체)"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Pin to Screen (Full)"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Pin to Screen (Full)"
@@ -79906,16 +79918,16 @@
             "value" : "화면에 고정됨"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pinned to screen"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Vastgezet aan scherm"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Pinned to screen"
           }
         },
         "pl" : {
@@ -80100,16 +80112,16 @@
             "value" : "배치 방향"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Placement Strategy"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Plaatsingsstrategie"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Placement Strategy"
           }
         },
         "pl" : {
@@ -80290,13 +80302,13 @@
             "value" : "Places traffic light buttons and window titles directly inside the dock preview frames for a more compact and minimal appearance."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Places traffic light buttons and window titles directly inside the dock preview frames for a more compact and minimal appearance."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Places traffic light buttons and window titles directly inside the dock preview frames for a more compact and minimal appearance."
@@ -80480,13 +80492,13 @@
             "value" : "Places traffic light buttons and window titles directly inside the preview frames."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Places traffic light buttons and window titles directly inside the preview frames."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Places traffic light buttons and window titles directly inside the preview frames."
@@ -80671,16 +80683,16 @@
             "value" : "변경사항을 적용하기 위해 앱을 종료하세요! :)"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Please Quit the App to Apply Changes! :)"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sluit de app om de wijzigingen toe te passen! :)"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Please Quit the App to Apply Changes! :)"
           }
         },
         "pl" : {
@@ -80862,16 +80874,16 @@
             "value" : "변경사항을 적용하기 위해 앱을 껐다가 켜주세요! :)"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Please Restart the App to Apply Changes! :)"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Start de app opnieuw op om de wijzigingen toe te passen! :)"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Please Restart the App to Apply Changes! :)"
           }
         },
         "pl" : {
@@ -81052,16 +81064,16 @@
             "value" : "변경사항을 적용하기 위해 앱을 껐다 켜주세요. OK를 누르면 앱이 종료됩니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Please restart the application to apply your changes. Click OK to quit the app."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Herstart de app om je veranderingen op te slaan. Druk OK om de app af te sluiten."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Please restart the application to apply your changes. Click OK to quit the app."
           }
         },
         "pl" : {
@@ -81243,15 +81255,15 @@
             "value" : "팝오버"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Popover"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Popover"
           }
         },
@@ -81433,13 +81445,13 @@
             "value" : "Position Dock Preview Controls"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Position Dock Preview Controls"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Position Dock Preview Controls"
@@ -81624,13 +81636,13 @@
             "value" : "Position Offset"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Position Offset"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Position Offset"
@@ -81814,16 +81826,16 @@
             "value" : "위치 창 컨트롤"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Position Window Controls"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Positie vensterbesturing"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Position Window Controls"
           }
         },
         "pl" : {
@@ -82005,16 +82017,16 @@
             "value" : "창의 전체 크기 미리 보기 표시"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Present a full size preview of the window"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Geef een voorbeeld van het venster op volledige grootte weer"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Present a full size preview of the window"
           }
         },
         "pl" : {
@@ -82195,13 +82207,13 @@
             "value" : "Press a key…"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Press a key…"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Press a key…"
@@ -82386,16 +82398,16 @@
             "value" : "초기화 키를 누른 상태에서 아무 키 조합이나 눌러 키 바인딩을 설정하세요."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Press any key combination after holding the initialization key to set the keybind."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Om de sneltoetsencombinatie in te stellen: druk op een willekeurige toetsencombinatie nadat u de initialisatie toets ingedrukt hebt gehouden."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Press any key combination after holding the initialization key to set the keybind."
           }
         },
         "pl" : {
@@ -82577,16 +82589,16 @@
             "value" : "아무 키나 눌러서 단축키를 설정하세요"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Press any key to set the keybind."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Druk op een toets om de toetscombinatie in te stellen."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Press any key to set the keybind."
           }
         },
         "pl" : {
@@ -82768,16 +82780,16 @@
             "value" : "아무 키나 누르세요"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Press any key..."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Druk op een toets..."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Press any key..."
           }
         },
         "pl" : {
@@ -82959,16 +82971,16 @@
             "value" : "트리거 키만 누릅니다(예: Tab 키만 누름)."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Press ONLY the trigger key (e.g. just Tab)"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Druk ALLEEN op de trigger toets (bijv. alleen Tab)"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Press ONLY the trigger key (e.g. just Tab)"
           }
         },
         "pl" : {
@@ -83149,13 +83161,13 @@
             "value" : "Press shortcut…"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Press shortcut…"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Press shortcut…"
@@ -83340,16 +83352,16 @@
             "value" : "키 조합 입력..."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Press the key combination..."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Druk de toetscombinatie in..."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Press the key combination..."
           }
         },
         "pl" : {
@@ -83530,16 +83542,16 @@
             "value" : "미리보기 중에 도크가 숨겨지지 않도록 하기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Prevent dock from hiding during previews"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Voorkom dat het dock tijdens previews wordt verborgen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Prevent dock from hiding during previews"
           }
         },
         "pl" : {
@@ -83720,13 +83732,13 @@
             "value" : "Prevent preview reappearance during fade-out"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Prevent preview reappearance during fade-out"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Prevent preview reappearance during fade-out"
@@ -83910,16 +83922,16 @@
             "value" : "창이 하나만 있는 앱이 미리 보기에 표시되지 않도록 합니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Prevents apps that only ever have a single window from appearing in previews."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Voorkomt dat apps die slechts één venster hebben, in voorvertoningen worden weergegeven."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Prevents apps that only ever have a single window from appearing in previews."
           }
         },
         "pl" : {
@@ -84101,16 +84113,16 @@
             "value" : "인접한 창으로 옆으로 이동할 때 미리보기가 사라지는 것을 방지합니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Prevents previews from disappearing when moving sideways to adjacent windows"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Voorkomt dat voorvertoningen verdwijnen wanneer u zijwaarts naar aangrenzende vensters beweegt"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Prevents previews from disappearing when moving sideways to adjacent windows"
           }
         },
         "pl" : {
@@ -84291,16 +84303,16 @@
             "value" : "모양 및 품질 미리보기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Preview Appearance & Quality"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Voorbeeld uiterlijk & kwaliteit"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Preview Appearance & Quality"
           }
         },
         "pl" : {
@@ -84482,16 +84494,16 @@
             "value" : "모양 및 품질 미리보기(독 미리보기)"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Preview Appearance & Quality (Dock Previews)"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Voorbeeld uiterlijk & kwaliteit (Dock voorbeeld)"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Preview Appearance & Quality (Dock Previews)"
           }
         },
         "pl" : {
@@ -84672,13 +84684,13 @@
             "value" : "Preview Height"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Preview Height"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Preview Height"
@@ -84863,16 +84875,16 @@
             "value" : "호버 동작 미리보기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Preview Hover Action"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Voorbeeld van Hover Actie"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Preview Hover Action"
           }
         },
         "pl" : {
@@ -85053,16 +85065,16 @@
             "value" : "미리보기 호버 동작 지연"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Preview Hover Action Delay"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Voorbeeld van Hover Actie vertraging"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Preview Hover Action Delay"
           }
         },
         "pl" : {
@@ -85244,16 +85256,16 @@
             "value" : "호버 딜레이 미리보기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Preview Hover Delay"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Voorbeeld van Hover Actie"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Preview Hover Delay"
           }
         },
         "pl" : {
@@ -85435,13 +85447,13 @@
             "value" : "레이아웃 미리보기(독)"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Preview Layout (Dock)"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Preview Layout (Dock)"
@@ -85625,13 +85637,13 @@
             "value" : "레이아웃 미리보기(스위쳐)"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Preview Layout (Switcher)"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Preview Layout (Switcher)"
@@ -85815,13 +85827,13 @@
             "value" : "품질 프로필 미리보기"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Preview Quality Profiles"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Preview Quality Profiles"
@@ -86006,16 +86018,16 @@
             "value" : "미리보기 크기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Preview Size"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Grootte voorvertoning"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Preview Size"
           }
         },
         "pl" : {
@@ -86196,13 +86208,13 @@
             "value" : "Preview Width"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Preview Width"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Preview Width"
@@ -86386,13 +86398,13 @@
             "value" : "미리보기 창 페이드 아웃 기간"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Preview Window Fade Out Duration"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Preview Window Fade Out Duration"
@@ -86576,13 +86588,13 @@
             "value" : "미리보기 창 비활성 타이머"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Preview Window Inactivity Timer"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Preview Window Inactivity Timer"
@@ -86766,13 +86778,13 @@
             "value" : "미리보기 창 열기 지연"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Preview Window Open Delay"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Preview Window Open Delay"
@@ -86957,13 +86969,13 @@
             "value" : "미리보기 창 크기는 화면 크기의 1/%lld로 조정됩니다."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Preview windows are sized to 1/%lld of your screen dimensions"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Preview windows are sized to 1/%lld of your screen dimensions"
@@ -87147,13 +87159,13 @@
             "value" : "Profile"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Profile"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Profile"
@@ -87337,15 +87349,15 @@
             "value" : "픽셀"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "px"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "px"
           }
         },
@@ -87527,16 +87539,16 @@
             "value" : "종료"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Quit"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Afsluiten"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Quit"
           }
         },
         "pl" : {
@@ -87718,16 +87730,16 @@
             "value" : "앱 종료"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Quit App"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sluit App"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Quit App"
           }
         },
         "pl" : {
@@ -87908,16 +87920,16 @@
             "value" : "DockDoor 종료"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Quit DockDoor"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sluit DockDoor"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Quit DockDoor"
           }
         },
         "pl" : {
@@ -88098,13 +88110,13 @@
             "value" : "Reading app information..."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Reading app information..."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Reading app information..."
@@ -88289,13 +88301,13 @@
             "value" : "Recently used"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Recently used"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Recently used"
@@ -88479,16 +88491,16 @@
             "value" : "모션 감소"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Reduce motion"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Beweging verminderen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reduce motion"
           }
         },
         "pl" : {
@@ -88670,13 +88682,13 @@
             "value" : "Refresh dock size"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Refresh dock size"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Refresh dock size"
@@ -88860,16 +88872,16 @@
             "value" : "편안한"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Relaxed"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ontspannen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Relaxed"
           }
         },
         "pl" : {
@@ -89050,16 +89062,16 @@
             "value" : "스위처에서 창을 선택하려면 초기화 키에서 손을 떼세요."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Release initializer key to select window in Switcher"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Laat de initialisatie toets los om een ​​venster in Switcher te selecteren"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Release initializer key to select window in Switcher"
           }
         },
         "pl" : {
@@ -89240,16 +89252,16 @@
             "value" : "제거"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Remove"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Verwijderen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Remove"
           }
         },
         "pl" : {
@@ -89430,16 +89442,16 @@
             "value" : "모두 제거"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Remove All"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Alles verwijderen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Remove All"
           }
         },
         "pl" : {
@@ -89620,13 +89632,13 @@
             "value" : "Removes the background panel from individual window previews."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Removes the background panel from individual window previews."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Removes the background panel from individual window previews."
@@ -89810,13 +89822,13 @@
             "value" : "Removes the pill-shaped background styling from traffic light buttons in dock previews for a cleaner look."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Removes the pill-shaped background styling from traffic light buttons in dock previews for a cleaner look."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Removes the pill-shaped background styling from traffic light buttons in dock previews for a cleaner look."
@@ -90000,13 +90012,13 @@
             "value" : "Removes the pill-shaped background styling from traffic light buttons."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Removes the pill-shaped background styling from traffic light buttons."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Removes the pill-shaped background styling from traffic light buttons."
@@ -90190,13 +90202,13 @@
             "value" : "Removes the pill-shaped background styling from window titles in dock previews for a cleaner look."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Removes the pill-shaped background styling from window titles in dock previews for a cleaner look."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Removes the pill-shaped background styling from window titles in dock previews for a cleaner look."
@@ -90380,13 +90392,13 @@
             "value" : "Removes the pill-shaped background styling from window titles."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Removes the pill-shaped background styling from window titles."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Removes the pill-shaped background styling from window titles."
@@ -90570,16 +90582,16 @@
             "value" : "버그 제보하기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Report a Bug"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Een bug doorgeven"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Report a Bug"
           }
         },
         "pl" : {
@@ -90760,16 +90772,16 @@
             "value" : "새로운 기능 요청"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Request a Feature"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Vraag een nieuwe feature aan"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Request a Feature"
           }
         },
         "pl" : {
@@ -90951,16 +90963,16 @@
             "value" : "다른 앱의 창 미리 보기를 캡처하는 데 필요합니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Required for capturing window previews of other apps"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Vereist voor het vastleggen van venstervoorbeelden van andere apps"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Required for capturing window previews of other apps"
           }
         },
         "pl" : {
@@ -91142,13 +91154,13 @@
             "value" : "Required for capturing window previews of other apps. Without this, only the compact list view will be available."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Required for capturing window previews of other apps. Without this, only the compact list view will be available."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Required for capturing window previews of other apps. Without this, only the compact list view will be available."
@@ -91332,16 +91344,16 @@
             "value" : "도크 호버 감지 및 창 전환기 핫키에 필요합니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Required for dock hover detection and window switcher hotkeys"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Vereist voor dock hover detectie en sneltoetsen voor vensterwisseling"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Required for dock hover detection and window switcher hotkeys"
           }
         },
         "pl" : {
@@ -91522,15 +91534,15 @@
             "value" : "초기화"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Reset"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Reset"
           }
         },
@@ -91713,16 +91725,16 @@
             "value" : "모든 설정 초기화"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Reset All Settings"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Reset Alle Instellingen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reset All Settings"
           }
         },
         "pl" : {
@@ -91903,16 +91915,16 @@
             "value" : "모든 설정을 기본값으로 초기화"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Reset All Settings to Defaults"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Reset Alle Instellingen naar Standaard"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reset All Settings to Defaults"
           }
         },
         "pl" : {
@@ -92093,16 +92105,16 @@
             "value" : "기본 설정으로 초기화"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Reset to Defaults"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Reset naar Standaard"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reset to Defaults"
           }
         },
         "pl" : {
@@ -92283,16 +92295,16 @@
             "value" : "앱 다시 시작하기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Restart app"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "App herstarten"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Restart app"
           }
         },
         "pl" : {
@@ -92474,16 +92486,16 @@
             "value" : "앱 다시 시작하기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Restart App"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Herstart app"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Restart App"
           }
         },
         "pl" : {
@@ -92664,16 +92676,16 @@
             "value" : "재시작 필요합니다"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Restart required"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Herstart nodig"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Restart required"
           }
         },
         "pl" : {
@@ -92854,13 +92866,13 @@
             "value" : "Retina (1280px)"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Retina (1280px)"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Retina (1280px)"
@@ -93044,13 +93056,13 @@
             "value" : "Return"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Return"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Return"
@@ -93234,16 +93246,16 @@
             "value" : "색을 우클릭하여 삭제하세요."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Right click a color to remove it."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Klik met je rechtermuisknop om een kleur te verwijderen."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Right click a color to remove it."
           }
         },
         "pl" : {
@@ -93424,13 +93436,13 @@
             "value" : "Round the corners of window preview images for a modern look."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Round the corners of window preview images for a modern look."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Round the corners of window preview images for a modern look."
@@ -93614,13 +93626,13 @@
             "value" : "Rounded corners"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Rounded corners"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Rounded corners"
@@ -93805,16 +93817,16 @@
             "value" : "둥근 이미지 모서리"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Rounded image corners"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Afbeelding met afgeronde hoeken"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Rounded image corners"
           }
         },
         "pl" : {
@@ -93995,16 +94007,16 @@
             "value" : "화면"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Screen"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Scherm"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Screen"
           }
         },
         "pl" : {
@@ -94186,16 +94198,16 @@
             "value" : "화면 기록:"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Screen Capturing:"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Scherm Vastleggen:"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Screen Capturing:"
           }
         },
         "pl" : {
@@ -94376,16 +94388,16 @@
             "value" : "화면 녹화"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Screen recording"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Schermopname"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Screen recording"
           }
         },
         "pl" : {
@@ -94566,13 +94578,13 @@
             "value" : "Screen Recording permission is required for window thumbnails."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Screen Recording permission is required for window thumbnails."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Screen Recording permission is required for window thumbnails."
@@ -94756,13 +94768,13 @@
             "value" : "Screen Recording permission is required to show window thumbnails."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Screen Recording permission is required to show window thumbnails."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Screen Recording permission is required to show window thumbnails."
@@ -94947,16 +94959,16 @@
             "value" : "화면 기록 권한"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Screen Recording Permissions"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Schermopname Machtigingen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Screen Recording Permissions"
           }
         },
         "pl" : {
@@ -95138,16 +95150,16 @@
             "value" : "마지막으로 활성화된 창이 있는 화면"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Screen with last active window"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Scherm met laatst actieve venster"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Screen with last active window"
           }
         },
         "pl" : {
@@ -95329,16 +95341,16 @@
             "value" : "마우스가 있는 화면"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Screen with mouse"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Scherm met muis"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Screen with mouse"
           }
         },
         "pl" : {
@@ -95519,13 +95531,13 @@
             "value" : "Scroll behavior:"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Scroll behavior:"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Scroll behavior:"
@@ -95709,13 +95721,13 @@
             "value" : "Scroll direction:"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Scroll direction:"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Scroll direction:"
@@ -95899,13 +95911,13 @@
             "value" : "Scroll long titles (marquee)"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Scroll long titles (marquee)"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Scroll long titles (marquee)"
@@ -96090,13 +96102,13 @@
             "value" : "Scroll to window on mouse hover"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Scroll to window on mouse hover"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Scroll to window on mouse hover"
@@ -96280,13 +96292,13 @@
             "value" : "Scroll up on a dock icon to bring the app to front, scroll down to hide all its windows."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Scroll up on a dock icon to bring the app to front, scroll down to hide all its windows."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Scroll up on a dock icon to bring the app to front, scroll down to hide all its windows."
@@ -96470,13 +96482,13 @@
             "value" : "Search Fuzziness"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Search Fuzziness"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Search Fuzziness"
@@ -96660,16 +96672,16 @@
             "value" : "초"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "seconds"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "seconden"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "seconds"
           }
         },
         "pl" : {
@@ -96852,16 +96864,16 @@
             "value" : "창 크게 보기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "See a large preview of the window"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Zie een grote voorvertoning van het scherm"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "See a large preview of the window"
           }
         },
         "pl" : {
@@ -97044,16 +97056,16 @@
             "value" : "창 미리보기 보기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "See a preview of the window"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Zie een voorvertoning van het scherm"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "See a preview of the window"
           }
         },
         "pl" : {
@@ -97234,16 +97246,16 @@
             "value" : "더 보기..."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "See more..."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Zie meer..."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "See more..."
           }
         },
         "pl" : {
@@ -97425,13 +97437,13 @@
             "value" : "Seek playback (scrub through track)"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Seek playback (scrub through track)"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Seek playback (scrub through track)"
@@ -97615,16 +97627,16 @@
             "value" : "프로필을 선택하면 일반적인 성능 설정을 빠르게 조정할 수 있습니다. 수동으로 제어하려면 '고급'을 선택합니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Select a profile to quickly adjust common performance settings. Choose \"Advanced\" for manual control."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Selecteer een profiel om snel algemene prestatie-instellingen aan te passen. Kies 'Geavanceerd' voor handmatige bediening."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Select a profile to quickly adjust common performance settings. Choose \"Advanced\" for manual control."
           }
         },
         "pl" : {
@@ -97805,13 +97817,13 @@
             "value" : "Select an application:"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Select an application:"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Select an application:"
@@ -97996,16 +98008,16 @@
             "value" : "초기화 키(예: Command ⌘)를 선택합니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Select an initialization key (e.g. Command ⌘)"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Selecteer een initialisatie sleutel (bijv. Command ⌘)"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Select an initialization key (e.g. Command ⌘)"
           }
         },
         "pl" : {
@@ -98186,13 +98198,13 @@
             "value" : "Select and scroll to windows when hovering with mouse. Disable for keyboard-only navigation."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Select and scroll to windows when hovering with mouse. Disable for keyboard-only navigation."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Select and scroll to windows when hovering with mouse. Disable for keyboard-only navigation."
@@ -98377,16 +98389,16 @@
             "value" : "캡처하고 미리 볼 수 있는 애플리케이션을 선택합니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Select which applications can be captured and previewed"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Selecteer welke applicaties vastgelegd en vooraf bekeken kunnen worden"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Select which applications can be captured and previewed"
           }
         },
         "pl" : {
@@ -98567,16 +98579,16 @@
             "value" : "DockDoor에 미리보기를 표시할 애플리케이션을 선택합니다. 선택하지 않은 앱은 무시됩니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Select which applications DockDoor should show previews for. Unchecked apps will be ignored."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Selecteer voor welke apps DockDoor previews moet weergeven. Niet aangevinkte apps worden genegeerd."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Select which applications DockDoor should show previews for. Unchecked apps will be ignored."
           }
         },
         "pl" : {
@@ -98757,13 +98769,13 @@
             "value" : "Select which calendars appear in the dock preview when hovering over the Calendar app."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Select which calendars appear in the dock preview when hovering over the Calendar app."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Select which calendars appear in the dock preview when hovering over the Calendar app."
@@ -98947,16 +98959,16 @@
             "value" : "Selected app:"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Selected app:"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Gekozen app:"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Selected app:"
           }
         },
         "pl" : {
@@ -99137,13 +99149,13 @@
             "value" : "Selected App's Windows"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Selected App's Windows"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Selected App's Windows"
@@ -99327,13 +99339,13 @@
             "value" : "Selected Window Only"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Selected Window Only"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Selected Window Only"
@@ -99518,16 +99530,16 @@
             "value" : "선택 하이라이트"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Selection Highlight"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Selectie markering"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Selection Highlight"
           }
         },
         "pl" : {
@@ -99708,13 +99720,13 @@
             "value" : "Set a threshold to automatically switch to compact mode when an app has that many or more windows. Set to 0 to disable."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Set a threshold to automatically switch to compact mode when an app has that many or more windows. Set to 0 to disable."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Set a threshold to automatically switch to compact mode when an app has that many or more windows. Set to 0 to disable."
@@ -99899,16 +99911,16 @@
             "value" : "초기화 키와 키 바인딩 설정"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Set Initialization Key and Keybind"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Stel initialisatie sleutel en toetscombinatie in"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Set Initialization Key and Keybind"
           }
         },
         "pl" : {
@@ -100090,16 +100102,16 @@
             "value" : "무제한의 경우 0으로 설정"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Set to 0 for unlimited"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Instellen op 0 voor onbeperkt"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Set to 0 for unlimited"
           }
         },
         "pl" : {
@@ -100281,16 +100293,16 @@
             "value" : "트리거 키 설정"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Set Trigger Key"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Trigger toets instellen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Set Trigger Key"
           }
         },
         "pl" : {
@@ -100472,16 +100484,16 @@
             "value" : "미리보기에서 사용할 최대 행(하단/상단 독의 경우) 또는 열(측면 독의 경우)을 설정합니다. '0'은 동적으로 맞춤을 결정합니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Sets the max rows (for bottom/top Dock) or columns (for side Dock) previews will use. '0' dynamically determines fit."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Hiermee stelt u het maximum aantal rijen (voor onderste/bovenste Dock) of kolommen (voor zij-Dock) in dat voorvertoningen worden gebruikt. '0' bepaalt dynamisch de pasvorm."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Sets the max rows (for bottom/top Dock) or columns (for side Dock) previews will use. '0' dynamically determines fit."
           }
         },
         "pl" : {
@@ -100663,16 +100675,16 @@
             "value" : "창 전환기에서 사용할 최대 행 수를 설정합니다. '0'은 화면 높이에 따라 행을 동적으로 결정합니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Sets the maximum number of rows the Window Switcher will use. '0' dynamically determines rows based on screen height."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Hiermee stelt u het maximale aantal rijen in dat de venster wisselaar gebruikt. '0' bepaalt dynamisch het aantal rijen op basis van de schermhoogte."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Sets the maximum number of rows the Window Switcher will use. '0' dynamically determines rows based on screen height."
           }
         },
         "pl" : {
@@ -100854,16 +100866,16 @@
             "value" : "그림자"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Shadowed"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Schaduwen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shadowed"
           }
         },
         "pl" : {
@@ -101044,13 +101056,13 @@
             "value" : "Shake a window preview rapidly"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Shake a window preview rapidly"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Shake a window preview rapidly"
@@ -101234,13 +101246,13 @@
             "value" : "Shift Indicator"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Shift Indicator"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Shift Indicator"
@@ -101425,13 +101437,13 @@
             "value" : "Show active app indicator below dock icon"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Show active app indicator below dock icon"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Show active app indicator below dock icon"
@@ -101615,13 +101627,13 @@
             "value" : "Show active window border"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Show active window border"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Show active window border"
@@ -101805,16 +101817,16 @@
             "value" : "고급 설정 표시"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Show Advanced Settings"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Toon geavanceerde instellingen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Show Advanced Settings"
           }
         },
         "pl" : {
@@ -101995,13 +102007,13 @@
             "value" : "Show All"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Show All"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Show All"
@@ -102185,13 +102197,13 @@
             "value" : "Show App Header"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Show App Header"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Show App Header"
@@ -102375,13 +102387,13 @@
             "value" : "Show App Icon Only"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Show App Icon Only"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Show App Icon Only"
@@ -102566,16 +102578,16 @@
             "value" : "앱 이름 표시"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Show App Name"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "App-naam weergeven"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Show App Name"
           }
         },
         "pl" : {
@@ -102757,16 +102769,16 @@
             "value" : "Dock 미리 보기에서 앱 이름 표시"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Show App Name in Dock Previews"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "App-naam in Dock Previews tonen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Show App Name in Dock Previews"
           }
         },
         "pl" : {
@@ -102947,13 +102959,13 @@
             "value" : "유효한 창이 없을 때 큰 컨트롤 표시"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Show big controls when no valid windows"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Show big controls when no valid windows"
@@ -103137,13 +103149,13 @@
             "value" : "도크 마우스오버 시 미디어/캘린더 컨트롤 보기"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Show media/calendar controls on Dock hover"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Show media/calendar controls on Dock hover"
@@ -103327,16 +103339,16 @@
             "value" : "메뉴 막대 아이콘 표시"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Show menu bar icon"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Menubalkpictogram weergeven"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Show menu bar icon"
           }
         },
         "pl" : {
@@ -103518,16 +103530,16 @@
             "value" : "메뉴 막대에 아이콘 표시"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Show Menu Bar Icon"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Laat Menu Bar Icon Zien"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Show Menu Bar Icon"
           }
         },
         "pl" : {
@@ -103708,16 +103720,16 @@
             "value" : "앱 레이블 위에 미리보기 표시"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Show preview above app labels"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Voorbeeld weergeven boven app-labels"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Show preview above app labels"
           }
         },
         "pl" : {
@@ -103898,13 +103910,13 @@
             "value" : "Show previews while holding Cmd+Tab."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Show previews while holding Cmd+Tab."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Show previews while holding Cmd+Tab."
@@ -104088,13 +104100,13 @@
             "value" : "Show window previews when hovering over Dock icons."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Show window previews when hovering over Dock icons."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Show window previews when hovering over Dock icons."
@@ -104278,13 +104290,13 @@
             "value" : "Show Window Switcher instantly"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Show Window Switcher instantly"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Show Window Switcher instantly"
@@ -104468,16 +104480,16 @@
             "value" : "창 제목 표시"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Show Window Title"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Toon venstertitel"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Show Window Title"
           }
         },
         "pl" : {
@@ -104659,16 +104671,16 @@
             "value" : "창 제목 표시"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Show Window Title in"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Laat de Schermnaam Zien in"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Show Window Title in"
           }
         },
         "pl" : {
@@ -104850,16 +104862,16 @@
             "value" : "미리보기에서 창 제목 표시"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Show Window Title in Previews"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Laat de Schermnaam Zien in Voorvertoning"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Show Window Title in Previews"
           }
         },
         "pl" : {
@@ -105041,16 +105053,16 @@
             "value" : "창 제목 표시"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Show Window Titles"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Laat de Schermnaam Zien"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Show Window Titles"
           }
         },
         "pl" : {
@@ -105232,16 +105244,16 @@
             "value" : "미리보기에서 창 제목 표시"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Show Window Titles on Previews"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Toon venstertitels op previews"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Show Window Titles on Previews"
           }
         },
         "pl" : {
@@ -105422,13 +105434,13 @@
             "value" : "Show windows from current Space only"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Show windows from current Space only"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Show windows from current Space only"
@@ -105613,16 +105625,16 @@
             "value" : "현재 창 대신 마지막으로 활성화된 창을 먼저 표시합니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Shows last active window first, instead of current window."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Toont het laatst actieve venster eerst, in plaats van het huidige venster."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shows last active window first, instead of current window."
           }
         },
         "pl" : {
@@ -105804,13 +105816,13 @@
             "value" : "Shows only windows from the current Space"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Shows only windows from the current Space"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Shows only windows from the current Space"
@@ -105995,13 +106007,13 @@
             "value" : "Shows only windows from the frontmost app in the current Space"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Shows only windows from the frontmost app in the current Space"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Shows only windows from the frontmost app in the current Space"
@@ -106186,13 +106198,13 @@
             "value" : "Shows only windows from the frontmost application"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Shows only windows from the frontmost application"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Shows only windows from the frontmost application"
@@ -106378,16 +106390,16 @@
             "value" : "클릭 시뮬레이션"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Simulate a click"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Simuleer een klik"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Simulate a click"
           }
         },
         "pl" : {
@@ -106569,16 +106581,16 @@
             "value" : "클릭 시뮬레이션(창 열기)"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Simulate a click (open the window)"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Simuleer een klik (open het scherm)"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Simulate a click (open the window)"
           }
         },
         "pl" : {
@@ -106760,13 +106772,13 @@
             "value" : "Skip (use list view only)"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Skip (use list view only)"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Skip (use list view only)"
@@ -106950,13 +106962,13 @@
             "value" : "Skip the small delay before the switcher appears. May feel snappier but can cause flickering if you quickly release the key."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Skip the small delay before the switcher appears. May feel snappier but can cause flickering if you quickly release the key."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Skip the small delay before the switcher appears. May feel snappier but can cause flickering if you quickly release the key."
@@ -107141,16 +107153,16 @@
             "value" : "작게"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Small"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Klein"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Small"
           }
         },
         "pl" : {
@@ -107332,16 +107344,16 @@
             "value" : "소형(1/%lld)"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Small (1/%lld)"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Klein (1/%lld)"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Small (1/%lld)"
           }
         },
         "pl" : {
@@ -107522,16 +107534,16 @@
             "value" : "Snappy"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Snappy"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Vlug"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Snappy"
           }
         },
         "pl" : {
@@ -107712,13 +107724,13 @@
             "value" : "Sort minimized/hidden windows to end"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Sort minimized/hidden windows to end"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Sort minimized/hidden windows to end"
@@ -107903,16 +107915,16 @@
             "value" : "날짜별로 창 미리보기 정렬"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Sort Window Previews by Date"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sorteer venster voorvertoningen op datum"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Sort Window Previews by Date"
           }
         },
         "pl" : {
@@ -108094,16 +108106,16 @@
             "value" : "날짜별로 창 미리보기 정렬(여러 개일 경우)"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Sort Window Previews by Date (if multiple)"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sorteer venster voorvertoningen op datum (indien veelvoud)"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Sort Window Previews by Date (if multiple)"
           }
         },
         "pl" : {
@@ -108284,13 +108296,13 @@
             "value" : "Space"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Space"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Space"
@@ -108474,13 +108486,13 @@
             "value" : "Spacing Scale"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Spacing Scale"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Spacing Scale"
@@ -108664,13 +108676,13 @@
             "value" : "Stable"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Stable"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Stable"
@@ -108854,16 +108866,16 @@
             "value" : "표준"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Standard"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Standaard"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Standard"
           }
         },
         "pl" : {
@@ -109044,13 +109056,13 @@
             "value" : "Standard (640px)"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Standard (640px)"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Standard (640px)"
@@ -109234,13 +109246,13 @@
             "value" : "Start on second window in Switcher"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Start on second window in Switcher"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Start on second window in Switcher"
@@ -109425,16 +109437,16 @@
             "value" : "키 바인드 기록 시작"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Start recording keybind"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Start opname toetscombinatie"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Start recording keybind"
           }
         },
         "pl" : {
@@ -109616,16 +109628,16 @@
             "value" : "키 입력 기록 시작"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Start Recording Keybind"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Start opname toetscombinatie"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Start Recording Keybind"
           }
         },
         "pl" : {
@@ -109807,16 +109819,16 @@
             "value" : "녹화 시작 키 설정"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Start recording trigger key"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Start opname trigger toets"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Start recording trigger key"
           }
         },
         "pl" : {
@@ -109997,13 +110009,13 @@
             "value" : "Stream Keep-Alive Duration"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Stream Keep-Alive Duration"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Stream Keep-Alive Duration"
@@ -110189,16 +110201,16 @@
             "value" : "아원자"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Subatomic"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sub atomisch"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Subatomic"
           }
         },
         "pl" : {
@@ -110379,16 +110391,16 @@
             "value" : "DockDoor를 더욱 발전시키기 위한 새로운 기능을 제안해 주세요."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Suggest new features to make DockDoor even better."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Stel nieuwe functies voor om DockDoor nog beter te maken."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Suggest new features to make DockDoor even better."
           }
         },
         "pl" : {
@@ -110570,16 +110582,16 @@
             "value" : "지원"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Support"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ondersteuning"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Support"
           }
         },
         "pl" : {
@@ -110760,16 +110772,16 @@
             "value" : "지원 및 기여"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Support & Contributions"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ondersteuning & bijdragen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Support & Contributions"
           }
         },
         "pl" : {
@@ -110950,16 +110962,16 @@
             "value" : "소액 기부로 개발 지원"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Support development with a small donation"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ondersteun ontwikkeling met een kleine donatie"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Support development with a small donation"
           }
         },
         "pl" : {
@@ -111140,16 +111152,16 @@
             "value" : "DockDoor 지원"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Support DockDoor"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Steun DockDoor"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Support DockDoor"
           }
         },
         "pl" : {
@@ -111331,16 +111343,16 @@
             "value" : "지원 설정"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Support settings"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Instellingen voor ondersteuning"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Support settings"
           }
         },
         "pl" : {
@@ -111521,13 +111533,13 @@
             "value" : "Swipe on window previews in the dock popup. Direction is relative to dock position — swipe towards the dock (e.g., down when dock is at bottom, left when dock is on left)."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Swipe on window previews in the dock popup. Direction is relative to dock position — swipe towards the dock (e.g., down when dock is at bottom, left when dock is on left)."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Swipe on window previews in the dock popup. Direction is relative to dock position — swipe towards the dock (e.g., down when dock is at bottom, left when dock is on left)."
@@ -111711,13 +111723,13 @@
             "value" : "Swipe up or down on window previews in the keyboard-activated window switcher. Only vertical swipes are recognized, unless in compact mode."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Swipe up or down on window previews in the keyboard-activated window switcher. Only vertical swipes are recognized, unless in compact mode."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Swipe up or down on window previews in the keyboard-activated window switcher. Only vertical swipes are recognized, unless in compact mode."
@@ -111901,13 +111913,13 @@
             "value" : "Switcher Frame Rate"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Switcher Frame Rate"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Switcher Frame Rate"
@@ -112091,13 +112103,13 @@
             "value" : "Switcher Live Preview Scope"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Switcher Live Preview Scope"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Switcher Live Preview Scope"
@@ -112281,13 +112293,13 @@
             "value" : "Switcher Quality"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Switcher Quality"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Switcher Quality"
@@ -112471,13 +112483,13 @@
             "value" : "Tab"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Tab"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Tab"
@@ -112661,16 +112673,16 @@
             "value" : "모든 기여자에게 감사합니다 ❤️"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Thank you to all contributors ❤️"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Dank aan alle bijdragers ❤️"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Thank you to all contributors ❤️"
           }
         },
         "pl" : {
@@ -112852,16 +112864,16 @@
             "value" : "DockDoor를 응원해 주셔서 감사합니다! 💖"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Thanks for supporting DockDoor! 💖"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bedankt voor het steunen van DockDoor! 💖"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Thanks for supporting DockDoor! 💖"
           }
         },
         "pl" : {
@@ -113042,16 +113054,16 @@
             "value" : "권한 변경 사항은 재시작 후 적용됩니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The changes to permissions will take effect after restarting."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "De gewijzigde machtigingen worden van kracht nadat u opnieuw bent opgestart."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "The changes to permissions will take effect after restarting."
           }
         },
         "pl" : {
@@ -113232,13 +113244,13 @@
             "value" : "The indicator appears next to the active app's dock icon. Note: This feature does not support auto-hiding docks."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "The indicator appears next to the active app's dock icon. Note: This feature does not support auto-hiding docks."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "The indicator appears next to the active app's dock icon. Note: This feature does not support auto-hiding docks."
@@ -113423,16 +113435,16 @@
             "value" : "신호등 버튼과 창 제목에 대해 선택한 위치가 겹치게 됩니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The selected positions for Traffic Light Buttons and Window Title will overlap."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "De geselecteerde posities voor verkeerslichtknoppen en venstertitels zullen elkaar overlappen."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "The selected positions for Traffic Light Buttons and Window Title will overlap."
           }
         },
         "pl" : {
@@ -113613,16 +113625,16 @@
             "value" : "창 전환기(보통 Alt/Cmd-Tab)를 사용하면 키보드 단축키로 열려 있는 앱 창 사이를 빠르게 전환할 수 있습니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The Window Switcher (often Alt/Cmd-Tab) lets you quickly cycle between open app windows with a keyboard shortcut."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Met de venster wisselaar (vaak Alt/Cmd-Tab) kunt u met een sneltoets schakelen tussen geopende app-vensters."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "The Window Switcher (often Alt/Cmd-Tab) lets you quickly cycle between open app windows with a keyboard shortcut."
           }
         },
         "pl" : {
@@ -113807,13 +113819,13 @@
             "value" : "This display is currently disconnected. The window switcher will appear on the main display until reconnected."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "This display is currently disconnected. The window switcher will appear on the main display until reconnected."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "This display is currently disconnected. The window switcher will appear on the main display until reconnected."
@@ -113999,16 +114011,16 @@
             "value" : "이 디스플레이는 현재 연결이 끊어졌습니다. 선택한 디스플레이가 다시 연결될 때까지 창 전환기가 기본 디스플레이에 나타납니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This display is currently disconnected. The window switcher will appear on the main display until the selected display is reconnected."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Dit scherm is momenteel niet verbonden. De venster schakelaar blijft op het hoofdscherm zichtbaar totdat het geselecteerde scherm weer is verbonden."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "This display is currently disconnected. The window switcher will appear on the main display until the selected display is reconnected."
           }
         },
         "pl" : {
@@ -114189,13 +114201,13 @@
             "value" : "이 설정은 위에서 '창 미리보기가 있는 컨트롤 포함'이 활성화된 경우에만 적용됩니다."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "This setting only applies when \"Embed controls with window previews\" is enabled above."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "This setting only applies when \"Embed controls with window previews\" is enabled above."
@@ -114379,13 +114391,13 @@
             "value" : "This will add the app to the blacklist using its bundle identifier for reliable matching."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "This will add the app to the blacklist using its bundle identifier for reliable matching."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "This will add the app to the blacklist using its bundle identifier for reliable matching."
@@ -114569,13 +114581,13 @@
             "value" : "Thumbnail (320px)"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Thumbnail (320px)"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Thumbnail (320px)"
@@ -114760,16 +114772,16 @@
             "value" : "작은(1/%lld)"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Tiny (1/%lld)"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Klein (1/%lld)"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Tiny (1/%lld)"
           }
         },
         "pl" : {
@@ -114950,13 +114962,13 @@
             "value" : "Title Format"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Title Format"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Title Format"
@@ -115140,13 +115152,13 @@
             "value" : "오늘"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Today"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Today"
@@ -115330,16 +115342,16 @@
             "value" : "토글"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Toggle"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Omschakelen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Toggle"
           }
         },
         "pl" : {
@@ -115521,16 +115533,16 @@
             "value" : "전체화면 켜기/끄기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Toggle Full Screen"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Volledig scherm in-/uitschakelen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Toggle Full Screen"
           }
         },
         "pl" : {
@@ -115715,16 +115727,16 @@
             "value" : "왼쪽 상단"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Top Left"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Linksboven"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Top Left"
           }
         },
         "pl" : {
@@ -115906,16 +115918,16 @@
             "value" : "오른쪽 상단"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Top Right"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Rechtsboven"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Top Right"
           }
         },
         "pl" : {
@@ -116096,16 +116108,16 @@
             "value" : "신호등 버튼"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Traffic Light Buttons"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Verkeerslichtknoppen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Traffic Light Buttons"
           }
         },
         "pl" : {
@@ -116286,16 +116298,16 @@
             "value" : "미리보기의 신호등 버튼"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Traffic Light Buttons in Previews"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Verkeerslichtknoppen in previews"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Traffic Light Buttons in Previews"
           }
         },
         "pl" : {
@@ -116477,16 +116489,16 @@
             "value" : "신호등 버튼 위치"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Traffic Light Buttons Position"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Positie van verkeerslichtknoppen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Traffic Light Buttons Position"
           }
         },
         "pl" : {
@@ -116667,16 +116679,16 @@
             "value" : "신호등 버튼 가시성"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Traffic Light Buttons Visibility"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Zichtbaarheid van verkeerslichtknoppen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Traffic Light Buttons Visibility"
           }
         },
         "pl" : {
@@ -116857,13 +116869,13 @@
             "value" : "Translation Contributors"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Translation Contributors"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Translation Contributors"
@@ -117048,16 +117060,16 @@
             "value" : "트리거 키"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Trigger Key"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Trigger toets"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Trigger Key"
           }
         },
         "pl" : {
@@ -117239,16 +117251,16 @@
             "value" : "독 미리보기에서 창 위로 마우스를 가져가면 동작을 트리거합니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Triggers an action when hovering over a window in a dock preview"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Activeert een actie wanneer u met de muis over een venster in een dock voorbeeld beweegt"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Triggers an action when hovering over a window in a dock preview"
           }
         },
         "pl" : {
@@ -117430,16 +117442,16 @@
             "value" : "도크 미리보기에서 창을 드래그하는 동안 창을 흔들면 동작을 트리거합니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Triggers an action when shaking a window while it is being dragged from a dock preview"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Activeert een actie wanneer een venster wordt geschud terwijl het vanuit een dock voorbeeld wordt gesleept"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Triggers an action when shaking a window while it is being dragged from a dock preview"
           }
         },
         "pl" : {
@@ -117620,16 +117632,16 @@
             "value" : "최소화 해제"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Un-minimize"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Minimaliseren ongedaan maken"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Un-minimize"
           }
         },
         "pl" : {
@@ -117810,16 +117822,16 @@
             "value" : "알 수 없는 디스플레이"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unknown Display"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Onbekend display"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Unknown Display"
           }
         },
         "pl" : {
@@ -118000,13 +118012,13 @@
             "value" : "고정해제"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Unpin"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Unpin"
@@ -118190,13 +118202,13 @@
             "value" : "Unselected Content Opacity"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Unselected Content Opacity"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Unselected Content Opacity"
@@ -118380,16 +118392,16 @@
             "value" : "최신 버전입니다"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Up to date"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Actueel"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Up to date"
           }
         },
         "pl" : {
@@ -118570,16 +118582,16 @@
             "value" : "최신 버전입니다"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Up to Date"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Up-to-date"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Up to Date"
           }
         },
         "pl" : {
@@ -118760,16 +118772,16 @@
             "value" : "업데이트가 중단되었습니다: %@"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Update aborted: %@"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Update afgebroken: %@"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Update aborted: %@"
           }
         },
         "pl" : {
@@ -118950,16 +118962,16 @@
             "value" : "업데이트 사용 가능"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Update available"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Update beschikbaar"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Update available"
           }
         },
         "pl" : {
@@ -119140,13 +119152,13 @@
             "value" : "Update Channel"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Update Channel"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Update Channel"
@@ -119331,16 +119343,16 @@
             "value" : "업데이트 설정"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Update settings"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Instellingen bijwerken"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Update settings"
           }
         },
         "pl" : {
@@ -119521,16 +119533,16 @@
             "value" : "v%@ 업데이트 가능"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Update v%@ available"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Update v%@ beschikbaar"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Update v%@ available"
           }
         },
         "pl" : {
@@ -119711,16 +119723,16 @@
             "value" : "업데이터가 구성되지 않았습니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Updater not configured."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Updater niet geconfigureerd."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Updater not configured."
           }
         },
         "pl" : {
@@ -119902,15 +119914,15 @@
             "value" : "업데이트"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Updates"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Updates"
           }
         },
@@ -120093,16 +120105,16 @@
             "value" : "클래식 창 명령 사용"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Use classic window ordering"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Gebruik klassieke venster volgorde"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Use classic window ordering"
           }
         },
         "pl" : {
@@ -120284,16 +120296,16 @@
             "value" : "기본 MacOS 키 바인드 ⌘ + ⇥ 사용"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Use default MacOS keybind ⌘ + ⇥"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Gebruik standaard MacOS toetsencombinatie ⌘ + ⇥"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Use default MacOS keybind ⌘ + ⇥"
           }
         },
         "pl" : {
@@ -120474,16 +120486,16 @@
             "value" : "Use Liquid Glass (macOS 26+)"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Use Liquid Glass (macOS 26+)"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Gebruik Liquid Glass (macOS 26+)"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Use Liquid Glass (macOS 26+)"
           }
         },
         "pl" : {
@@ -120664,16 +120676,16 @@
             "value" : "단색 색상 사용"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Use Monochrome Colors"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Gebruik monochrome kleuren"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Use Monochrome Colors"
           }
         },
         "pl" : {
@@ -120855,16 +120867,16 @@
             "value" : "강조 표시를 위해 시스템 강조 색상 사용"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Use System Accent Color for Highlight"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Gebruik systeem accentkleur voor markering"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Use System Accent Color for Highlight"
           }
         },
         "pl" : {
@@ -121046,16 +121058,16 @@
             "value" : "균일한 이미지 미리보기 반경 사용"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Use Uniform Image Preview Radius"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Uniforme afbeelding voorvertoning-radius gebruiken"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Use Uniform Image Preview Radius"
           }
         },
         "pl" : {
@@ -121237,16 +121249,16 @@
             "value" : "Windows 스타일 창 순서 사용"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Use Windows-style window ordering"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Gebruik venstervolgorde in Windows-stijl"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Use Windows-style window ordering"
           }
         },
         "pl" : {
@@ -121428,16 +121440,16 @@
             "value" : "스위처에서 Windows 스타일 창 순서 사용"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Use Windows-style window ordering in Switcher"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Gebruik venstervolgorde in Windows-stijl in Switcher"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Use Windows-style window ordering in Switcher"
           }
         },
         "pl" : {
@@ -121619,16 +121631,16 @@
             "value" : "창 전환기에서 Windows 스타일 창 순서 사용"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Use Windows-style window ordering in the window switcher"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Gebruik Windows-stijl venstervolgorde in de vensterwisselaar"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Use Windows-style window ordering in the window switcher"
           }
         },
         "pl" : {
@@ -121810,13 +121822,13 @@
             "value" : "Uses your default window switcher settings"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Uses your default window switcher settings"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Uses your default window switcher settings"
@@ -122001,16 +122013,16 @@
             "value" : "버전 %@"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Version %@"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Versie %@"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Version %@"
           }
         },
         "pl" : {
@@ -122192,13 +122204,13 @@
             "value" : "Vertical"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Vertical"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Vertical"
@@ -122382,13 +122394,13 @@
             "value" : "View"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "View"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "View"
@@ -122572,13 +122584,13 @@
             "value" : "Visibility"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Visibility"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Visibility"
@@ -122762,16 +122774,16 @@
             "value" : "직접 보고 싶으신가요? 소스 코드 살펴보기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Want to see for yourself? Review our source code"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Zelf zien? Bekijk onze broncode"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Want to see for yourself? Review our source code"
           }
         },
         "pl" : {
@@ -122953,16 +122965,16 @@
             "value" : "해당 언어로 앱을 보고 싶으신가요?"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Want to see the app in your language?"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Wilt u de app in uw taal bekijken?"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Want to see the app in your language?"
           }
         },
         "pl" : {
@@ -123144,16 +123156,16 @@
             "value" : "개발 후원하기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Want to support development?"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Wilt u ontwikkeling steunen?"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Want to support development?"
           }
         },
         "pl" : {
@@ -123334,16 +123346,16 @@
             "value" : "DockDoor에 오신 것을 환영합니다!"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Welcome to DockDoor!"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Welkom bij DockDoor!"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Welcome to DockDoor!"
           }
         },
         "pl" : {
@@ -123526,16 +123538,16 @@
             "value" : "이게 뭐야? 개미를 위한 창문인가?"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "What is this? A window for ANTS?"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Wat is dit? Een raam voor MIEREN?"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "What is this? A window for ANTS?"
           }
         },
         "pl" : {
@@ -123716,16 +123728,16 @@
             "value" : "When an app terminates, remove only its windows from the preview instead of hiding the entire preview."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "When an app terminates, remove only its windows from the preview instead of hiding the entire preview."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : ""
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "When an app terminates, remove only its windows from the preview instead of hiding the entire preview."
           }
         },
         "pl" : {
@@ -123906,13 +123918,13 @@
             "value" : "When disabled, long titles remain static instead of scrolling."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "When disabled, long titles remain static instead of scrolling."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "When disabled, long titles remain static instead of scrolling."
@@ -124096,13 +124108,13 @@
             "value" : "임베디드 모드가 활성화된 경우, 모든 창이 최소화/숨겨져 있거나 창이 없는 경우 임베디드 컨트롤 대신 큰 컨트롤을 표시합니다."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "When embedded mode is enabled, show big controls instead of embedded ones if all windows are minimized/hidden or there are no windows."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "When embedded mode is enabled, show big controls instead of embedded ones if all windows are minimized/hidden or there are no windows."
@@ -124287,16 +124299,16 @@
             "value" : "활성화하면 모든 미리보기 이미지가 둥근 직사각형으로 잘립니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "When enabled, all preview images will be cropped to a rounded rectangle."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Wanneer deze optie is ingeschakeld, worden alle voorbeeldafbeeldingen bijgesneden tot een afgeronde rechthoek."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "When enabled, all preview images will be cropped to a rounded rectangle."
           }
         },
         "pl" : {
@@ -124478,16 +124490,16 @@
             "value" : "이 기능을 활성화하면 앱의 Dock 아이콘을 클릭하면 Windows 작업 표시줄 동작과 유사하게 해당 애플리케이션의 모든 창이 최소화됩니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "When enabled, clicking an app's Dock icon will minimize all windows of that application, similar to Windows taskbar behavior"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Als deze optie is ingeschakeld, worden alle vensters van die toepassing geminimaliseerd als u op het Dock pictogram van een app klikt, vergelijkbaar met het gedrag van de Windows taakbalk"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "When enabled, clicking an app's Dock icon will minimize all windows of that application, similar to Windows taskbar behavior"
           }
         },
         "pl" : {
@@ -124669,16 +124681,16 @@
             "value" : "활성화하면 현재 선택되어 있는 창을 제외한 모든 창을 어둡게 합니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "When enabled, dims all windows except those currently under selected."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Wanneer deze optie is ingeschakeld, worden alle vensters gedimd, behalve de vensters die op dat moment zijn geselecteerd."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "When enabled, dims all windows except those currently under selected."
           }
         },
         "pl" : {
@@ -124859,13 +124871,13 @@
             "value" : "When enabled, hovering over an app in the Dock shows windows from all instances of that app. When disabled, shows only windows from the specific instance under the mouse."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "When enabled, hovering over an app in the Dock shows windows from all instances of that app. When disabled, shows only windows from the specific instance under the mouse."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "When enabled, hovering over an app in the Dock shows windows from all instances of that app. When disabled, shows only windows from the specific instance under the mouse."
@@ -125049,13 +125061,13 @@
             "value" : "When enabled, moving the mouse back over the preview during fade-out will not reactivate it. You must hover over the dock icon again to show the preview."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "When enabled, moving the mouse back over the preview during fade-out will not reactivate it. You must hover over the dock icon again to show the preview."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "When enabled, moving the mouse back over the preview during fade-out will not reactivate it. You must hover over the dock icon again to show the preview."
@@ -125240,16 +125252,16 @@
             "value" : "활성화하면 현재 창 대신 마지막으로 활성화된 창을 먼저 표시합니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "When enabled, shows the last active window first instead of the current window"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Wanneer ingeschakeld, wordt het laatst actieve venster eerst weergegeven in plaats van het huidige venster"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "When enabled, shows the last active window first instead of the current window"
           }
         },
         "pl" : {
@@ -125430,13 +125442,13 @@
             "value" : "When enabled, shows visual indicators and dims minimized/hidden windows. When disabled, treats them as normal windows with full functionality."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "When enabled, shows visual indicators and dims minimized/hidden windows. When disabled, treats them as normal windows with full functionality."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "When enabled, shows visual indicators and dims minimized/hidden windows. When disabled, treats them as normal windows with full functionality."
@@ -125620,13 +125632,13 @@
             "value" : "When enabled, switching between dock icons while a preview is already open will show previews instantly."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "When enabled, switching between dock icons while a preview is already open will show previews instantly."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "When enabled, switching between dock icons while a preview is already open will show previews instantly."
@@ -125810,13 +125822,13 @@
             "value" : "When enabled, window previews show live video instead of static screenshots. Uses ScreenCaptureKit for real-time capture."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "When enabled, window previews show live video instead of static screenshots. Uses ScreenCaptureKit for real-time capture."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "When enabled, window previews show live video instead of static screenshots. Uses ScreenCaptureKit for real-time capture."
@@ -126001,16 +126013,16 @@
             "value" : "미리보기 위로 마우스를 가져가면"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "When hovering over the preview"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Wanneer u met de muis over de voorvertoning beweegt"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "When hovering over the preview"
           }
         },
         "pl" : {
@@ -126191,13 +126203,13 @@
             "value" : "When opening the window switcher, highlight the second window instead of the first."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "When opening the window switcher, highlight the second window instead of the first."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "When opening the window switcher, highlight the second window instead of the first."
@@ -126381,13 +126393,13 @@
             "value" : "When scrolling on the media widget preview, choose whether to adjust system volume or seek through the track."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "When scrolling on the media widget preview, choose whether to adjust system volume or seek through the track."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "When scrolling on the media widget preview, choose whether to adjust system volume or seek through the track."
@@ -126573,16 +126585,16 @@
             "value" : "도크 타일 미리 보기를 표시할 때"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "When Showing Dock Tile Previews"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bij het tonen van Dock tegel previews"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "When Showing Dock Tile Previews"
           }
         },
         "pl" : {
@@ -126765,16 +126777,16 @@
             "value" : "윈도우 스위쳐를 사용하는 경우"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "When Using Window Switcher"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bij het gebruik van de vensterschakelaar"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "When Using Window Switcher"
           }
         },
         "pl" : {
@@ -126955,16 +126967,16 @@
             "value" : "아래 버튼을 클릭하면 DockDoor가 다시 시작되고 메뉴 표시줄로 이동하여 백그라운드에서 실행됩니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "When you click the button below, DockDoor will restart and move to the menu bar to run in the background."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Wanneer u op de onderstaande knop klikt, wordt DockDoor opnieuw opgestart en wordt de menubalk op de achtergrond uitgevoerd."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "When you click the button below, DockDoor will restart and move to the menu bar to run in the background."
           }
         },
         "pl" : {
@@ -127146,16 +127158,16 @@
             "value" : "권한이 필요한 이유"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Why we need permissions"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Waarom we toestemming nodig hebben"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Why we need permissions"
           }
         },
         "pl" : {
@@ -127337,13 +127349,13 @@
             "value" : "Widgets"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Widgets"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Widgets"
@@ -127527,13 +127539,13 @@
             "value" : "Window Background"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Window Background"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Window Background"
@@ -127718,16 +127730,16 @@
             "value" : "윈도우 버퍼"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Window Buffer"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Scherm Buffer"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Window Buffer"
           }
         },
         "pl" : {
@@ -127908,16 +127920,16 @@
             "value" : "독의 창 버퍼(픽셀)"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Window Buffer from Dock (pixels)"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Venster buffer van Dock (pixels)"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Window Buffer from Dock (pixels)"
           }
         },
         "pl" : {
@@ -128099,16 +128111,16 @@
             "value" : "윈도우 캐시 수명"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Window Cache Lifespan"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Levensduur venster cache"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Window Cache Lifespan"
           }
         },
         "pl" : {
@@ -128289,16 +128301,16 @@
             "value" : "창 이미지 캐시 수명"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Window Image Cache Lifespan"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Levensduur van de cache van de venster afbeelding"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Window Image Cache Lifespan"
           }
         },
         "pl" : {
@@ -128479,13 +128491,13 @@
             "value" : "Window Image Capture Quality"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Window Image Capture Quality"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Window Image Capture Quality"
@@ -128669,16 +128681,16 @@
             "value" : "창 이미지 해상도 스케일(1=최고)"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Window Image Resolution Scale (1=Best)"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Resolutieschaal van venster afbeelding (1=beste)"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Window Image Resolution Scale (1=Best)"
           }
         },
         "pl" : {
@@ -128860,16 +128872,16 @@
             "value" : "창 이미지 해상도 스케일(높을수록 해상도가 낮음)"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Window Image Resolution Scale (higher means lower resolution)"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Resolutieschaal van venster afbeelding (hoger betekent lagere resolutie)"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Window Image Resolution Scale (higher means lower resolution)"
           }
         },
         "pl" : {
@@ -129050,13 +129062,13 @@
             "value" : "Window Preview Keyboard Shortcuts"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Window Preview Keyboard Shortcuts"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Window Preview Keyboard Shortcuts"
@@ -129241,16 +129253,16 @@
             "value" : "창 미리보기 레이아웃"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Window Preview Layout"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Voorvertoning venster lay-out"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Window Preview Layout"
           }
         },
         "pl" : {
@@ -129432,16 +129444,16 @@
             "value" : "창 미리보기 레이아웃 제한"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Window Preview Layout Limits"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Voorvertoning venster lay-out limieten"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Window Preview Layout Limits"
           }
         },
         "pl" : {
@@ -129622,16 +129634,16 @@
             "value" : "창 미리보기 크기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Window Preview Size"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Voorvertoning venster grootte"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Window Preview Size"
           }
         },
         "pl" : {
@@ -129812,13 +129824,13 @@
             "value" : "Window Processing Debounce Interval"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Window Processing Debounce Interval"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Window Processing Debounce Interval"
@@ -130003,16 +130015,16 @@
             "value" : "창 선택 배경색"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Window Selection Background Color"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Achtergrondkleur van venster selectie"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Window Selection Background Color"
           }
         },
         "pl" : {
@@ -130194,16 +130206,16 @@
             "value" : "창 선택 배경 불투명도"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Window Selection Background Opacity"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Achtergrond dekking van venster selectie"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Window Selection Background Opacity"
           }
         },
         "pl" : {
@@ -130385,16 +130397,16 @@
             "value" : "창 크기"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Window Size"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Scherm Formaat"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Window Size"
           }
         },
         "pl" : {
@@ -130575,13 +130587,13 @@
             "value" : "Window sort order"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Window sort order"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Window sort order"
@@ -130766,16 +130778,16 @@
             "value" : "윈도우 스위쳐"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Window Switcher"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Scherm Wisselaar"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Window Switcher"
           }
         },
         "pl" : {
@@ -130957,16 +130969,16 @@
             "value" : "창 전환기 사용자 지정"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Window Switcher Customization"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Aanpassing van venster schakelaar"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Window Switcher Customization"
           }
         },
         "pl" : {
@@ -131147,13 +131159,13 @@
             "value" : "Window Switcher Gestures"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Window Switcher Gestures"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Window Switcher Gestures"
@@ -131337,13 +131349,13 @@
             "value" : "Window Switcher is disabled. Enable it in General settings to use keyboard shortcuts."
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Window Switcher is disabled. Enable it in General settings to use keyboard shortcuts."
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Window Switcher is disabled. Enable it in General settings to use keyboard shortcuts."
@@ -131528,16 +131540,16 @@
             "value" : "창 전환기 전용"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Window Switcher only"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Alleen Scherm Wisselaar"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Window Switcher only"
           }
         },
         "pl" : {
@@ -131719,16 +131731,16 @@
             "value" : "창 전환기 배치"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Window Switcher Placement"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Plaatsing van de venster schakelaar"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Window Switcher Placement"
           }
         },
         "pl" : {
@@ -131909,16 +131921,16 @@
             "value" : "창 전환기 설정"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Window Switcher Settings"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Scherm wisselaar instellingen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Window Switcher Settings"
           }
         },
         "pl" : {
@@ -132100,13 +132112,13 @@
             "value" : "Window Switcher Shortcut"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Window Switcher Shortcut"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Window Switcher Shortcut"
@@ -132290,13 +132302,13 @@
             "value" : "Window Switcher Shortcuts"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Window Switcher Shortcuts"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Window Switcher Shortcuts"
@@ -132480,13 +132492,13 @@
             "value" : "Window Threshold"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Window Threshold"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Window Threshold"
@@ -132670,13 +132682,13 @@
             "value" : "Window Title"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Window Title"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Window Title"
@@ -132861,16 +132873,16 @@
             "value" : "창 제목 필터"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Window title filters"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Venstertitel filters"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Window title filters"
           }
         },
         "pl" : {
@@ -133051,16 +133063,16 @@
             "value" : "창 제목 필터"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Window Title Filters"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Venster titel filters"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Window Title Filters"
           }
         },
         "pl" : {
@@ -133241,13 +133253,13 @@
             "value" : "Window Title Only"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Window Title Only"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Window Title Only"
@@ -133432,16 +133444,16 @@
             "value" : "창 제목 위치"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Window Title Position"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Schermnaam Positie"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Window Title Position"
           }
         },
         "pl" : {
@@ -133622,16 +133634,16 @@
             "value" : "창 제목 가시성"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Window Title Visibility"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Schermnaam Zichtbaarheid"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Window Title Visibility"
           }
         },
         "pl" : {
@@ -133813,16 +133825,16 @@
             "value" : "미리보기의 창 제목"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Window Titles in Previews"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Venstertitels in Previews"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Window Titles in Previews"
           }
         },
         "pl" : {
@@ -134004,16 +134016,16 @@
             "value" : "창 전환 설정"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Windows switching settings"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Scherm wisselaar instellingen"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Windows switching settings"
           }
         },
         "pl" : {
@@ -134195,13 +134207,13 @@
             "value" : "X-Large"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "X-Large"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "X-Large"
@@ -134386,13 +134398,13 @@
             "value" : "X-Small"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "X-Small"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "X-Small"
@@ -134577,16 +134589,16 @@
             "value" : "DockDoor의 작동을 위해 손쉬운 사용 권한을 허용해야 합니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "You need to give DockDoor access to the accessibility API in order for it to function."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "U moet DockDoor toegang geven tot de toegankelijkheids-API om deze te laten functioneren."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "You need to give DockDoor access to the accessibility API in order for it to function."
           }
         },
         "pl" : {
@@ -134767,16 +134779,16 @@
             "value" : "앱 버전: %@"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your app is on version %@"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Je hebt app versie %@"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Your app is on version %@"
           }
         },
         "pl" : {
@@ -134958,16 +134970,16 @@
             "value" : "단축키가 설정됩니다(예: ⌘ + Tab)."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your shortcut will be set (e.g. ⌘ + Tab)"
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Uw sneltoets wordt ingesteld (bijv. ⌘ + Tab)"
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Your shortcut will be set (e.g. ⌘ + Tab)"
           }
         },
         "pl" : {
@@ -135148,16 +135160,16 @@
             "value" : "신호등이 자동으로 비활성화되도록 설정됩니다."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your traffic lights will be set to disabled automatically."
+          }
+        },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Uw verkeerslichten worden automatisch uitgeschakeld."
-          }
-        },
-        "no" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Your traffic lights will be set to disabled automatically."
           }
         },
         "pl" : {
@@ -135338,15 +135350,15 @@
             "value" : "Z"
           }
         },
-        "nl" : {
+        "nb" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Z"
           }
         },
-        "no" : {
+        "nl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Z"
           }
         },

--- a/DockDoor/Views/Hover Window/WindowPreview.swift
+++ b/DockDoor/Views/Hover Window/WindowPreview.swift
@@ -385,11 +385,75 @@ struct WindowPreview: View {
                     .padding(.trailing, 8)
                     .padding(.bottom, 8)
                 }
+            case .parallelTopLeftBottomLeft:
+                VStack {
+                    HStack {
+                        titleContent
+                        Spacer()
+                    }
+                    .padding(.leading, 8)
+                    .padding(.top, 8)
+                    Spacer()
+                    HStack {
+                        Spacer()
+                        controlsContent
+                    }
+                    .padding(.leading, 8)
+                    .padding(.bottom, 8)
+                }
+            case .parallelTopRightBottomRight:
+                VStack {
+                    HStack {
+                        titleContent
+                        Spacer()
+                    }
+                    .padding(.trailing, 8)
+                    .padding(.top, 8)
+                    Spacer()
+                    HStack {
+                        Spacer()
+                        controlsContent
+                    }
+                    .padding(.trailing, 8)
+                    .padding(.bottom, 8)
+                }
+            case .parallelBottomLeftTopLeft:
+                VStack {
+                    HStack {
+                        controlsContent
+                        Spacer()
+                    }
+                    .padding(.leading, 8)
+                    .padding(.top, 8)
+                    Spacer()
+                    HStack {
+                        Spacer()
+                        titleContent
+                    }
+                    .padding(.leading, 8)
+                    .padding(.bottom, 8)
+                }
+            case .parallelBottomRightTopRight:
+                VStack {
+                    HStack {
+                        controlsContent
+                        Spacer()
+                    }
+                    .padding(.trailing, 8)
+                    .padding(.top, 8)
+                    Spacer()
+                    HStack {
+                        Spacer()
+                        titleContent
+                    }
+                    .padding(.trailing, 8)
+                    .padding(.bottom, 8)
+                }
             }
         }
     }
 
-    private func windowSwitcherContent(_ selected: Bool, showTitleContent: Bool = true, showControlsContent: Bool = true) -> some View {
+    private func windowSwitcherContent(_ selected: Bool, isLeadingControls: Bool, showTitleContent: Bool = true, showControlsContent: Bool = true) -> some View {
         let shouldShowWindowTitle = effectiveShowWindowTitle &&
             (effectiveWindowTitleVisibility == .alwaysVisible || selected || isHoveringOverWindowSwitcherPreview)
 
@@ -443,8 +507,7 @@ struct WindowPreview: View {
             }
         }
 
-        @ViewBuilder
-        func contentRow(isLeadingControls: Bool) -> some View {
+        return VStack(spacing: 0) {
             HStack(spacing: 4) {
                 if isLeadingControls {
                     if showControlsContent {
@@ -468,26 +531,9 @@ struct WindowPreview: View {
             }
             .fixedSize(horizontal: false, vertical: true)
         }
-
-        return VStack(spacing: 0) {
-            switch effectiveControlPosition {
-            case .topLeading:
-                contentRow(isLeadingControls: false)
-            case .topTrailing:
-                contentRow(isLeadingControls: true)
-            case .bottomLeading:
-                contentRow(isLeadingControls: false)
-            case .bottomTrailing:
-                contentRow(isLeadingControls: true)
-            case .diagonalTopLeftBottomRight, .diagonalBottomLeftTopRight:
-                contentRow(isLeadingControls: false)
-            case .diagonalTopRightBottomLeft, .diagonalBottomRightTopLeft:
-                contentRow(isLeadingControls: true)
-            }
-        }
     }
 
-    private func dockPreviewContent(_ selected: Bool, showTitleContent: Bool = true, showControlsContent: Bool = true) -> some View {
+    private func dockPreviewContent(_ selected: Bool, isLeadingControls: Bool, showTitleContent: Bool = true, showControlsContent: Bool = true) -> some View {
         // Determine what title to show: window name first, then app name as fallback
         let titleToShow: String? = if let windowTitle = windowInfo.windowName, !windowTitle.isEmpty {
             windowTitle
@@ -536,46 +582,28 @@ struct WindowPreview: View {
             }
         }
 
-        @ViewBuilder
-        func contentRow(isLeadingControls: Bool) -> some View {
-            HStack(spacing: 4) {
-                if isLeadingControls {
-                    if showControlsContent {
-                        controlsContent
-                    }
-                    Spacer()
-                    if showTitleContent {
-                        titleContent
-                    }
-                } else {
-                    if showTitleContent {
-                        titleContent
-                    }
-                    Spacer()
-                    if showControlsContent {
-                        controlsContent
-                    }
-                }
-            }
-        }
-
         // Only show the toolbar if there's either a title or traffic lights to display
         if hasTitle || hasTrafficLights {
             return AnyView(
                 VStack(spacing: 0) {
-                    switch effectiveControlPosition {
-                    case .topLeading:
-                        contentRow(isLeadingControls: false)
-                    case .topTrailing:
-                        contentRow(isLeadingControls: true)
-                    case .bottomLeading:
-                        contentRow(isLeadingControls: false)
-                    case .bottomTrailing:
-                        contentRow(isLeadingControls: true)
-                    case .diagonalTopLeftBottomRight, .diagonalBottomLeftTopRight:
-                        contentRow(isLeadingControls: false)
-                    case .diagonalTopRightBottomLeft, .diagonalBottomRightTopLeft:
-                        contentRow(isLeadingControls: true)
+                    HStack(spacing: 4) {
+                        if isLeadingControls {
+                            if showControlsContent {
+                                controlsContent
+                            }
+                            Spacer()
+                            if showTitleContent {
+                                titleContent
+                            }
+                        } else {
+                            if showTitleContent {
+                                titleContent
+                            }
+                            Spacer()
+                            if showControlsContent {
+                                controlsContent
+                            }
+                        }
                     }
                 }
             )
@@ -599,32 +627,48 @@ struct WindowPreview: View {
                     windowSwitcherActive
                 {
                     Group {
-                        if windowSwitcherActive, effectiveControlPosition == .topLeading ||
-                            effectiveControlPosition == .topTrailing
-                        {
-                            windowSwitcherContent(finalIsSelected)
+                        if windowSwitcherActive, effectiveControlPosition == .topLeading {
+                            windowSwitcherContent(finalIsSelected, isLeadingControls: false)
+                        } else if windowSwitcherActive, effectiveControlPosition == .topTrailing {
+                            windowSwitcherContent(finalIsSelected, isLeadingControls: true)
                         } else if windowSwitcherActive, effectiveControlPosition == .diagonalTopLeftBottomRight {
-                            windowSwitcherContent(finalIsSelected, showTitleContent: true, showControlsContent: false)
+                            windowSwitcherContent(finalIsSelected, isLeadingControls: false, showTitleContent: true, showControlsContent: false)
                         } else if windowSwitcherActive, effectiveControlPosition == .diagonalTopRightBottomLeft {
-                            windowSwitcherContent(finalIsSelected, showTitleContent: true, showControlsContent: false)
+                            windowSwitcherContent(finalIsSelected, isLeadingControls: true, showTitleContent: true, showControlsContent: false)
                         } else if windowSwitcherActive, effectiveControlPosition == .diagonalBottomLeftTopRight {
-                            windowSwitcherContent(finalIsSelected, showTitleContent: false, showControlsContent: true)
+                            windowSwitcherContent(finalIsSelected, isLeadingControls: false, showTitleContent: false, showControlsContent: true)
                         } else if windowSwitcherActive, effectiveControlPosition == .diagonalBottomRightTopLeft {
-                            windowSwitcherContent(finalIsSelected, showTitleContent: false, showControlsContent: true)
+                            windowSwitcherContent(finalIsSelected, isLeadingControls: true, showTitleContent: false, showControlsContent: true)
+                        } else if windowSwitcherActive, effectiveControlPosition == .parallelTopLeftBottomLeft {
+                            windowSwitcherContent(finalIsSelected, isLeadingControls: false, showTitleContent: true, showControlsContent: false)
+                        } else if windowSwitcherActive, effectiveControlPosition == .parallelTopRightBottomRight {
+                            windowSwitcherContent(finalIsSelected, isLeadingControls: true, showTitleContent: true, showControlsContent: false)
+                        } else if windowSwitcherActive, effectiveControlPosition == .parallelBottomLeftTopLeft {
+                            windowSwitcherContent(finalIsSelected, isLeadingControls: true, showTitleContent: false, showControlsContent: true)
+                        } else if windowSwitcherActive, effectiveControlPosition == .parallelBottomRightTopRight {
+                            windowSwitcherContent(finalIsSelected, isLeadingControls: false, showTitleContent: false, showControlsContent: true)
                         }
 
-                        if !windowSwitcherActive, effectiveControlPosition == .topLeading ||
-                            effectiveControlPosition == .topTrailing
-                        {
-                            dockPreviewContent(finalIsSelected)
+                        if !windowSwitcherActive, effectiveControlPosition == .topLeading {
+                            dockPreviewContent(finalIsSelected, isLeadingControls: false)
+                        } else if !windowSwitcherActive, effectiveControlPosition == .topTrailing {
+                            dockPreviewContent(finalIsSelected, isLeadingControls: true)
                         } else if !windowSwitcherActive, effectiveControlPosition == .diagonalTopLeftBottomRight {
-                            dockPreviewContent(finalIsSelected, showTitleContent: true, showControlsContent: false)
+                            dockPreviewContent(finalIsSelected, isLeadingControls: false, showTitleContent: true, showControlsContent: false)
                         } else if !windowSwitcherActive, effectiveControlPosition == .diagonalTopRightBottomLeft {
-                            dockPreviewContent(finalIsSelected, showTitleContent: true, showControlsContent: false)
+                            dockPreviewContent(finalIsSelected, isLeadingControls: true, showTitleContent: true, showControlsContent: false)
                         } else if !windowSwitcherActive, effectiveControlPosition == .diagonalBottomLeftTopRight {
-                            dockPreviewContent(finalIsSelected, showTitleContent: false, showControlsContent: true)
+                            dockPreviewContent(finalIsSelected, isLeadingControls: false, showTitleContent: false, showControlsContent: true)
                         } else if !windowSwitcherActive, effectiveControlPosition == .diagonalBottomRightTopLeft {
-                            dockPreviewContent(finalIsSelected, showTitleContent: false, showControlsContent: true)
+                            dockPreviewContent(finalIsSelected, isLeadingControls: true, showTitleContent: false, showControlsContent: true)
+                        } else if !windowSwitcherActive, effectiveControlPosition == .parallelTopLeftBottomLeft {
+                            dockPreviewContent(finalIsSelected, isLeadingControls: false, showTitleContent: true, showControlsContent: false)
+                        } else if !windowSwitcherActive, effectiveControlPosition == .parallelTopRightBottomRight {
+                            dockPreviewContent(finalIsSelected, isLeadingControls: true, showTitleContent: true, showControlsContent: false)
+                        } else if !windowSwitcherActive, effectiveControlPosition == .parallelBottomLeftTopLeft {
+                            dockPreviewContent(finalIsSelected, isLeadingControls: true, showTitleContent: false, showControlsContent: true)
+                        } else if !windowSwitcherActive, effectiveControlPosition == .parallelBottomRightTopRight {
+                            dockPreviewContent(finalIsSelected, isLeadingControls: false, showTitleContent: false, showControlsContent: true)
                         }
                     }
                     .padding(.bottom, 4)
@@ -640,32 +684,48 @@ struct WindowPreview: View {
                     windowSwitcherActive
                 {
                     Group {
-                        if windowSwitcherActive, effectiveControlPosition == .bottomLeading ||
-                            effectiveControlPosition == .bottomTrailing
-                        {
-                            windowSwitcherContent(finalIsSelected)
+                        if windowSwitcherActive, effectiveControlPosition == .bottomLeading {
+                            windowSwitcherContent(finalIsSelected, isLeadingControls: false)
+                        } else if windowSwitcherActive, effectiveControlPosition == .bottomTrailing {
+                            windowSwitcherContent(finalIsSelected, isLeadingControls: true)
                         } else if windowSwitcherActive, effectiveControlPosition == .diagonalTopLeftBottomRight {
-                            windowSwitcherContent(finalIsSelected, showTitleContent: false, showControlsContent: true)
+                            windowSwitcherContent(finalIsSelected, isLeadingControls: false, showTitleContent: false, showControlsContent: true)
                         } else if windowSwitcherActive, effectiveControlPosition == .diagonalTopRightBottomLeft {
-                            windowSwitcherContent(finalIsSelected, showTitleContent: false, showControlsContent: true)
+                            windowSwitcherContent(finalIsSelected, isLeadingControls: true, showTitleContent: false, showControlsContent: true)
                         } else if windowSwitcherActive, effectiveControlPosition == .diagonalBottomLeftTopRight {
-                            windowSwitcherContent(finalIsSelected, showTitleContent: true, showControlsContent: false)
+                            windowSwitcherContent(finalIsSelected, isLeadingControls: false, showTitleContent: true, showControlsContent: false)
                         } else if windowSwitcherActive, effectiveControlPosition == .diagonalBottomRightTopLeft {
-                            windowSwitcherContent(finalIsSelected, showTitleContent: true, showControlsContent: false)
+                            windowSwitcherContent(finalIsSelected, isLeadingControls: true, showTitleContent: true, showControlsContent: false)
+                        } else if windowSwitcherActive, effectiveControlPosition == .parallelTopLeftBottomLeft {
+                            windowSwitcherContent(finalIsSelected, isLeadingControls: true, showTitleContent: false, showControlsContent: true)
+                        } else if windowSwitcherActive, effectiveControlPosition == .parallelTopRightBottomRight {
+                            windowSwitcherContent(finalIsSelected, isLeadingControls: false, showTitleContent: false, showControlsContent: true)
+                        } else if windowSwitcherActive, effectiveControlPosition == .parallelBottomLeftTopLeft {
+                            windowSwitcherContent(finalIsSelected, isLeadingControls: false, showTitleContent: true, showControlsContent: false)
+                        } else if windowSwitcherActive, effectiveControlPosition == .parallelBottomRightTopRight {
+                            windowSwitcherContent(finalIsSelected, isLeadingControls: true, showTitleContent: true, showControlsContent: false)
                         }
 
-                        if !windowSwitcherActive, effectiveControlPosition == .bottomLeading ||
-                            effectiveControlPosition == .bottomTrailing
-                        {
-                            dockPreviewContent(finalIsSelected)
+                        if !windowSwitcherActive, effectiveControlPosition == .bottomLeading {
+                            dockPreviewContent(finalIsSelected, isLeadingControls: false)
+                        } else if !windowSwitcherActive, effectiveControlPosition == .bottomTrailing {
+                            dockPreviewContent(finalIsSelected, isLeadingControls: true)
                         } else if !windowSwitcherActive, effectiveControlPosition == .diagonalTopLeftBottomRight {
-                            dockPreviewContent(finalIsSelected, showTitleContent: false, showControlsContent: true)
+                            dockPreviewContent(finalIsSelected, isLeadingControls: false, showTitleContent: false, showControlsContent: true)
                         } else if !windowSwitcherActive, effectiveControlPosition == .diagonalTopRightBottomLeft {
-                            dockPreviewContent(finalIsSelected, showTitleContent: false, showControlsContent: true)
+                            dockPreviewContent(finalIsSelected, isLeadingControls: true, showTitleContent: false, showControlsContent: true)
                         } else if !windowSwitcherActive, effectiveControlPosition == .diagonalBottomLeftTopRight {
-                            dockPreviewContent(finalIsSelected, showTitleContent: true, showControlsContent: false)
+                            dockPreviewContent(finalIsSelected, isLeadingControls: false, showTitleContent: true, showControlsContent: false)
                         } else if !windowSwitcherActive, effectiveControlPosition == .diagonalBottomRightTopLeft {
-                            dockPreviewContent(finalIsSelected, showTitleContent: true, showControlsContent: false)
+                            dockPreviewContent(finalIsSelected, isLeadingControls: true, showTitleContent: true, showControlsContent: false)
+                        } else if !windowSwitcherActive, effectiveControlPosition == .parallelTopLeftBottomLeft {
+                            dockPreviewContent(finalIsSelected, isLeadingControls: true, showTitleContent: false, showControlsContent: true)
+                        } else if !windowSwitcherActive, effectiveControlPosition == .parallelTopRightBottomRight {
+                            dockPreviewContent(finalIsSelected, isLeadingControls: false, showTitleContent: false, showControlsContent: true)
+                        } else if !windowSwitcherActive, effectiveControlPosition == .parallelBottomLeftTopLeft {
+                            dockPreviewContent(finalIsSelected, isLeadingControls: false, showTitleContent: true, showControlsContent: false)
+                        } else if !windowSwitcherActive, effectiveControlPosition == .parallelBottomRightTopRight {
+                            dockPreviewContent(finalIsSelected, isLeadingControls: true, showTitleContent: true, showControlsContent: false)
                         }
                     }
                     .padding(.top, 4)

--- a/DockDoor/consts.swift
+++ b/DockDoor/consts.swift
@@ -378,6 +378,10 @@ enum WindowSwitcherControlPosition: String, CaseIterable, Defaults.Serializable 
     case diagonalTopRightBottomLeft
     case diagonalBottomLeftTopRight
     case diagonalBottomRightTopLeft
+    case parallelTopLeftBottomLeft
+    case parallelTopRightBottomRight
+    case parallelBottomLeftTopLeft
+    case parallelBottomRightTopRight
 
     var localizedName: String {
         switch self {
@@ -397,6 +401,14 @@ enum WindowSwitcherControlPosition: String, CaseIterable, Defaults.Serializable 
             String(localized: "Diagonal - Title bottom left, controls top right")
         case .diagonalBottomRightTopLeft:
             String(localized: "Diagonal - Title bottom right, controls top left")
+        case .parallelTopLeftBottomLeft:
+            String(localized: "Parallel - Title top left, controls bottom left")
+        case .parallelTopRightBottomRight:
+            String(localized: "Parallel - Title top right, controls bottom right")
+        case .parallelBottomLeftTopLeft:
+            String(localized: "Parallel - Title bottom left, controls top left")
+        case .parallelBottomRightTopRight:
+            String(localized: "Parallel - Title bottom right, controls top right")
         }
     }
 }


### PR DESCRIPTION
## Describe your changes
This adds 4 new title and traffic controls alignment options, allowing you to align them at the same edges:

|                          | Left | Right |
|--------------------------|--------------------------|--------------------------|
| **Title top** | <img width="496" height="214" alt="image" src="https://github.com/user-attachments/assets/78c99a0b-6f33-48d2-8585-aa86e43bdabe" /> | <img width="521" height="222" alt="image" src="https://github.com/user-attachments/assets/7c552094-3836-4eb0-89ed-41b4d3691a57" />|
| **Title bottom** | <img width="505" height="223" alt="image" src="https://github.com/user-attachments/assets/7ab69396-3fbf-40fb-a880-e6bb60eafcd8" /> | <img width="503" height="215" alt="image" src="https://github.com/user-attachments/assets/57f9dcaf-19c3-41fb-9693-f9f4b35f4d74" /> |

P.S: Apart from introducing changes to the localization files due to these new alignment options, it looks like Xcode also added entries for a whole lot of new languages. Let me know if this needs to be addressed.

## Related issue number(s) and link(s)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] If this change affects core functionality, I have added a description highlighting the changes
- [x] I have followed conventional commit guidelines

## Core Functionality Changes
If this PR modifies core functionality, please provide a brief description of the changes and their impact below:
