### PR TITLE
fix: hide minimized and hidden labels in compact mode when "Distinguish minimized/hidden windows" option is disabled

### DIFF
--- a/DockDoor/Views/Hover Window/WindowPreviewCompact.swift
+++ b/DockDoor/Views/Hover Window/WindowPreviewCompact.swift
@@ -74,6 +74,7 @@ struct WindowPreviewCompact: View {
     }
 
     private var stateIndicator: String? {
+        guard showMinimizedHiddenLabels else { return nil }
         if windowInfo.isMinimized {
             return "Minimized"
         } else if windowInfo.isHidden {


### PR DESCRIPTION
## Describe your changes

<img width="362" height="351" alt="2025-12-22_QSpace Pro_10-05-52" src="https://github.com/user-attachments/assets/d035722e-b431-463e-8732-fac2448e17dc" />

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] If this change affects core functionality, I have added a description highlighting the changes
- [x] I have followed conventional commit guidelines
