### PR TITLE
feat:  Add widget app filters so users can disable dock hover widgets

### DIFF
--- a/DockDoor/Utilities/Window Management/WindowUtil.swift
+++ b/DockDoor/Utilities/Window Management/WindowUtil.swift
@@ -260,15 +260,22 @@ enum WindowUtil {
         PermissionsChecker.hasScreenRecordingPermission()
     }
 
-    static func isAppFiltered(_ app: NSRunningApplication) -> Bool {
-        let filters = Defaults[.appNameFilters]
+    static func matchesAppFilters(bundleIdentifier: String?, appName: String, filters: [String]) -> Bool {
         guard !filters.isEmpty else { return false }
 
-        let bundleId = app.bundleIdentifier ?? ""
-        let appName = app.localizedName ?? ""
+        if let bundleIdentifier, filters.contains(bundleIdentifier) {
+            return true
+        }
 
-        // Check bundle ID (new format) or app name (legacy format)
-        return filters.contains(bundleId) || filters.contains(where: { $0.caseInsensitiveCompare(appName) == .orderedSame })
+        return filters.contains(where: { $0.caseInsensitiveCompare(appName) == .orderedSame })
+    }
+
+    static func isAppFiltered(_ app: NSRunningApplication) -> Bool {
+        matchesAppFilters(
+            bundleIdentifier: app.bundleIdentifier,
+            appName: app.localizedName ?? "",
+            filters: Defaults[.appNameFilters]
+        )
     }
 
     /// Returns window IDs that are cached with fresh images (within cache lifespan)

--- a/DockDoor/Views/Hover Window/Shared Components/SharedPreviewWindowCoordinator.swift
+++ b/DockDoor/Views/Hover Window/Shared Components/SharedPreviewWindowCoordinator.swift
@@ -600,8 +600,13 @@ final class SharedPreviewWindowCoordinator: NSPanel {
         var finalEmbeddedContentType: EmbeddedContentType = .none
         var useBigStandaloneViewInstead = false
         var viewForBigStandalone: AnyView?
+        let widgetsAreFiltered = WindowUtil.matchesAppFilters(
+            bundleIdentifier: bundleIdentifier,
+            appName: appName,
+            filters: Defaults[.widgetAppFilters]
+        )
 
-        if let bundleId = bundleIdentifier {
+        if let bundleId = bundleIdentifier, !widgetsAreFiltered {
             let actualAppContentType = getEmbeddedContentType(for: bundleId)
 
             switch actualAppContentType {

--- a/DockDoor/Views/Settings/FiltersSettingsView.swift
+++ b/DockDoor/Views/Settings/FiltersSettingsView.swift
@@ -5,10 +5,12 @@ import SwiftUI
 struct FiltersSettingsView: View {
     @Default(.appNameFilters) var appNameFilters
     @Default(.windowTitleFilters) var windowTitleFilters
+    @Default(.widgetAppFilters) var widgetAppFilters
     @Default(.customAppDirectories) var customAppDirectories
 
     @State private var showingAddFilterSheet = false
     @State private var showingAppPickerSheet = false
+    @State private var showingWidgetAppPickerSheet = false
     @State private var showingDirectoryPicker = false
     @State private var newFilter = FilterEntry(text: "")
 
@@ -224,6 +226,67 @@ struct FiltersSettingsView: View {
                         }
                     }
                 }
+
+                // Widget App Filters Section
+                SettingsGroup(header: "Widget App Filters") {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Disable dock hover widgets for selected apps while keeping their regular previews. Useful for browsers that expose media sessions like YouTube.")
+                            .font(.footnote)
+                            .foregroundColor(.secondary)
+                            .padding(.bottom, 4)
+
+                        if widgetAppFilters.isEmpty {
+                            Text("Widgets enabled for all apps")
+                                .foregroundColor(.secondary)
+                                .padding(.vertical, 8)
+                        } else {
+                            ScrollView {
+                                VStack(alignment: .leading, spacing: 4) {
+                                    ForEach(widgetAppFilters, id: \.self) { filter in
+                                        HStack {
+                                            Text(filter)
+                                                .lineLimit(1)
+
+                                            Spacer()
+
+                                            Button(action: {
+                                                widgetAppFilters.removeAll { $0 == filter }
+                                            }) {
+                                                Image(systemName: "xmark.circle.fill")
+                                                    .foregroundColor(.secondary)
+                                            }
+                                            .buttonStyle(.plain)
+                                        }
+                                        .padding(.vertical, 2)
+                                    }
+                                }
+                                .padding(8)
+                            }
+                            .frame(maxHeight: 120)
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 8)
+                                    .stroke(Color.gray.opacity(0.25), lineWidth: 1)
+                            )
+                        }
+
+                        HStack {
+                            Button("Select Apps to Disable Widgets For...") {
+                                showingWidgetAppPickerSheet = true
+                            }
+                            .buttonStyle(AccentButtonStyle(color: .accentColor))
+
+                            Spacer()
+
+                            if !widgetAppFilters.isEmpty {
+                                DangerButton(action: {
+                                    widgetAppFilters.removeAll()
+                                }) {
+                                    Text("Clear All")
+                                }
+                            }
+                        }
+                    }
+                }
             }
             .sheet(isPresented: $showingAddFilterSheet) {
                 AddFilterSheet(
@@ -241,6 +304,14 @@ struct FiltersSettingsView: View {
                     selectedApps: $appNameFilters,
                     title: "Application Filters",
                     description: "Uncheck apps to hide them from DockDoor previews.",
+                    selectionMode: .exclude
+                )
+            }
+            .sheet(isPresented: $showingWidgetAppPickerSheet) {
+                AppPickerSheet(
+                    selectedApps: $widgetAppFilters,
+                    title: "Widget App Filters",
+                    description: "Uncheck apps to disable dock hover widgets for them while keeping regular previews.",
                     selectionMode: .exclude
                 )
             }

--- a/DockDoor/consts.swift
+++ b/DockDoor/consts.swift
@@ -240,6 +240,7 @@ extension Defaults.Keys {
 
     static let appNameFilters = Key<[String]>("appNameFilters", default: [])
     static let windowTitleFilters = Key<[String]>("windowTitleFilters", default: [])
+    static let widgetAppFilters = Key<[String]>("widgetAppFilters", default: [])
     static let groupedAppsInSwitcher = Key<[String]>("groupedAppsInSwitcher", default: [])
     static let customAppDirectories = Key<[String]>("customAppDirectories", default: [])
     static let filteredCalendarIdentifiers = Key<[String]>("filteredCalendarIdentifiers", default: [])


### PR DESCRIPTION
## Describe your changes
This adds a per-app widget filter for dock previews.

The recent widget behavior is useful in many apps, but it can be distracting and make hover flow feel slower in browsers, especially when sites like YouTube expose media sessions. This change lets users disable dock hover widgets for selected apps without hiding the app itself from DockDoor previews.

The settings UI adds a new `Widget App Filters` section at the end of the existing Filters screen. Internally, the filter is stored as `widgetAppFilters` and uses the same app matching behavior as the existing app filters by reusing shared logic in `WindowUtil`.

Behaviorally, this only affects widget rendering. Normal previews remain unchanged.

## Related issue number(s) and link(s)
N/A

## Checklist before requesting a review
- [x] I have performed a self-review of my code and understand every line
- [x] If this change affects core functionality, I have added a description highlighting the changes
- [x] I have followed conventional commit guidelines
- [x] I have tested this PR on my own machine

## AI Assistance Disclosure
- [ ] No AI tools were used
- [x] Yes - describe below how AI was used and confirm you reviewed/tested the output

Used Codex to help implement the feature and clean up the branch/workflow. I reviewed the resulting code, verified the architecture against the existing filter system, and checked that the change stays scoped to widget rendering only. I still need to complete my own manual runtime testing before requesting final review.

## Core Functionality Changes
This changes dock preview behavior for apps selected in the new `Widget App Filters` setting.

Impact:
- selected apps will no longer show dock hover widgets
- regular DockDoor previews for those apps still work as before
- widget filter matching follows the same bundle ID / app name matching pattern already used by existing app filters