### PR TITLE
feat: add dock click window restore setting

### DIFF
--- a/DockDoor/Utilities/DockObserver.swift
+++ b/DockDoor/Utilities/DockObserver.swift
@@ -803,7 +803,7 @@ final class DockObserver {
                 // This prevents native dock's restore from confusing our logic
                 let needsRestore = restorationNeededAtClickTime || currentlyHasMinimizedWindows
 
-                if needsRestore {
+                if needsRestore, Defaults[.restoreAllMinimizedWindowsOnDockClick] {
                     DebugLogger.log("DockClick", details: "\(appName): restoring (needsRestore=true, minimized=\(currentlyHasMinimizedWindows))")
                     restoreAppWindows(windows: windows, app: app, appName: appName)
                 } else if wasFrontmostOnHover, !windows.isEmpty {

--- a/DockDoor/Views/Settings/DockPreviewsSettingsView.swift
+++ b/DockDoor/Views/Settings/DockPreviewsSettingsView.swift
@@ -148,9 +148,11 @@ struct DockPreviewsSettingsView: View {
                     .pickerStyle(MenuPickerStyle())
                     .padding(.leading, 20)
 
-                    Toggle(isOn: $restoreAllMinimizedWindowsOnDockClick) { Text("Restore all minimized windows on dock icon click") }
-                        .settingsSearchTarget("dockPreviews.restoreAllMinimizedOnClick")
-                        .padding(.leading, 20)
+                    if dockClickAction == .minimize {
+                        Toggle(isOn: $restoreAllMinimizedWindowsOnDockClick) { Text("Restore all minimized windows on dock icon click") }
+                            .settingsSearchTarget("dockPreviews.restoreAllMinimizedOnClick")
+                            .padding(.leading, 20)
+                    }
                 }
 
                 Toggle(isOn: $enableCmdRightClickQuit) { Text("CMD + Right Click on dock icon to quit app") }

--- a/DockDoor/Views/Settings/DockPreviewsSettingsView.swift
+++ b/DockDoor/Views/Settings/DockPreviewsSettingsView.swift
@@ -14,6 +14,7 @@ struct DockPreviewsSettingsView: View {
     @Default(.tapEquivalentInterval) var tapEquivalentInterval
     @Default(.shouldHideOnDockItemClick) var shouldHideOnDockItemClick
     @Default(.dockClickAction) var dockClickAction
+    @Default(.restoreAllMinimizedWindowsOnDockClick) var restoreAllMinimizedWindowsOnDockClick
     @Default(.enableCmdRightClickQuit) var enableCmdRightClickQuit
     @Default(.quitAppOnWindowClose) var quitAppOnWindowClose
     @Default(.bufferFromDock) var bufferFromDock
@@ -146,6 +147,10 @@ struct DockPreviewsSettingsView: View {
                     }
                     .pickerStyle(MenuPickerStyle())
                     .padding(.leading, 20)
+
+                    Toggle(isOn: $restoreAllMinimizedWindowsOnDockClick) { Text("Restore all minimized windows on dock icon click") }
+                        .settingsSearchTarget("dockPreviews.restoreAllMinimizedOnClick")
+                        .padding(.leading, 20)
                 }
 
                 Toggle(isOn: $enableCmdRightClickQuit) { Text("CMD + Right Click on dock icon to quit app") }

--- a/DockDoor/Views/Settings/MainSettingsView.swift
+++ b/DockDoor/Views/Settings/MainSettingsView.swift
@@ -101,6 +101,7 @@ struct MainSettingsView: View {
                 Defaults[.bufferFromDock] = Defaults.Keys.bufferFromDock.defaultValue
                 Defaults[.shouldHideOnDockItemClick] = Defaults.Keys.shouldHideOnDockItemClick.defaultValue
                 Defaults[.dockClickAction] = Defaults.Keys.dockClickAction.defaultValue
+                Defaults[.restoreAllMinimizedWindowsOnDockClick] = Defaults.Keys.restoreAllMinimizedWindowsOnDockClick.defaultValue
                 Defaults[.enableCmdRightClickQuit] = Defaults.Keys.enableCmdRightClickQuit.defaultValue
                 Defaults[.previewHoverAction] = Defaults.Keys.previewHoverAction.defaultValue
 

--- a/DockDoor/Views/Settings/Search/SettingsSearchCatalog.swift
+++ b/DockDoor/Views/Settings/Search/SettingsSearchCatalog.swift
@@ -223,6 +223,14 @@ enum SettingsSearchCatalog {
             icon: "cursorarrow.click.2"
         ),
         SettingsSearchItem(
+            id: "dockPreviews.restoreAllMinimizedOnClick",
+            title: String(localized: "Restore all minimized windows on dock icon click"),
+            keywords: ["restore", "click", "minimize", "open"],
+            tab: "DockPreviews",
+            section: String(localized: "Dock Interaction"),
+            icon: "rectangle.stack"
+        ),
+        SettingsSearchItem(
             id: "dockPreviews.cmdRightClickQuit",
             title: String(localized: "CMD + Right Click on dock icon to quit app"),
             keywords: ["quit", "right click", "command", "force"],

--- a/DockDoor/Views/Settings/Search/SettingsSearchEngine.swift
+++ b/DockDoor/Views/Settings/Search/SettingsSearchEngine.swift
@@ -1,3 +1,4 @@
+import Defaults
 import SwiftUI
 
 final class SettingsSearchEngine: ObservableObject {
@@ -51,7 +52,7 @@ final class SettingsSearchEngine: ObservableObject {
         let tokens = trimmed.lowercased().split(separator: " ").map(String.init)
         var scored: [SettingsSearchResult] = []
 
-        for item in items {
+        for item in items where isAvailable(item) {
             let titleLower = item.title.lowercased()
             let descLower = item.description.lowercased()
             let keywordsLower = item.keywords.map { $0.lowercased() }
@@ -91,5 +92,14 @@ final class SettingsSearchEngine: ObservableObject {
         }
 
         results = scored
+    }
+
+    private func isAvailable(_ item: SettingsSearchItem) -> Bool {
+        switch item.id {
+        case "dockPreviews.restoreAllMinimizedOnClick":
+            Defaults[.dockClickAction] == .minimize
+        default:
+            true
+        }
     }
 }

--- a/DockDoor/consts.swift
+++ b/DockDoor/consts.swift
@@ -39,6 +39,7 @@ extension Defaults.Keys {
     static let switcherBackwardKeyCode = Key<UInt16>("switcherBackwardKeyCode", default: 56)
     static let shouldHideOnDockItemClick = Key<Bool>("shouldHideOnDockItemClick", default: false)
     static let dockClickAction = Key<DockClickAction>("dockClickAction", default: .hide)
+    static let restoreAllMinimizedWindowsOnDockClick = Key<Bool>("restoreAllMinimizedWindowsOnDockClick", default: true)
     static let enableCmdRightClickQuit = Key<Bool>("enableCmdRightClickQuit", default: true)
     static let quitAppOnWindowClose = Key<Bool>("quitAppOnWindowClose", default: false)
     static let enableDockScrollGesture = Key<Bool>("enableDockScrollGesture", default: false)


### PR DESCRIPTION
## Describe your changes

When the "Hide" option is checked, if the user clicks on an app in the dock that has more than one window, then all windows will be opened. This can make the screen a little messy. This PR keeps the behavior enabled by default, but adds an opt-out setting, so users can choos whether to open all windows when the icon is clicked.

## Related issue number(s) and link(s)

Fixes #1324

## Checklist before requesting a review
- [x] I have performed a self-review of my code and understand every line
- [x] If this change affects core functionality, I have added a description highlighting the changes
- [x] I have followed conventional commit guidelines
- [ ] I have tested this PR on my own machine

## AI Assistance Disclosure

> **Policy**: AI-assisted contributions are welcome, but you must understand, test, and take full responsibility for your code. Pasting AI-generated code or PR descriptions without genuine human review and understanding will result in your PR being closed and may result in a ban from contributing.

**Did you use AI tools (ChatGPT, Claude, Copilot, Cursor, etc.) for this PR?**
- [ ] No AI tools were used
- [x] Yes - describe below how AI was used and confirm you reviewed/tested the output

I used Claude Code to implement the small setting change. I checked the diff and understood what these changes were doing, and confirmed that they were minor changes and not breaking ones

## Core Functionality Changes

This PR modifies Dock icon click behavior when "Hide all app windows on dock icon click" is enabled.

By default, behavior is unchanged: DockDoor still restores all minimized windows when reopening an app from the Dock. If the new "Restore all minimized windows on dock icon click" setting is disabled, DockDoor no longer batch-restores minimized windows during the Dock icon click restore path.