### PR TITLE
fix: preserve window order for non-grouped apps in switcher when group window by app is enabled

### DIFF
--- a/DockDoor/Utilities/Window Management/WindowUtil.swift
+++ b/DockDoor/Utilities/Window Management/WindowUtil.swift
@@ -1078,29 +1078,23 @@ extension WindowUtil {
         let groupedApps = Set(Defaults[.groupedAppsInSwitcher])
         guard !groupedApps.isEmpty else { return windows }
 
-        // Group by bundle ID while tracking first appearance order
-        var windowsByApp: [String: [WindowInfo]] = [:]
-        var order: [String] = []
+        // Track which grouped apps we've already seen (to keep only first window)
+        var seenGroupedApps = Set<String>()
+        var result: [WindowInfo] = []
 
         for window in windows {
             let bundleId = window.app.bundleIdentifier ?? ""
-            if windowsByApp[bundleId] == nil {
-                order.append(bundleId)
-            }
-            windowsByApp[bundleId, default: []].append(window)
-        }
 
-        // Build result preserving order
-        var result: [WindowInfo] = []
-        for bundleId in order {
-            guard let appWindows = windowsByApp[bundleId] else { continue }
             if groupedApps.contains(bundleId) {
-                // Take only the most recent window (first since sorted by recency)
-                if let mostRecent = appWindows.first {
-                    result.append(mostRecent)
+                // This is a grouped app - only keep the first window we see
+                if !seenGroupedApps.contains(bundleId) {
+                    seenGroupedApps.insert(bundleId)
+                    result.append(window)
                 }
+                // Skip subsequent windows of this grouped app
             } else {
-                result.append(contentsOf: appWindows)
+                // Not a grouped app - keep all windows in their original position
+                result.append(window)
             }
         }
         return result


### PR DESCRIPTION
## Describe your changes

I introduced a bug in one of my previous commits and just noticed it.
Basically windows that aren't selected for "Group Windows by App" are being affected if this setting is enabled even  (all their windows stick together in the sorting list)

Unnecessary summary from Claude Code:

```
⏺ The Problem:

The function groups ALL windows by bundle ID first, then iterates through apps in "first appearance order". For non-grouped apps, it appends ALL windows of that app together, which destroys the original sorted order.

Example:
- Original sorted order (recently used): [Chrome-1, Safari-1, Chrome-2, Finder-1, Safari-2]
- Safari is in groupedApps
- After groupWindowsByApp:
    - Chrome appears first → adds ALL Chrome windows: [Chrome-1, Chrome-2]
    - Safari appears next → adds only most recent: [Safari-1]
    - Finder appears last → adds its window: [Finder-1]
- Result: [Chrome-1, Chrome-2, Safari-1, Finder-1]

Chrome windows are now stuck together even though Chrome is NOT in the grouped list!

The Fix:
We should only remove duplicate windows for apps that ARE in the groupedApps set, while preserving the original position for all other windows.

⏺ The new implementation:

1. Single pass through windows in their original sorted order
2. For grouped apps: Only keeps the first window seen (most recent), skips subsequent windows
3. For non-grouped apps: Keeps ALL windows in their original position

Before (buggy):
Input:  [Chrome-1, Safari-1, Chrome-2, Finder-1]  (Safari grouped)
Output: [Chrome-1, Chrome-2, Safari-1, Finder-1]  ← Chrome windows stuck together!

After (fixed):
Input:  [Chrome-1, Safari-1, Chrome-2, Finder-1]  (Safari grouped)
Output: [Chrome-1, Safari-1, Chrome-2, Finder-1]  ← Order preserved!

The fix is simpler and more efficient (O(n) single pass instead of grouping then rebuilding). Please build and test to verify it resolves your issue.
```

## Related issue number(s) and link(s)
N/A

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] If this change affects core functionality, I have added a description highlighting the changes
- [x] I have followed conventional commit guidelines
