### PR TITLE
feat: Add settings backup and restore via JSON export/import

### DIFF
--- a/DockDoor/Utilities/SettingsBackupManager.swift
+++ b/DockDoor/Utilities/SettingsBackupManager.swift
@@ -1,0 +1,100 @@
+//
+//  SettingsBackupManager.swift
+//  DockDoor
+//
+
+import AppKit
+import Defaults
+import Foundation
+import UniformTypeIdentifiers
+
+/// Handles exporting and importing DockDoor settings via the UserDefaults persistent domain.
+///
+/// This approach is inherently resilient to changes in settings keys — new keys are
+/// simply missing from older backups (and use their defaults), while removed keys in
+/// newer versions are silently ignored on import.
+enum SettingsBackupManager {
+    // MARK: - Export
+
+    /// Presents a save panel and exports all current settings to a JSON file.
+    @MainActor
+    static func exportSettings() {
+        guard let bundleID = Bundle.main.bundleIdentifier,
+              let defaults = UserDefaults.standard.persistentDomain(forName: bundleID)
+        else {
+            MessageUtil.showAlert(
+                title: String(localized: "Export Failed"),
+                message: String(localized: "Could not read current settings.")
+            )
+            return
+        }
+
+        let panel = NSSavePanel()
+        panel.title = String(localized: "Export DockDoor Settings")
+        panel.nameFieldStringValue = "DockDoor-Settings.json"
+        panel.allowedContentTypes = [.json]
+        panel.canCreateDirectories = true
+
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+
+        do {
+            let data = try JSONSerialization.data(
+                withJSONObject: defaults,
+                options: [.prettyPrinted, .sortedKeys]
+            )
+            try data.write(to: url, options: .atomic)
+        } catch {
+            MessageUtil.showAlert(
+                title: String(localized: "Export Failed"),
+                message: error.localizedDescription
+            )
+        }
+    }
+
+    // MARK: - Import
+
+    /// Presents an open panel and imports settings from a JSON file.
+    @MainActor
+    static func importSettings() {
+        let panel = NSOpenPanel()
+        panel.title = String(localized: "Import DockDoor Settings")
+        panel.allowsMultipleSelection = false
+        panel.canChooseDirectories = false
+        panel.canChooseFiles = true
+        panel.allowedContentTypes = [.json]
+
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+
+        do {
+            let data = try Data(contentsOf: url)
+            guard let dict = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+                MessageUtil.showAlert(
+                    title: String(localized: "Import Failed"),
+                    message: String(localized: "The selected file does not contain valid settings.")
+                )
+                return
+            }
+
+            MessageUtil.showAlert(
+                title: String(localized: "Import Settings"),
+                message: String(localized: "This will replace all current settings with the imported values. DockDoor will restart to apply changes."),
+                actions: [.ok, .cancel]
+            ) { action in
+                guard action == .ok else { return }
+
+                guard let bundleID = Bundle.main.bundleIdentifier else { return }
+
+                // Replace the entire persistent domain with the imported values.
+                UserDefaults.standard.setPersistentDomain(dict, forName: bundleID)
+                UserDefaults.standard.synchronize()
+
+                askUserToRestartApplication()
+            }
+        } catch {
+            MessageUtil.showAlert(
+                title: String(localized: "Import Failed"),
+                message: error.localizedDescription
+            )
+        }
+    }
+}

--- a/DockDoor/Views/Settings/MainSettingsView.swift
+++ b/DockDoor/Views/Settings/MainSettingsView.swift
@@ -17,9 +17,10 @@ struct MainSettingsView: View {
                 applicationBasicsSection
                 activeAppIndicatorSection
 
+                settingsManagementSection
+
                 HStack {
                     Spacer()
-                    Button("Reset All Settings to Defaults") { showResetConfirmation() }
                     Button("Quit DockDoor") { (NSApplication.shared.delegate as! AppDelegate).quitApp() }
                     Spacer()
                 }
@@ -80,6 +81,35 @@ struct MainSettingsView: View {
     private var activeAppIndicatorSection: some View {
         SettingsGroup(header: "Active App Indicator") {
             ActiveAppIndicatorSettingsView()
+        }
+    }
+
+    // MARK: - Settings Management
+
+    private var settingsManagementSection: some View {
+        SettingsGroup(header: "Settings Management") {
+            VStack(alignment: .leading, spacing: 10) {
+                HStack(spacing: 12) {
+                    Button {
+                        SettingsBackupManager.exportSettings()
+                    } label: {
+                        Label("Export Settings", systemImage: "square.and.arrow.up")
+                    }
+
+                    Button {
+                        SettingsBackupManager.importSettings()
+                    } label: {
+                        Label("Import Settings", systemImage: "square.and.arrow.down")
+                    }
+                }
+
+                Text("Export your settings to a file for backup or transfer to another machine. Import to restore a previous configuration.")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+
+                Button("Reset All Settings to Defaults") { showResetConfirmation() }
+                    .padding(.top, 4)
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Adds settings backup and restore via JSON export/import.

## Changes

- New `SettingsBackupManager` with `exportSettings()` / `importSettings()` methods using `UserDefaults.persistentDomain(forName:)` for full domain capture
- Added "Settings Management" section in `MainSettingsView` with Export/Import buttons
- Moved "Reset All Settings" into the same section

## How it works

Export serializes the entire `UserDefaults` domain to JSON via `NSSavePanel`. Import reads the file via `NSOpenPanel`, confirms with the user, writes all keys back, and prompts for restart. Works forward/backward — unknown keys are ignored on import, missing keys use defaults.

Closes #688