### PR TITLE
feat: improve title bar scroll gestures and restore behavior

### DIFF
--- a/DockDoor.xcodeproj/project.pbxproj
+++ b/DockDoor.xcodeproj/project.pbxproj
@@ -1014,6 +1014,8 @@
 				Base,
 				he,
 				fr,
+				"zh-Hans",
+				"zh-Hant",
 			);
 			mainGroup = BB157B5C2C0E31CE00997315;
 			packageReferences = (

--- a/DockDoor/Utilities/DockObserver.swift
+++ b/DockDoor/Utilities/DockObserver.swift
@@ -51,6 +51,12 @@ final class DockObserver {
         let timestamp: Date
     }
 
+    private struct RuntimeRestoreFrame {
+        let windowId: CGWindowID
+        let processIdentifier: pid_t
+        let originalFrame: CGRect
+    }
+
     weak static var activeInstance: DockObserver?
     let previewCoordinator: SharedPreviewWindowCoordinator
 
@@ -67,6 +73,7 @@ final class DockObserver {
 
     private var eventTap: CFMachPort?
     private var eventTapRunLoopSource: CFRunLoopSource?
+    private var scrollGestureSettingsObserver: Defaults.Observation?
 
     // Dock click behavior state
     var currentClickedAppPID: pid_t?
@@ -80,11 +87,14 @@ final class DockObserver {
     private let dockScrollActionDebounceInterval: TimeInterval = 0.3
     private var lastTitleBarScrollActionTime: Date = .distantPast
     private var pendingTitleBarRestoreState: PendingRestoreState?
+    private var runtimeTitleBarRestoreFrames: [String: RuntimeRestoreFrame] = [:]
 
     private let titleBarScrollActionDebounceInterval: TimeInterval = 0.35
     private let minimumTitleBarScrollDelta: Double = 0.15
     private let fallbackTitleBarHeight: CGFloat = 48
     private let maximumTitleBarHeight: CGFloat = 72
+    private let titleBarFrameTolerance: CGFloat = 8
+    private let maximumPersistentTitleBarRestoreFrames = 50
 
     private var cachedTitleBarInfo: CachedTitleBarInfo?
     private var titleBarRefreshScheduled = false
@@ -115,6 +125,10 @@ final class DockObserver {
             (isMediaApp(bundleId) && Defaults[.enableMediaWidget])
     }
 
+    private var titleBarVerticalScrollBehavior: TitleBarVerticalScrollBehavior {
+        Defaults[.titleBarVerticalScrollBehavior]
+    }
+
     static func isDockVisible() -> Bool {
         if let frontmostApp = NSWorkspace.shared.frontmostApplication,
            WindowUtil.isAppInFullscreen(frontmostApp)
@@ -129,6 +143,7 @@ final class DockObserver {
         DockObserver.activeInstance = self
         setupSelectedDockItemObserver()
         startHealthCheckTimer()
+        observeScrollGestureSettings()
         enableDockClickDetection()
     }
 
@@ -139,6 +154,7 @@ final class DockObserver {
         healthCheckTimer?.invalidate()
         teardownObserver()
         teardownCmdTabObserver()
+        scrollGestureSettingsObserver?.invalidate()
 
         removeEventTap()
     }
@@ -154,8 +170,7 @@ final class DockObserver {
         teardownObserver()
         teardownCmdTabObserver()
         setupSelectedDockItemObserver()
-        removeEventTap()
-        setupEventTap()
+        refreshEventTap()
     }
 
     private func performHealthCheck() {
@@ -636,6 +651,23 @@ final class DockObserver {
         setupEventTap()
     }
 
+    private func observeScrollGestureSettings() {
+        scrollGestureSettingsObserver?.invalidate()
+        scrollGestureSettingsObserver = Defaults.observe(
+            keys: .enableDockScrollGesture,
+            .enableTitleBarScrollGesture
+        ) { [weak self] in
+            DispatchQueue.main.async {
+                self?.refreshEventTap()
+            }
+        }
+    }
+
+    private func refreshEventTap() {
+        removeEventTap()
+        setupEventTap()
+    }
+
     private func removeEventTap() {
         if let eventTap {
             CGEvent.tapEnable(tap: eventTap, enable: false)
@@ -1022,7 +1054,9 @@ final class DockObserver {
             return false
         }
 
-        if let cached = cachedTitleBarInfo, Date().timeIntervalSince(cached.timestamp) > titleBarCacheMaxAge {
+        let now = Date()
+
+        if let cached = cachedTitleBarInfo, now.timeIntervalSince(cached.timestamp) > titleBarCacheMaxAge {
             cachedTitleBarInfo = nil
         }
 
@@ -1042,7 +1076,6 @@ final class DockObserver {
         let normalizedDeltaX = isNaturalScrolling ? -deltaX : deltaX
         let normalizedDeltaY = isNaturalScrolling ? -deltaY : deltaY
 
-        let now = Date()
         guard now.timeIntervalSince(lastTitleBarScrollActionTime) >= titleBarScrollActionDebounceInterval else {
             return true
         }
@@ -1073,24 +1106,37 @@ final class DockObserver {
     }
 
     private func handleTitleBarVerticalScroll(_ action: VerticalScrollAction, for window: WindowInfo, now: Date) {
+        switch titleBarVerticalScrollBehavior {
+        case .resizeAndCenter:
+            handleTimedTitleBarVerticalScroll(action, for: window, now: now)
+        case .maximizeAndRestore:
+            handlePersistentTitleBarVerticalScroll(action, for: window, now: now)
+        }
+    }
+
+    private func handleTimedTitleBarVerticalScroll(_ action: VerticalScrollAction, for window: WindowInfo, now: Date) {
         if let pendingTitleBarRestoreState,
            pendingTitleBarRestoreState.windowId == window.id,
            pendingTitleBarRestoreState.processIdentifier == window.app.processIdentifier,
            pendingTitleBarRestoreState.action == action,
            pendingTitleBarRestoreState.expirationDate > now
         {
-            window.setWindowFrame(pendingTitleBarRestoreState.originalFrame)
+            _ = window.setWindowFrame(pendingTitleBarRestoreState.originalFrame)
             self.pendingTitleBarRestoreState = nil
             return
         }
 
         guard let originalFrame = window.currentWindowFrame() else {
-            performTitleBarVerticalScrollAction(action, on: window)
+            _ = performTitleBarVerticalScrollAction(action, on: window, originalFrame: nil)
             pendingTitleBarRestoreState = nil
             return
         }
 
-        performTitleBarVerticalScrollAction(action, on: window)
+        guard performTitleBarVerticalScrollAction(action, on: window, originalFrame: originalFrame) else {
+            pendingTitleBarRestoreState = nil
+            return
+        }
+
         pendingTitleBarRestoreState = PendingRestoreState(
             windowId: window.id,
             processIdentifier: window.app.processIdentifier,
@@ -1100,22 +1146,169 @@ final class DockObserver {
         )
     }
 
-    private func performTitleBarVerticalScrollAction(_ action: VerticalScrollAction, on window: WindowInfo) {
+    private func handlePersistentTitleBarVerticalScroll(_ action: VerticalScrollAction, for window: WindowInfo, now: Date) {
         switch action {
         case .maximize:
-            window.zoom()
+            guard let originalFrame = restoreFrame(for: window) ?? window.currentWindowFrame() else {
+                _ = performTitleBarVerticalScrollAction(.maximize, on: window, originalFrame: nil)
+                return
+            }
+
+            guard performTitleBarVerticalScrollAction(.maximize, on: window, originalFrame: originalFrame) else {
+                removeRestoreFrame(for: window)
+                return
+            }
+            saveRestoreFrameIfNeeded(originalFrame, for: window, now: now)
+
+        case .center:
+            if let originalFrame = restoreFrame(for: window) {
+                if let appliedFrame = window.setWindowFrame(originalFrame),
+                   titleBarFrame(appliedFrame, matches: originalFrame)
+                {
+                    removeRestoreFrame(for: window)
+                }
+            } else {
+                _ = performTitleBarVerticalScrollAction(.center, on: window, originalFrame: nil)
+            }
+        }
+    }
+
+    private func performTitleBarVerticalScrollAction(_ action: VerticalScrollAction, on window: WindowInfo, originalFrame: CGRect?) -> Bool {
+        let targetFrame: CGRect?
+        let appliedFrame: CGRect?
+
+        switch action {
+        case .maximize:
+            targetFrame = window.targetFrame(for: .full)
+            appliedFrame = window.zoom()
         case .center:
             switch centeredWindowSizingMode {
             case .uniform:
-                window.centerWindow(scale: centeredWindowScale)
+                targetFrame = window.centeredWindowTargetFrame(scale: centeredWindowScale)
+                appliedFrame = window.centerWindow(scale: centeredWindowScale)
             case .separate:
-                window.centerWindow(
+                targetFrame = window.centeredWindowTargetFrame(
+                    widthScale: centeredWindowWidthScale,
+                    heightScale: centeredWindowHeightScale,
+                    lockAspectRatio: centeredWindowLockAspectRatio
+                )
+                appliedFrame = window.centerWindow(
                     widthScale: centeredWindowWidthScale,
                     heightScale: centeredWindowHeightScale,
                     lockAspectRatio: centeredWindowLockAspectRatio
                 )
             }
         }
+
+        guard let targetFrame, let appliedFrame else {
+            return false
+        }
+
+        guard titleBarFrame(appliedFrame, matches: targetFrame) else {
+            if let originalFrame {
+                _ = window.setWindowFrame(originalFrame)
+            }
+            return false
+        }
+
+        return true
+    }
+
+    private func saveRestoreFrameIfNeeded(_ originalFrame: CGRect, for window: WindowInfo, now: Date) {
+        let runtimeKey = runtimeRestoreKey(for: window)
+        if runtimeTitleBarRestoreFrames[runtimeKey] == nil {
+            runtimeTitleBarRestoreFrames[runtimeKey] = RuntimeRestoreFrame(
+                windowId: window.id,
+                processIdentifier: window.app.processIdentifier,
+                originalFrame: originalFrame
+            )
+        }
+
+        guard let persistentKey = persistentRestoreKey(for: window),
+              !Defaults[.titleBarScrollPersistentRestoreFrames].contains(where: { $0.identityKey == persistentKey }),
+              let bundleIdentifier = window.app.bundleIdentifier,
+              let windowTitle = normalizedWindowTitle(for: window)
+        else {
+            return
+        }
+
+        var frames = Defaults[.titleBarScrollPersistentRestoreFrames]
+        frames.append(TitleBarScrollPersistentRestoreFrame(
+            bundleIdentifier: bundleIdentifier,
+            windowTitle: windowTitle,
+            originalFrame: originalFrame,
+            updatedAt: now
+        ))
+        Defaults[.titleBarScrollPersistentRestoreFrames] = trimmedPersistentRestoreFrames(frames)
+    }
+
+    private func restoreFrame(for window: WindowInfo) -> CGRect? {
+        let runtimeKey = runtimeRestoreKey(for: window)
+        if let runtimeFrame = runtimeTitleBarRestoreFrames[runtimeKey],
+           runtimeFrame.windowId == window.id,
+           runtimeFrame.processIdentifier == window.app.processIdentifier
+        {
+            return runtimeFrame.originalFrame
+        }
+
+        guard let persistentKey = persistentRestoreKey(for: window),
+              let persistentFrame = Defaults[.titleBarScrollPersistentRestoreFrames].first(where: { $0.identityKey == persistentKey })
+        else {
+            return nil
+        }
+
+        return persistentFrame.originalFrame
+    }
+
+    private func removeRestoreFrame(for window: WindowInfo) {
+        runtimeTitleBarRestoreFrames.removeValue(forKey: runtimeRestoreKey(for: window))
+
+        guard let persistentKey = persistentRestoreKey(for: window) else {
+            return
+        }
+
+        Defaults[.titleBarScrollPersistentRestoreFrames] = Defaults[.titleBarScrollPersistentRestoreFrames]
+            .filter { $0.identityKey != persistentKey }
+    }
+
+    private func runtimeRestoreKey(for window: WindowInfo) -> String {
+        "\(window.app.processIdentifier)|\(window.id)"
+    }
+
+    private func persistentRestoreKey(for window: WindowInfo) -> String? {
+        guard let bundleIdentifier = window.app.bundleIdentifier,
+              let windowTitle = normalizedWindowTitle(for: window)
+        else {
+            return nil
+        }
+
+        return "\(bundleIdentifier)|\(windowTitle)"
+    }
+
+    private func normalizedWindowTitle(for window: WindowInfo) -> String? {
+        let title = (window.windowName ?? (try? window.axElement.title()) ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return title.isEmpty ? nil : title
+    }
+
+    private func trimmedPersistentRestoreFrames(_ frames: [TitleBarScrollPersistentRestoreFrame]) -> [TitleBarScrollPersistentRestoreFrame] {
+        var seenKeys = Set<String>()
+        return frames
+            .sorted { $0.updatedAt > $1.updatedAt }
+            .filter { frame in
+                guard !seenKeys.contains(frame.identityKey) else {
+                    return false
+                }
+                seenKeys.insert(frame.identityKey)
+                return true
+            }
+            .prefix(maximumPersistentTitleBarRestoreFrames)
+            .map { $0 }
+    }
+
+    private func titleBarFrame(_ appliedFrame: CGRect, matches targetFrame: CGRect) -> Bool {
+        abs(appliedFrame.width - targetFrame.width) <= titleBarFrameTolerance &&
+            abs(appliedFrame.height - targetFrame.height) <= titleBarFrameTolerance
     }
 
     private func resolvedTitleBarHeight(for window: WindowInfo, windowFrame: CGRect) -> CGFloat {

--- a/DockDoor/Utilities/DockObserver.swift
+++ b/DockDoor/Utilities/DockObserver.swift
@@ -1151,19 +1151,17 @@ final class DockObserver {
         case .maximize:
             let currentFrame = window.currentWindowFrame()
             let maximizeTargetFrame = window.targetFrame(for: .full)
-            let isAlreadyMaximized: Bool
-            if let currentFrame, let maximizeTargetFrame {
-                isAlreadyMaximized = titleBarFrame(currentFrame, matches: maximizeTargetFrame, includePosition: true)
+            let isAlreadyMaximized: Bool = if let currentFrame, let maximizeTargetFrame {
+                titleBarFrame(currentFrame, matches: maximizeTargetFrame, includePosition: true)
             } else {
-                isAlreadyMaximized = false
+                false
             }
 
             // 窗口被手动拖到其他屏幕后，当前 frame 应成为新的恢复点。
-            let originalFrame: CGRect?
-            if isAlreadyMaximized {
-                originalFrame = restoreFrame(for: window) ?? currentFrame
+            let originalFrame: CGRect? = if isAlreadyMaximized {
+                restoreFrame(for: window) ?? currentFrame
             } else {
-                originalFrame = currentFrame ?? restoreFrame(for: window)
+                currentFrame ?? restoreFrame(for: window)
             }
 
             guard let originalFrame else {

--- a/DockDoor/Utilities/DockObserver.swift
+++ b/DockDoor/Utilities/DockObserver.swift
@@ -1149,7 +1149,24 @@ final class DockObserver {
     private func handlePersistentTitleBarVerticalScroll(_ action: VerticalScrollAction, for window: WindowInfo, now: Date) {
         switch action {
         case .maximize:
-            guard let originalFrame = restoreFrame(for: window) ?? window.currentWindowFrame() else {
+            let currentFrame = window.currentWindowFrame()
+            let maximizeTargetFrame = window.targetFrame(for: .full)
+            let isAlreadyMaximized: Bool
+            if let currentFrame, let maximizeTargetFrame {
+                isAlreadyMaximized = titleBarFrame(currentFrame, matches: maximizeTargetFrame, includePosition: true)
+            } else {
+                isAlreadyMaximized = false
+            }
+
+            // 窗口被手动拖到其他屏幕后，当前 frame 应成为新的恢复点。
+            let originalFrame: CGRect?
+            if isAlreadyMaximized {
+                originalFrame = restoreFrame(for: window) ?? currentFrame
+            } else {
+                originalFrame = currentFrame ?? restoreFrame(for: window)
+            }
+
+            guard let originalFrame else {
                 _ = performTitleBarVerticalScrollAction(.maximize, on: window, originalFrame: nil)
                 return
             }
@@ -1158,12 +1175,12 @@ final class DockObserver {
                 removeRestoreFrame(for: window)
                 return
             }
-            saveRestoreFrameIfNeeded(originalFrame, for: window, now: now)
+            saveRestoreFrame(originalFrame, for: window, now: now)
 
         case .center:
             if let originalFrame = restoreFrame(for: window) {
                 if let appliedFrame = window.setWindowFrame(originalFrame),
-                   titleBarFrame(appliedFrame, matches: originalFrame)
+                   titleBarFrame(appliedFrame, matches: originalFrame, includePosition: true)
                 {
                     removeRestoreFrame(for: window)
                 }
@@ -1214,18 +1231,15 @@ final class DockObserver {
         return true
     }
 
-    private func saveRestoreFrameIfNeeded(_ originalFrame: CGRect, for window: WindowInfo, now: Date) {
+    private func saveRestoreFrame(_ originalFrame: CGRect, for window: WindowInfo, now: Date) {
         let runtimeKey = runtimeRestoreKey(for: window)
-        if runtimeTitleBarRestoreFrames[runtimeKey] == nil {
-            runtimeTitleBarRestoreFrames[runtimeKey] = RuntimeRestoreFrame(
-                windowId: window.id,
-                processIdentifier: window.app.processIdentifier,
-                originalFrame: originalFrame
-            )
-        }
+        runtimeTitleBarRestoreFrames[runtimeKey] = RuntimeRestoreFrame(
+            windowId: window.id,
+            processIdentifier: window.app.processIdentifier,
+            originalFrame: originalFrame
+        )
 
         guard let persistentKey = persistentRestoreKey(for: window),
-              !Defaults[.titleBarScrollPersistentRestoreFrames].contains(where: { $0.identityKey == persistentKey }),
               let bundleIdentifier = window.app.bundleIdentifier,
               let windowTitle = normalizedWindowTitle(for: window)
         else {
@@ -1233,6 +1247,7 @@ final class DockObserver {
         }
 
         var frames = Defaults[.titleBarScrollPersistentRestoreFrames]
+            .filter { $0.identityKey != persistentKey }
         frames.append(TitleBarScrollPersistentRestoreFrame(
             bundleIdentifier: bundleIdentifier,
             windowTitle: windowTitle,
@@ -1306,9 +1321,21 @@ final class DockObserver {
             .map { $0 }
     }
 
-    private func titleBarFrame(_ appliedFrame: CGRect, matches targetFrame: CGRect) -> Bool {
-        abs(appliedFrame.width - targetFrame.width) <= titleBarFrameTolerance &&
+    private func titleBarFrame(
+        _ appliedFrame: CGRect,
+        matches targetFrame: CGRect,
+        includePosition: Bool = false
+    ) -> Bool {
+        let sizeMatches = abs(appliedFrame.width - targetFrame.width) <= titleBarFrameTolerance &&
             abs(appliedFrame.height - targetFrame.height) <= titleBarFrameTolerance
+
+        guard includePosition else {
+            return sizeMatches
+        }
+
+        return sizeMatches &&
+            abs(appliedFrame.minX - targetFrame.minX) <= titleBarFrameTolerance &&
+            abs(appliedFrame.minY - targetFrame.minY) <= titleBarFrameTolerance
     }
 
     private func resolvedTitleBarHeight(for window: WindowInfo, windowFrame: CGRect) -> CGFloat {

--- a/DockDoor/Utilities/Window Management/WindowInfo.swift
+++ b/DockDoor/Utilities/Window Management/WindowInfo.swift
@@ -266,11 +266,48 @@ extension WindowInfo {
             return nil
         }
 
-        guard let screen = NSScreen.screens.first(where: { $0.frame.intersects(windowFrame) }) ?? NSScreen.main else {
+        guard let screen = Self.bestScreen(for: windowFrame) ?? NSScreen.main else {
             return nil
         }
 
         return (screen, currentSize)
+    }
+
+    private static var axCoordinateBaseMaxY: CGFloat {
+        let mainDisplayID = CGMainDisplayID()
+        let mainDisplayScreen = NSScreen.screens.first { screen in
+            guard let screenNumber = screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? NSNumber else {
+                return false
+            }
+            return screenNumber.uint32Value == mainDisplayID
+        }
+
+        guard let primaryScreen = mainDisplayScreen ?? NSScreen.screens.first else {
+            return 0
+        }
+
+        return primaryScreen.frame.origin == .zero ? primaryScreen.frame.maxY : primaryScreen.frame.height
+    }
+
+    private static func bestScreen(for frame: CGRect) -> NSScreen? {
+        let intersectingScreens = NSScreen.screens.compactMap { screen -> (screen: NSScreen, area: CGFloat)? in
+            let intersection = screen.frame.intersection(frame)
+            guard !intersection.isNull, intersection.width > 0, intersection.height > 0 else {
+                return nil
+            }
+            return (screen, intersection.width * intersection.height)
+        }
+
+        if let bestMatch = intersectingScreens.max(by: { $0.area < $1.area })?.screen {
+            return bestMatch
+        }
+
+        let frameCenter = CGPoint(x: frame.midX, y: frame.midY)
+        return NSScreen.screens.min { first, second in
+            let firstCenter = CGPoint(x: first.frame.midX, y: first.frame.midY)
+            let secondCenter = CGPoint(x: second.frame.midX, y: second.frame.midY)
+            return frameCenter.distance(to: firstCenter) < frameCenter.distance(to: secondCenter)
+        }
     }
 
     static func currentWindowFrame(for element: AXUIElement) -> CGRect? {
@@ -280,10 +317,9 @@ extension WindowInfo {
             return nil
         }
 
-        let primaryScreenMaxY = NSScreen.screens.first?.frame.maxY ?? NSScreen.main?.frame.maxY ?? 0
         return CGRect(
             x: currentPosition.x,
-            y: primaryScreenMaxY - currentPosition.y - currentSize.height,
+            y: axCoordinateBaseMaxY - currentPosition.y - currentSize.height,
             width: currentSize.width,
             height: currentSize.height
         )
@@ -295,8 +331,7 @@ extension WindowInfo {
 
     @discardableResult
     private func applyWindowFrame(_ targetFrame: CGRect, on screen: NSScreen) -> CGRect? {
-        let primaryScreenMaxY = NSScreen.screens.first?.frame.maxY ?? screen.frame.maxY
-        let axY = primaryScreenMaxY - targetFrame.maxY
+        let axY = Self.axCoordinateBaseMaxY - targetFrame.maxY
         let newPosition = CGPoint(x: targetFrame.origin.x, y: axY)
         let newSize = CGSize(width: targetFrame.width, height: targetFrame.height)
 
@@ -313,7 +348,7 @@ extension WindowInfo {
 
     @discardableResult
     func setWindowFrame(_ targetFrame: CGRect) -> CGRect? {
-        guard let screen = NSScreen.screens.first(where: { $0.frame.intersects(targetFrame) })
+        guard let screen = Self.bestScreen(for: targetFrame)
             ?? currentWindowPlacementContext()?.screen
             ?? NSScreen.main
         else {

--- a/DockDoor/Utilities/Window Management/WindowInfo.swift
+++ b/DockDoor/Utilities/Window Management/WindowInfo.swift
@@ -168,7 +168,8 @@ extension WindowInfo {
         }
     }
 
-    func zoom() {
+    @discardableResult
+    func zoom() -> CGRect? {
         positionWindow(rect: .full)
     }
 
@@ -292,7 +293,8 @@ extension WindowInfo {
         Self.currentWindowFrame(for: axElement)
     }
 
-    private func applyWindowFrame(_ targetFrame: CGRect, on screen: NSScreen) {
+    @discardableResult
+    private func applyWindowFrame(_ targetFrame: CGRect, on screen: NSScreen) -> CGRect? {
         let primaryScreenMaxY = NSScreen.screens.first?.frame.maxY ?? screen.frame.maxY
         let axY = primaryScreenMaxY - targetFrame.maxY
         let newPosition = CGPoint(x: targetFrame.origin.x, y: axY)
@@ -301,32 +303,43 @@ extension WindowInfo {
         guard let positionValue = AXValue.from(point: newPosition),
               let sizeValue = AXValue.from(size: newSize)
         else {
-            return
+            return nil
         }
 
         try? axElement.setAttribute(kAXPositionAttribute, positionValue)
         try? axElement.setAttribute(kAXSizeAttribute, sizeValue)
+        return currentWindowFrame()
     }
 
-    func setWindowFrame(_ targetFrame: CGRect) {
+    @discardableResult
+    func setWindowFrame(_ targetFrame: CGRect) -> CGRect? {
         guard let screen = NSScreen.screens.first(where: { $0.frame.intersects(targetFrame) })
             ?? currentWindowPlacementContext()?.screen
             ?? NSScreen.main
         else {
-            return
+            return nil
         }
 
-        applyWindowFrame(targetFrame, on: screen)
+        return applyWindowFrame(targetFrame, on: screen)
     }
 
-    private func positionWindow(rect: WindowPositionRect) {
+    @discardableResult
+    private func positionWindow(rect: WindowPositionRect) -> CGRect? {
         guard let context = currentWindowPlacementContext() else {
-            return
+            return nil
         }
 
         let visibleFrame = context.screen.visibleFrame
         let targetFrame = rect.frame(in: visibleFrame, currentSize: context.size)
-        applyWindowFrame(targetFrame, on: context.screen)
+        return applyWindowFrame(targetFrame, on: context.screen)
+    }
+
+    func targetFrame(for rect: WindowPositionRect) -> CGRect? {
+        guard let context = currentWindowPlacementContext() else {
+            return nil
+        }
+
+        return rect.frame(in: context.screen.visibleFrame, currentSize: context.size)
     }
 
     func fillLeftHalf() {
@@ -365,31 +378,68 @@ extension WindowInfo {
         positionWindow(rect: .center)
     }
 
-    func centerWindow(scale: CGFloat) {
-        guard let context = currentWindowPlacementContext() else {
-            return
+    @discardableResult
+    func centerWindow(scale: CGFloat) -> CGRect? {
+        guard let context = currentWindowPlacementContext(),
+              let targetFrame = centeredWindowTargetFrame(scale: scale, context: context)
+        else {
+            return nil
         }
 
+        return applyWindowFrame(targetFrame, on: context.screen)
+    }
+
+    func centeredWindowTargetFrame(scale: CGFloat) -> CGRect? {
+        guard let context = currentWindowPlacementContext() else {
+            return nil
+        }
+
+        return centeredWindowTargetFrame(scale: scale, context: context)
+    }
+
+    private func centeredWindowTargetFrame(scale: CGFloat, context: (screen: NSScreen, size: CGSize)) -> CGRect? {
         let visibleFrame = context.screen.visibleFrame
         let clampedScale = min(max(scale, 0.2), 1.0)
         let targetSize = CGSize(
             width: visibleFrame.width * clampedScale,
             height: visibleFrame.height * clampedScale
         )
-        let targetFrame = WindowPositionRect.center.frame(in: visibleFrame, currentSize: targetSize)
-        applyWindowFrame(targetFrame, on: context.screen)
+        return WindowPositionRect.center.frame(in: visibleFrame, currentSize: targetSize)
     }
 
-    func centerWindow(widthScale: CGFloat, heightScale: CGFloat, lockAspectRatio: Bool) {
-        guard let context = currentWindowPlacementContext() else {
-            return
+    @discardableResult
+    func centerWindow(widthScale: CGFloat, heightScale: CGFloat, lockAspectRatio: Bool) -> CGRect? {
+        guard let context = currentWindowPlacementContext(),
+              let targetFrame = centeredWindowTargetFrame(
+                  widthScale: widthScale,
+                  heightScale: heightScale,
+                  lockAspectRatio: lockAspectRatio,
+                  context: context
+              )
+        else {
+            return nil
         }
 
-        let visibleFrame = context.screen.visibleFrame
+        return applyWindowFrame(targetFrame, on: context.screen)
+    }
 
+    func centeredWindowTargetFrame(widthScale: CGFloat, heightScale: CGFloat, lockAspectRatio: Bool) -> CGRect? {
+        guard let context = currentWindowPlacementContext() else {
+            return nil
+        }
+
+        return centeredWindowTargetFrame(
+            widthScale: widthScale,
+            heightScale: heightScale,
+            lockAspectRatio: lockAspectRatio,
+            context: context
+        )
+    }
+
+    private func centeredWindowTargetFrame(widthScale: CGFloat, heightScale: CGFloat, lockAspectRatio: Bool, context: (screen: NSScreen, size: CGSize)) -> CGRect? {
+        let visibleFrame = context.screen.visibleFrame
         let clampedWidthScale = min(max(widthScale, 0.2), 1.0)
         let clampedHeightScale = min(max(heightScale, 0.2), 1.0)
-
         let maxWidth = visibleFrame.width * clampedWidthScale
         let maxHeight = visibleFrame.height * clampedHeightScale
 
@@ -397,10 +447,7 @@ extension WindowInfo {
         if lockAspectRatio {
             let currentSize = context.size
             guard currentSize.width > 0, currentSize.height > 0 else {
-                targetSize = CGSize(width: maxWidth, height: maxHeight)
-                let targetFrame = WindowPositionRect.center.frame(in: visibleFrame, currentSize: targetSize)
-                applyWindowFrame(targetFrame, on: context.screen)
-                return
+                return WindowPositionRect.center.frame(in: visibleFrame, currentSize: CGSize(width: maxWidth, height: maxHeight))
             }
 
             let scaleFactor = min(maxWidth / currentSize.width, maxHeight / currentSize.height)
@@ -409,8 +456,7 @@ extension WindowInfo {
             targetSize = CGSize(width: maxWidth, height: maxHeight)
         }
 
-        let targetFrame = WindowPositionRect.center.frame(in: visibleFrame, currentSize: targetSize)
-        applyWindowFrame(targetFrame, on: context.screen)
+        return WindowPositionRect.center.frame(in: visibleFrame, currentSize: targetSize)
     }
 
     func bringToFront() {

--- a/DockDoor/Views/Settings/Gestures/DockScrollGestureSection.swift
+++ b/DockDoor/Views/Settings/Gestures/DockScrollGestureSection.swift
@@ -44,6 +44,7 @@ struct DockScrollGestureSection: View {
 
 struct TitleBarScrollGestureSection: View {
     @Default(.enableTitleBarScrollGesture) var enableTitleBarScrollGesture
+    @Default(.titleBarVerticalScrollBehavior) var titleBarVerticalScrollBehavior
     @Default(.titleBarScrollCenteredWindowScale) var titleBarScrollCenteredWindowScale
     @Default(.titleBarScrollCenteredWindowSizingMode) var titleBarScrollCenteredWindowSizingMode
     @Default(.titleBarScrollCenteredWindowWidthScale) var titleBarScrollCenteredWindowWidthScale
@@ -84,9 +85,17 @@ struct TitleBarScrollGestureSection: View {
                         set: { titleBarScrollRestoreWindowInterval = CGFloat($0) }
                     )
 
-                    Text("Scroll up on a focused window title bar to maximize it, scroll down to center it using the configured window size, and scroll left or right to switch desktop spaces. Repeat the same up/down scroll within the configured restore time to restore the previous window size.")
+                    Text(titleBarScrollDescription)
                         .font(.caption)
                         .foregroundColor(.secondary)
+
+                    Picker("Vertical Scroll Behavior", selection: $titleBarVerticalScrollBehavior) {
+                        ForEach(TitleBarVerticalScrollBehavior.allCases, id: \.self) { behavior in
+                            Text(behavior.localizedName).tag(behavior)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+                    .settingsSearchTarget("gestures.verticalScrollBehavior")
 
                     Picker("Centered Window Sizing", selection: $titleBarScrollCenteredWindowSizingMode) {
                         ForEach(TitleBarCenteredWindowSizingMode.allCases, id: \.self) { mode in
@@ -143,17 +152,28 @@ struct TitleBarScrollGestureSection: View {
                         }
                     }
 
-                    sliderSetting(
-                        title: "Restore Window Time",
-                        value: restoreIntervalBinding,
-                        range: 0.5 ... 3,
-                        step: 0.1,
-                        unit: "seconds",
-                        formatter: NumberFormatter.oneDecimalFormatter
-                    )
-                    .settingsSearchTarget("gestures.restoreTime")
+                    if titleBarVerticalScrollBehavior == .resizeAndCenter {
+                        sliderSetting(
+                            title: "Restore Window Time",
+                            value: restoreIntervalBinding,
+                            range: 0.5 ... 3,
+                            step: 0.1,
+                            unit: "seconds",
+                            formatter: NumberFormatter.oneDecimalFormatter
+                        )
+                        .settingsSearchTarget("gestures.restoreTime")
+                    }
                 }
             }
+        }
+    }
+
+    private var titleBarScrollDescription: String {
+        switch titleBarVerticalScrollBehavior {
+        case .resizeAndCenter:
+            String(localized: "Scroll up on a focused window title bar to maximize it, scroll down to center it using the configured window size, and scroll left or right to switch desktop spaces. Repeat the same up/down scroll within the configured restore time to restore the previous window size.")
+        case .maximizeAndRestore:
+            String(localized: "Scroll up on a focused window title bar to maximize it and remember the original size. Scroll down to restore the remembered size; if no remembered size exists, the window is centered using the configured size. Scroll left or right to switch desktop spaces.")
         }
     }
 }

--- a/DockDoor/Views/Settings/Search/SettingsSearchCatalog.swift
+++ b/DockDoor/Views/Settings/Search/SettingsSearchCatalog.swift
@@ -1194,6 +1194,15 @@ enum SettingsSearchCatalog {
         ),
         // Title Bar Scroll - additional
         SettingsSearchItem(
+            id: "gestures.verticalScrollBehavior",
+            title: String(localized: "Vertical Scroll Behavior"),
+            description: String(localized: "Choose how vertical title bar scroll gestures resize, center, maximize, and restore windows."),
+            keywords: ["vertical", "scroll", "behavior", "maximize", "restore", "center"],
+            tab: "GesturesKeybinds",
+            section: String(localized: "Title Bar Scroll Gesture"),
+            icon: "arrow.up.arrow.down.square"
+        ),
+        SettingsSearchItem(
             id: "gestures.centeredSizingMode",
             title: String(localized: "Centered Window Sizing"),
             keywords: ["centered", "sizing", "uniform", "separate"],

--- a/DockDoor/consts.swift
+++ b/DockDoor/consts.swift
@@ -43,12 +43,14 @@ extension Defaults.Keys {
     static let quitAppOnWindowClose = Key<Bool>("quitAppOnWindowClose", default: false)
     static let enableDockScrollGesture = Key<Bool>("enableDockScrollGesture", default: false)
     static let enableTitleBarScrollGesture = Key<Bool>("enableTitleBarScrollGesture", default: false)
+    static let titleBarVerticalScrollBehavior = Key<TitleBarVerticalScrollBehavior>("titleBarVerticalScrollBehavior", default: .resizeAndCenter)
     static let titleBarScrollCenteredWindowScale = Key<CGFloat>("titleBarScrollCenteredWindowScale", default: 0.8)
     static let titleBarScrollCenteredWindowSizingMode = Key<TitleBarCenteredWindowSizingMode>("titleBarScrollCenteredWindowSizingMode", default: .uniform)
     static let titleBarScrollCenteredWindowWidthScale = Key<CGFloat>("titleBarScrollCenteredWindowWidthScale", default: 0.8)
     static let titleBarScrollCenteredWindowHeightScale = Key<CGFloat>("titleBarScrollCenteredWindowHeightScale", default: 0.8)
     static let titleBarScrollCenteredWindowLockAspectRatio = Key<Bool>("titleBarScrollCenteredWindowLockAspectRatio", default: false)
     static let titleBarScrollRestoreWindowInterval = Key<CGFloat>("titleBarScrollRestoreWindowInterval", default: 1.5)
+    static let titleBarScrollPersistentRestoreFrames = Key<[TitleBarScrollPersistentRestoreFrame]>("titleBarScrollPersistentRestoreFrames", default: [])
 
     // Dock Locking
     static let enableDockLocking = Key<Bool>("enableDockLocking", default: false)
@@ -758,6 +760,48 @@ enum TitleBarCenteredWindowSizingMode: String, CaseIterable, Defaults.Serializab
         case .separate:
             String(localized: "Width & height", comment: "Title bar centered window sizing mode")
         }
+    }
+}
+
+enum TitleBarVerticalScrollBehavior: String, CaseIterable, Defaults.Serializable {
+    case resizeAndCenter
+    case maximizeAndRestore
+
+    var localizedName: String {
+        switch self {
+        case .resizeAndCenter:
+            String(localized: "Resize & Center", comment: "Title bar vertical scroll behavior option")
+        case .maximizeAndRestore:
+            String(localized: "Maximize & Restore", comment: "Title bar vertical scroll behavior option")
+        }
+    }
+}
+
+struct TitleBarScrollPersistentRestoreFrame: Codable, Defaults.Serializable, Equatable {
+    let bundleIdentifier: String
+    let windowTitle: String
+    let x: Double
+    let y: Double
+    let width: Double
+    let height: Double
+    let updatedAt: Date
+
+    var identityKey: String {
+        "\(bundleIdentifier)|\(windowTitle)"
+    }
+
+    var originalFrame: CGRect {
+        CGRect(x: x, y: y, width: width, height: height)
+    }
+
+    init(bundleIdentifier: String, windowTitle: String, originalFrame: CGRect, updatedAt: Date) {
+        self.bundleIdentifier = bundleIdentifier
+        self.windowTitle = windowTitle
+        x = Double(originalFrame.origin.x)
+        y = Double(originalFrame.origin.y)
+        width = Double(originalFrame.width)
+        height = Double(originalFrame.height)
+        self.updatedAt = updatedAt
     }
 }
 


### PR DESCRIPTION
## Describe your changes
This PR improves title bar scroll gestures on focused windows.

It adds a vertical scroll behavior setting so users can keep the existing timed resize/center behavior or use a maximize/restore flow that remembers the original window frame. It also validates applied window frames before storing restore state, so constrained windows do not leave stale restore data behind.

Follow-up update: this PR also fixes restore behavior across multiple displays. When a window is moved to another display after a restore frame already exists, maximize/restore mode now refreshes the restore frame from the window's current display instead of reusing stale coordinates from the previous display. Restore success now checks both size and position, and AX/AppKit frame conversion uses a stable main-display coordinate base with better screen matching.

The change keeps the title bar scroll settings discoverable through settings search and preserves the existing centered window sizing controls.

## Related issue number(s) and link(s)

None.

## Checklist before requesting a review
- [x] I have performed a self-review of my code and understand every line
- [x] If this change affects core functionality, I have added a description highlighting the changes
- [x] I have followed conventional commit guidelines
- [ ] I have tested this PR on my own machine

## AI Assistance Disclosure

> **Policy**: AI-assisted contributions are welcome, but you must understand, test, and take full responsibility for your code. Pasting AI-generated code or PR descriptions without genuine human review and understanding will result in your PR being closed and may result in a ban from contributing.

**Did you use AI tools (ChatGPT, Claude, Copilot, Cursor, etc.) for this PR?**
- [ ] No AI tools were used
- [x] Yes - describe below how AI was used and confirm you reviewed/tested the output

Used ChatGPT/Codex to help rebase the branch, resolve conflicts against upstream `main`, update the multi-display title bar scroll restore fix, and prepare the PR description. I reviewed the resulting diff and verified the final branch state with Git checks.

## Core Functionality Changes
This changes title bar scroll handling:

- Horizontal title bar scrolling still switches Spaces.
- Vertical title bar scrolling can now either use the existing timed resize/center restore flow or a persistent maximize/restore flow.
- Maximize/restore mode records the original window frame and restores it on downward scroll.
- Frame application is checked before restore state is stored, which avoids keeping invalid restore data for windows that reject the requested size.
- Moving a window between displays now refreshes the remembered restore frame on the next maximize action.
- Restore validation now compares position as well as size, avoiding false success when a frame lands on the wrong display.
- Window frame read/write conversion now uses the main display coordinate base and chooses the target screen by best frame overlap.
- The new vertical scroll behavior setting is indexed in settings search.


