### PR TITLE
feat: add option to hide traffic lights in compact mode

### DIFF
--- a/DockDoor/Views/Hover Window/WindowPreviewCompact.swift
+++ b/DockDoor/Views/Hover Window/WindowPreviewCompact.swift
@@ -16,6 +16,7 @@ struct WindowPreviewCompact: View {
     @Default(.previewWidth) private var previewWidth
     @Default(.compactModeTitleFormat) private var titleFormat
     @Default(.compactModeItemSize) private var itemSize
+    @Default(.compactModeHideTrafficLights) private var hideTrafficLights
 
     // MARK: - Dock Preview Appearance Settings
 
@@ -163,7 +164,8 @@ struct WindowPreviewCompact: View {
             Spacer(minLength: 0)
 
             // Traffic light buttons
-            if windowInfo.closeButton != nil,
+            if !hideTrafficLights,
+               windowInfo.closeButton != nil,
                effectiveTrafficLightVisibility != .never,
                !showMinimizedHiddenLabels || (!windowInfo.isMinimized && !windowInfo.isHidden)
             {

--- a/DockDoor/Views/Settings/Appearance/CompactModeSection.swift
+++ b/DockDoor/Views/Settings/Appearance/CompactModeSection.swift
@@ -5,6 +5,7 @@ struct CompactModeSection: View {
     @Default(.disableImagePreview) var disableImagePreview
     @Default(.compactModeTitleFormat) var compactModeTitleFormat
     @Default(.compactModeItemSize) var compactModeItemSize
+    @Default(.compactModeHideTrafficLights) var compactModeHideTrafficLights
     @Default(.windowSwitcherCompactThreshold) var windowSwitcherCompactThreshold
     @Default(.dockPreviewCompactThreshold) var dockPreviewCompactThreshold
     @Default(.cmdTabCompactThreshold) var cmdTabCompactThreshold
@@ -86,6 +87,13 @@ struct CompactModeSection: View {
                     }
                 }
                 .pickerStyle(.menu)
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Toggle("Hide Traffic Lights", isOn: $compactModeHideTrafficLights)
+                    Text("Hides the close, minimize, and other window control buttons in compact mode to provide more room for window titles.")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
             }
         }
     }

--- a/DockDoor/consts.swift
+++ b/DockDoor/consts.swift
@@ -90,6 +90,7 @@ extension Defaults.Keys {
     static let enableWindowSwitcherSearch = Key<Bool>("enableWindowSwitcherSearch", default: false)
     static let compactModeTitleFormat = Key<CompactModeTitleFormat>("compactModeTitleFormat", default: .appNameAndTitle)
     static let compactModeItemSize = Key<CompactModeItemSize>("compactModeItemSize", default: .medium)
+    static let compactModeHideTrafficLights = Key<Bool>("compactModeHideTrafficLights", default: false)
 
     // Per-feature compact mode thresholds (0 = disabled, 1+ = enable when window count >= threshold)
     static let windowSwitcherCompactThreshold = Key<Int>("windowSwitcherCompactThreshold", default: 0)


### PR DESCRIPTION
## Summary
- Adds a new toggle "Hide Traffic Lights" in Settings → Appearance → Compact Mode
- When enabled, hides close/minimize/maximize buttons in compact (list) view
- Provides more room for window titles which often don't fit in the compact layout

## Closes
Closes #1064

## Changes
- `consts.swift`: Added `compactModeHideTrafficLights` setting key (default: false)
- `CompactModeSection.swift`: Added Toggle UI with descriptive help text
- `WindowPreviewCompact.swift`: Wired up setting to conditionally hide traffic light buttons

The toggle appears under **Appearance → Compact Mode (Titles Only) → Appearance** section.

## Testing
- [x] Verified toggle appears in settings
- [x] Verified traffic lights hide/show based on setting
- [x] Verified setting persists across app restarts