### PR TITLE
fix: allow Escape key to dismiss system app switcher

### DIFF
--- a/DockDoor/Utilities/KeybindHelper.swift
+++ b/DockDoor/Utilities/KeybindHelper.swift
@@ -441,7 +441,8 @@ class KeybindHelper {
                         Task { @MainActor in
                             self.previewCoordinator.hideWindow()
                         }
-                        return nil
+                        // Pass Escape through so the Dock can dismiss the system switcher too
+                        return Unmanaged.passUnretained(event)
                     case Int64(kVK_LeftArrow):
                         if hasSelection {
                             Task { @MainActor in


### PR DESCRIPTION
## Describe your changes

With Cmd+Tab enhancements on, the first **Esc** was handled only by DockDoor: we hid the preview and returned nil from the event tap, so the key never reached the Dock. Users had to press **Esc** again so the system could dismiss Apple’s app switcher ([issue #1208](https://github.com/ejbills/DockDoor/issues/1208)).

After hiding the preview, we now **pass the Escape event through** (`Unmanaged.passUnretained(event)`) instead of consuming it. One **Esc** should dismiss both DockDoor’s overlay and the system switcher when the OS treats Escape as cancel.

## Related issue number(s) and link(s)

- Closes / fixes: https://github.com/ejbills/DockDoor/issues/1208

## Checklist before requesting a review

- [x] I have performed a self-review of my code and understand every line
- [x] If this change affects core functionality, I have added a description highlighting the changes
- [x] I have followed conventional commit guidelines
- [x] I have tested this PR on my own machine

## AI Assistance Disclosure

**Did you use AI tools (ChatGPT, Claude, Copilot, Cursor, etc.) for this PR?**

- [ ] No AI tools were used
- [x] Yes - describe below how AI was used and confirm you reviewed/tested the output

I used Claude to find where Escape dismisses the app switcher, then read the file and made the change myself (a one-line edit). I built and tested on my Mac (macOS 26.5 Beta (25F5042g)) with Xcode 26.4. I used Claude to generate the commit message and reviewed it before submitting.

## Core Functionality Changes

**Cmd+Tab+Esc:** While the system app switcher is active and DockDoor’s Cmd+Tab preview is visible, the first **Esc** still hides DockDoor’s window, but the Escape key is no longer swallowed so the Dock can receive it and dismiss the stock switcher in one press.