### PR TITLE
fix: resolve race condition preventing window count updates in hover preview

### DIFF
--- a/DockDoor/Utilities/DockObserver+CmdTab.swift
+++ b/DockDoor/Utilities/DockObserver+CmdTab.swift
@@ -187,8 +187,8 @@ extension DockObserver {
                         guard let self else { return }
                         guard let screen = screenOrigin.screen() else { return }
 
-                        previewCoordinator.mergeWindowsIfShowing(
-                            for: appPID,
+                        previewCoordinator.mergeWindowsIfNeeded(
+                            appPID,
                             windows: freshWindows,
                             dockPosition: .cmdTab,
                             bestGuessMonitor: screen

--- a/DockDoor/Utilities/DockObserver.swift
+++ b/DockDoor/Utilities/DockObserver.swift
@@ -331,8 +331,8 @@ final class DockObserver {
                         }
                     }
 
-                    previewCoordinator.mergeWindowsIfShowing(
-                        for: currentAppPID,
+                    previewCoordinator.mergeWindowsIfNeeded(
+                        currentAppPID,
                         windows: freshWindows,
                         dockPosition: dockPosition,
                         bestGuessMonitor: monitor

--- a/DockDoor/Views/Hover Window/Shared Components/SharedPreviewWindowCoordinator.swift
+++ b/DockDoor/Views/Hover Window/Shared Components/SharedPreviewWindowCoordinator.swift
@@ -159,7 +159,6 @@ final class SharedPreviewWindowCoordinator: NSPanel {
     @MainActor
     @discardableResult
     func mergeWindowsIfShowing(for pid: pid_t? = nil, windows: [WindowInfo], dockPosition: DockPosition, bestGuessMonitor: NSScreen) -> Bool {
-        guard isVisible else { return false }
         guard windowSwitcherCoordinator.windowSwitcherActive || currentlyDisplayedPID == pid else { return false }
         windowSwitcherCoordinator.mergeWindows(windows, dockPosition: dockPosition, bestGuessMonitor: bestGuessMonitor)
         return true

--- a/DockDoor/Views/Hover Window/Shared Components/SharedPreviewWindowCoordinator.swift
+++ b/DockDoor/Views/Hover Window/Shared Components/SharedPreviewWindowCoordinator.swift
@@ -155,10 +155,10 @@ final class SharedPreviewWindowCoordinator: NSPanel {
         orderOut(nil)
     }
 
-    /// Merges fresh windows only if the preview is visible and showing the expected app (or window switcher is active).
+    /// Merges fresh windows if currently displaying the expected app.
     @MainActor
     @discardableResult
-    func mergeWindowsIfShowing(for pid: pid_t? = nil, windows: [WindowInfo], dockPosition: DockPosition, bestGuessMonitor: NSScreen) -> Bool {
+    func mergeWindowsIfNeeded(_ pid: pid_t? = nil, windows: [WindowInfo], dockPosition: DockPosition, bestGuessMonitor: NSScreen) -> Bool {
         guard windowSwitcherCoordinator.windowSwitcherActive || currentlyDisplayedPID == pid else { return false }
         windowSwitcherCoordinator.mergeWindows(windows, dockPosition: dockPosition, bestGuessMonitor: bestGuessMonitor)
         return true

--- a/DockDoor/Views/Hover Window/WindowPreview Supporting/PreviewStateCoordinator.swift
+++ b/DockDoor/Views/Hover Window/WindowPreview Supporting/PreviewStateCoordinator.swift
@@ -228,6 +228,7 @@ class PreviewStateCoordinator: ObservableObject {
         if windowsWereAdded, let monitor = lastKnownBestGuessMonitor {
             let dockPosition = DockUtils.getDockPosition()
             recomputeAndPublishDimensions(dockPosition: dockPosition, bestGuessMonitor: monitor)
+            frameRefreshRequestId = UUID()
         }
     }
 


### PR DESCRIPTION
When a new window is created while the hover preview is open, the preview does not update to show the new window until closed and reopened.

**Root cause:** `mergeWindowsIfShowing()` checked `isVisible` before allowing window list updates. This created a race condition where the async task fetching fresh windows would complete before the preview window was fully visible, causing the merge to be rejected.

**Solution:** Remove the `isVisible` check and rely solely on `currentlyDisplayedPID` matching. This allows window updates during preview initialization.

Additionally, trigger `frameRefreshRequestId` in `addWindows()` when windows are added via cache notifications to ensure UI updates.

## Describe your changes
Removed a single `guard isVisible` check that was blocking window list updates during preview initialization. Added frame refresh trigger to ensure UI updates when cache manager adds windows. These minimal changes fix the race condition without affecting other functionality.

## Related issue number(s) and link(s)
N/A - Bug discovered during testing

## Checklist before requesting a review
- [x] I have performed a self-review of my code and understand every line
- [x] If this change affects core functionality, I have added a description highlighting the changes
- [x] I have followed conventional commit guidelines
- [x] I have tested this PR on my own machine

## AI Assistance Disclosure

**Did you use AI tools (ChatGPT, Claude, Copilot, Cursor, etc.) for this PR?**
- [x] Yes - describe below how AI was used and confirm you reviewed/tested the output

Used Claude Code to help identify the race condition by adding debug logging and tracing the code flow. The actual fix (removing one line and adding another) was identified through analysis of the execution flow. I understand how the preview initialization works and why the `isVisible` check was causing the race condition. Tested the fix locally by opening new windows while preview is visible.

## Core Functionality Changes
This PR modifies the hover preview window update mechanism. Previously, window list updates were blocked if the preview wasn't fully visible. Now updates are allowed based solely on PID matching, enabling real-time updates during preview initialization without affecting other behavior.