### PR TITLE
feat: add optional Stage Manager preview optimization

### DIFF
--- a/DockDoor/Extensions/AXUIElement.swift
+++ b/DockDoor/Extensions/AXUIElement.swift
@@ -97,7 +97,10 @@ extension AXUIElement {
             let windows = DebugLogger.measureSlow("appElement.windows()", thresholdMs: 50, details: "PID: \(pid)") {
                 try? appElement.windows()
             }
-            if let windows { set.formUnion(windows) }
+            if let windows, !windows.isEmpty {
+                set.formUnion(windows)
+                return Array(set)
+            }
 
             let brute = windowsByBruteForce(pid)
             set.formUnion(brute)

--- a/DockDoor/Utilities/UpdaterState.swift
+++ b/DockDoor/Utilities/UpdaterState.swift
@@ -31,7 +31,7 @@ final class UpdaterState: NSObject, SPUUpdaterDelegate, ObservableObject {
 
     @Published var updateStatus: UpdateStatus = .noUpdates {
         didSet {
-            print("UpdaterState: updateStatus changed to: \(updateStatus)")
+            DebugLogger.log("UpdaterState", details: "updateStatus changed to: \(updateStatus)")
         }
     }
 
@@ -40,7 +40,7 @@ final class UpdaterState: NSObject, SPUUpdaterDelegate, ObservableObject {
             bindUpdaterProperties()
             if let updater {
                 isAutomaticChecksEnabled = updater.automaticallyChecksForUpdates
-                print("UpdaterState: Initialized with \(updateChannel.displayName)")
+                DebugLogger.log("UpdaterState", details: "Initialized with \(updateChannel.displayName)")
             }
         }
     }
@@ -122,7 +122,7 @@ final class UpdaterState: NSObject, SPUUpdaterDelegate, ObservableObject {
         // Reset update status when switching channels
         updateStatus = .noUpdates
 
-        print("UpdaterState: Switched to \(channel.displayName) channel")
+        DebugLogger.log("UpdaterState", details: "Switched to \(channel.displayName) channel")
     }
 
     func updater(_ updater: SPUUpdater, didFindValidUpdate item: SUAppcastItem) {
@@ -182,6 +182,6 @@ final class UpdaterState: NSObject, SPUUpdaterDelegate, ObservableObject {
     }
 
     func updater(_ updater: SPUUpdater, willShowModalAlert alert: NSAlert) {
-        print("UpdaterState (SPUUpdaterDelegate): updater:willShowModalAlert. Alert: \(alert.messageText)")
+        DebugLogger.log("UpdaterState", details: "updater:willShowModalAlert. Alert: \(alert.messageText)")
     }
 }

--- a/DockDoor/Utilities/Window Management/LiveWindowCapture.swift
+++ b/DockDoor/Utilities/Window Management/LiveWindowCapture.swift
@@ -175,6 +175,8 @@ final class WindowLiveCapture: ObservableObject {
     }
 
     private func startStream(for window: SCWindow) async {
+        guard isWindowVisibleOnAnyScreen(window) else { return }
+
         let filter = SCContentFilter(desktopIndependentWindow: window)
 
         let config = SCStreamConfiguration()
@@ -269,6 +271,11 @@ final class WindowLiveCapture: ObservableObject {
         guard stopGeneration == generationAtStop else { return }
 
         await stopAndCleanup()
+    }
+
+    private func isWindowVisibleOnAnyScreen(_ window: SCWindow) -> Bool {
+        guard !window.frame.isEmpty else { return false }
+        return NSScreen.screens.contains { $0.frame.intersects(window.frame) }
     }
 
     func stopCapture() async {

--- a/DockDoor/Utilities/Window Management/WindowInfo.swift
+++ b/DockDoor/Utilities/Window Management/WindowInfo.swift
@@ -423,18 +423,13 @@ extension WindowInfo {
 
         func attemptActivation() -> Bool {
             do {
-                var psn = ProcessSerialNumber()
-                _ = GetProcessForPID(app.processIdentifier, &psn)
-                _ = _SLPSSetFrontProcessWithOptions(&psn, UInt32(id), SLPSMode.userGenerated.rawValue)
-
-                WindowUtil.makeKeyWindow(&psn, windowID: id)
-
+                app.activate(options: [.activateIgnoringOtherApps])
                 try axElement.performAction(kAXRaiseAction)
                 try axElement.setAttribute(kAXMainWindowAttribute, true)
 
                 return true
             } catch {
-                print("Attempt \(retryCount + 1) failed to bring window to front: \(error)")
+                DebugLogger.log("WindowInfo", details: "Attempt \(retryCount + 1) failed to bring window to front: \(error)")
                 if error is AxError {
                     WindowUtil.removeWindowFromDesktopSpaceCache(with: id, in: app.processIdentifier)
                 }
@@ -453,7 +448,7 @@ extension WindowInfo {
             }
         }
 
-        print("Failed to bring window to front after \(maxRetries) attempts")
+        DebugLogger.log("WindowInfo", details: "Failed to bring window to front after \(maxRetries) attempts")
     }
 
     func warpMouseToCenterIfNeeded() {

--- a/DockDoor/Utilities/Window Management/WindowUtil.swift
+++ b/DockDoor/Utilities/Window Management/WindowUtil.swift
@@ -283,9 +283,14 @@ enum WindowUtil {
         let cacheLifespan = Defaults[.screenCaptureCacheLifespan]
         let windows = cachedWindows ?? desktopSpaceWindowCacheManager.readCache(pid: pid)
         return Set(windows.compactMap { window -> CGWindowID? in
-            guard window.image != nil,
+            guard let image = window.image,
                   Date().timeIntervalSince(window.imageCapturedTime) <= cacheLifespan
             else { return nil }
+            if stageManagerOptimizationEnabled,
+               isLikelyBadStageManagerCapture(image, axWindow: window.axElement)
+            {
+                return nil
+            }
             return window.id
         })
     }
@@ -300,6 +305,10 @@ enum WindowUtil {
         code: 1,
         userInfo: [NSLocalizedDescriptionKey: "Error encountered during image capture"]
     )
+
+    private static var stageManagerOptimizationEnabled: Bool {
+        Defaults[.stageManagerOptimization]
+    }
 }
 
 // MARK: - Cache Management
@@ -410,6 +419,39 @@ extension WindowUtil {
         )
     }
 
+    private static func captureWindowImage(window: SCWindow, axWindow: AXUIElement, transformedThumbnail: Bool, forceRefresh: Bool = false) async throws -> CGImage {
+        if transformedThumbnail {
+            guard let pid = window.owningApplication?.processID else {
+                throw captureError
+            }
+            return try captureTransformedWindowImage(
+                windowID: window.windowID,
+                pid: pid,
+                windowTitle: window.title,
+                axWindow: axWindow
+            )
+        }
+        return try await captureWindowImage(window: window, forceRefresh: forceRefresh)
+    }
+
+    private static func captureTransformedWindowImage(windowID: CGWindowID, pid: pid_t, windowTitle: String?, axWindow: AXUIElement) throws -> CGImage {
+        if let cachedImage = cachedWindowImage(windowID: windowID, pid: pid, windowTitle: windowTitle),
+           !isLikelyBadStageManagerCapture(cachedImage, axWindow: axWindow)
+        {
+            return cachedImage
+        }
+
+        throw captureError
+    }
+
+    private static func cachedWindowImage(windowID: CGWindowID, pid: pid_t, windowTitle: String?) -> CGImage? {
+        let cachedWindows = desktopSpaceWindowCacheManager.readCache(pid: pid)
+        if let exactMatch = cachedWindows.first(where: { $0.id == windowID && (windowTitle == nil || $0.windowName == windowTitle) }) {
+            return exactMatch.image
+        }
+        return cachedWindows.first(where: { $0.id == windowID })?.image
+    }
+
     static func captureWindowImage(windowID: CGWindowID, pid: pid_t, windowTitle: String? = nil, forceRefresh: Bool = false) async throws -> CGImage {
         // CGSHWCaptureWindowList requires screen recording permission
         guard hasScreenRecordingPermission() else {
@@ -423,7 +465,11 @@ extension WindowUtil {
                 let cachedImage = cachedWindow.image
             {
                 let cacheLifespan = Defaults[.screenCaptureCacheLifespan]
-                if Date().timeIntervalSince(cachedWindow.imageCapturedTime) <= cacheLifespan {
+                let cachedImageIsUsable = !stageManagerOptimizationEnabled ||
+                    !isLikelyBadStageManagerCapture(cachedImage, axWindow: cachedWindow.axElement)
+                if cachedImageIsUsable,
+                   Date().timeIntervalSince(cachedWindow.imageCapturedTime) <= cacheLifespan
+                {
                     return cachedImage
                 }
             }
@@ -869,9 +915,13 @@ extension WindowUtil {
     static func captureAndCacheWindowInfo(window: SCWindow, app: NSRunningApplication, skipWindowIDs: Set<CGWindowID> = []) async throws {
         let windowID = window.windowID
         let pid = app.processIdentifier
+        let appElement = AXUIElementCreateApplication(pid)
+        let stageManagerOptimizationEnabled = Self.stageManagerOptimizationEnabled
 
         // Fast path: skip if pre-computed by caller as fresh cached
-        if skipWindowIDs.contains(windowID) { return }
+        if skipWindowIDs.contains(windowID),
+           !stageManagerOptimizationEnabled || !isFocusedWindow(appAxElement: appElement, app: app, windowID: windowID)
+        { return }
 
         guard window.owningApplication != nil,
               window.isOnScreen,
@@ -919,8 +969,6 @@ extension WindowUtil {
             }
         }
 
-        let appElement = AXUIElementCreateApplication(pid)
-
         guard let axWindows = try? appElement.windows(), !axWindows.isEmpty else {
             return
         }
@@ -958,9 +1006,21 @@ extension WindowUtil {
                 isHidden: hiddenState
             )
 
-            if let image = try? await captureWindowImage(window: window) {
-                windowInfo.image = image
-                windowInfo.imageCapturedTime = Date()
+            if stageManagerOptimizationEnabled {
+                let focusedWindow = isFocusedWindow(windowRef, appAxElement: appElement, app: app, windowID: window.windowID)
+                let transformedThumbnail = !focusedWindow &&
+                    isLikelyTransformedThumbnail(frame: window.frame, axWindow: windowRef)
+                if let image = try? await captureWindowImage(window: window, axWindow: windowRef, transformedThumbnail: transformedThumbnail, forceRefresh: focusedWindow) {
+                    if focusedWindow || !isLikelyBadStageManagerCapture(image, axWindow: windowRef) {
+                        windowInfo.image = image
+                        windowInfo.imageCapturedTime = Date()
+                    }
+                }
+            } else {
+                if let image = try? await captureWindowImage(window: window) {
+                    windowInfo.image = image
+                    windowInfo.imageCapturedTime = Date()
+                }
             }
             updateDesktopSpaceWindowCache(with: windowInfo)
         }
@@ -975,12 +1035,15 @@ extension WindowUtil {
         existingCachedIDs: Set<CGWindowID> = []
     ) async throws {
         let pid = app.processIdentifier
+        let stageManagerOptimizationEnabled = Self.stageManagerOptimizationEnabled
 
         // Quick window ID check first (fast path)
         var cgID: CGWindowID = 0
         if _AXUIElementGetWindow(axWindow, &cgID) == .success, cgID != 0 {
             // Skip if already cached with fresh image (pre-computed by caller)
-            if skipWindowIDs.contains(cgID) { return }
+            if skipWindowIDs.contains(cgID),
+               !stageManagerOptimizationEnabled || !isFocusedWindow(appAxElement: appAxElement, app: app, windowID: cgID)
+            { return }
             guard !excludeWindowIDs.contains(cgID) else { return }
         }
 
@@ -1050,7 +1113,32 @@ extension WindowUtil {
         )
         info.windowName = windowTitle
 
-        if let image = try? await captureWindowImage(windowID: cgID, pid: pid, windowTitle: windowTitle) {
+        if stageManagerOptimizationEnabled {
+            let focusedWindow = isFocusedWindow(axWindow, appAxElement: appAxElement, app: app, windowID: cgID)
+            let transformedThumbnail: Bool = if focusedWindow {
+                false
+            } else if let frame = cgFrame(from: cgEntry) {
+                isLikelyTransformedThumbnail(frame: frame, axWindow: axWindow)
+            } else {
+                false
+            }
+
+            let image: CGImage? = if transformedThumbnail {
+                try? captureTransformedWindowImage(
+                    windowID: cgID,
+                    pid: pid,
+                    windowTitle: windowTitle,
+                    axWindow: axWindow
+                )
+            } else {
+                try? await captureWindowImage(windowID: cgID, pid: pid, windowTitle: windowTitle, forceRefresh: focusedWindow)
+            }
+
+            if let image, focusedWindow || !isLikelyBadStageManagerCapture(image, axWindow: axWindow) {
+                info.image = image
+                info.imageCapturedTime = Date()
+            }
+        } else if let image = try? await captureWindowImage(windowID: cgID, pid: pid, windowTitle: windowTitle) {
             info.image = image
             info.imageCapturedTime = Date()
         }
@@ -1059,8 +1147,173 @@ extension WindowUtil {
     }
 
     private static let minUsableImageDimension = 10
+    private static let transformedThumbnailAreaRatioThreshold: CGFloat = 0.65
+    private static let sparseCaptureSampleSize = 96
+    private static let sparseCaptureContentAreaThreshold: CGFloat = 0.35
+    private static let sparseCaptureContentPixelThreshold: CGFloat = 0.20
+    private static let undersizedCaptureAreaRatioThreshold: CGFloat = 0.45
+    private static let undersizedCaptureDimensionRatioThreshold: CGFloat = 0.65
+
+    private static func cgFrame(from cgEntry: [String: AnyObject]) -> CGRect? {
+        guard let bounds = cgEntry[kCGWindowBounds as String] as? [String: AnyObject] else { return nil }
+        let x = CGFloat((bounds["X"] as? NSNumber)?.doubleValue ?? 0)
+        let y = CGFloat((bounds["Y"] as? NSNumber)?.doubleValue ?? 0)
+        let width = CGFloat((bounds["Width"] as? NSNumber)?.doubleValue ?? 0)
+        let height = CGFloat((bounds["Height"] as? NSNumber)?.doubleValue ?? 0)
+        guard width > 0, height > 0 else { return nil }
+        return CGRect(x: x, y: y, width: width, height: height)
+    }
+
+    private static func isLikelyTransformedThumbnail(frame: CGRect, axWindow: AXUIElement) -> Bool {
+        guard let axSize = try? axWindow.size(),
+              axSize.width > 0,
+              axSize.height > 0,
+              frame.width > 0,
+              frame.height > 0
+        else { return false }
+
+        let areaRatio = (frame.width * frame.height) / (axSize.width * axSize.height)
+        let widthDelta = axSize.width - frame.width
+        let heightDelta = axSize.height - frame.height
+        return areaRatio < transformedThumbnailAreaRatioThreshold && (widthDelta > 120 || heightDelta > 120)
+    }
+
+    private static func isFocusedWindow(_ axWindow: AXUIElement, appAxElement: AXUIElement, app: NSRunningApplication, windowID: CGWindowID) -> Bool {
+        guard isAppFrontmost(app) else { return false }
+        guard let focusedWindow = try? appAxElement.focusedWindow() else { return false }
+        if CFEqual(focusedWindow, axWindow) { return true }
+        return (try? focusedWindow.cgWindowId()) == windowID
+    }
+
+    private static func isFocusedWindow(appAxElement: AXUIElement, app: NSRunningApplication, windowID: CGWindowID) -> Bool {
+        guard isAppFrontmost(app) else { return false }
+        guard let focusedWindow = try? appAxElement.focusedWindow() else { return false }
+        return (try? focusedWindow.cgWindowId()) == windowID
+    }
+
+    private static func isAppFrontmost(_ app: NSRunningApplication) -> Bool {
+        guard app.isActive || NSWorkspace.shared.frontmostApplication?.processIdentifier == app.processIdentifier else { return false }
+        return true
+    }
+
+    private static func isLikelyBadStageManagerCapture(_ image: CGImage, axWindow: AXUIElement) -> Bool {
+        isLikelyUndersizedStageManagerCapture(image, axWindow: axWindow) || isLikelySparseStageManagerCapture(image)
+    }
+
+    private static func isLikelyUndersizedStageManagerCapture(_ image: CGImage, axWindow: AXUIElement) -> Bool {
+        guard let axSize = try? axWindow.size(),
+              axSize.width > 0,
+              axSize.height > 0,
+              image.width > 0,
+              image.height > 0
+        else { return false }
+
+        let previewScale = max(1, Defaults[.windowPreviewImageScale])
+        let expectedWidth = axSize.width / previewScale
+        let expectedHeight = axSize.height / previewScale
+        guard expectedWidth > 0, expectedHeight > 0 else { return false }
+
+        let widthRatio = CGFloat(image.width) / expectedWidth
+        let heightRatio = CGFloat(image.height) / expectedHeight
+        let areaRatio = (CGFloat(image.width) * CGFloat(image.height)) / (expectedWidth * expectedHeight)
+
+        return areaRatio < undersizedCaptureAreaRatioThreshold &&
+            (widthRatio < undersizedCaptureDimensionRatioThreshold || heightRatio < undersizedCaptureDimensionRatioThreshold)
+    }
+
+    private static func isLikelySparseStageManagerCapture(_ image: CGImage) -> Bool {
+        let sampleSize = sparseCaptureSampleSize
+        let bytesPerPixel = 4
+        let bytesPerRow = sampleSize * bytesPerPixel
+        var pixels = [UInt8](repeating: 0, count: sampleSize * bytesPerRow)
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        let bitmapInfo = CGImageAlphaInfo.premultipliedLast.rawValue
+
+        let rendered = pixels.withUnsafeMutableBytes { buffer in
+            guard let baseAddress = buffer.baseAddress,
+                  let context = CGContext(
+                      data: baseAddress,
+                      width: sampleSize,
+                      height: sampleSize,
+                      bitsPerComponent: 8,
+                      bytesPerRow: bytesPerRow,
+                      space: colorSpace,
+                      bitmapInfo: bitmapInfo
+                  )
+            else { return false }
+
+            context.interpolationQuality = .low
+            context.draw(image, in: CGRect(x: 0, y: 0, width: sampleSize, height: sampleSize))
+            return true
+        }
+        guard rendered else { return false }
+
+        let background = averageCornerColor(in: pixels, sampleSize: sampleSize, bytesPerRow: bytesPerRow)
+        var minX = sampleSize
+        var minY = sampleSize
+        var maxX = -1
+        var maxY = -1
+        var contentPixels = 0
+
+        for y in 0 ..< sampleSize {
+            for x in 0 ..< sampleSize {
+                let offset = y * bytesPerRow + x * bytesPerPixel
+                let alpha = pixels[offset + 3]
+                guard alpha > 16 else { continue }
+
+                let distance = abs(Int(pixels[offset]) - background.red) +
+                    abs(Int(pixels[offset + 1]) - background.green) +
+                    abs(Int(pixels[offset + 2]) - background.blue)
+                guard distance > 60 else { continue }
+
+                contentPixels += 1
+                minX = min(minX, x)
+                minY = min(minY, y)
+                maxX = max(maxX, x)
+                maxY = max(maxY, y)
+            }
+        }
+
+        guard contentPixels > 0, maxX >= minX, maxY >= minY else { return false }
+
+        let totalArea = CGFloat(sampleSize * sampleSize)
+        let contentArea = CGFloat((maxX - minX + 1) * (maxY - minY + 1)) / totalArea
+        let contentPixelRatio = CGFloat(contentPixels) / totalArea
+        return contentArea < sparseCaptureContentAreaThreshold && contentPixelRatio < sparseCaptureContentPixelThreshold
+    }
+
+    private static func averageCornerColor(in pixels: [UInt8], sampleSize: Int, bytesPerRow: Int) -> (red: Int, green: Int, blue: Int) {
+        let cornerSize = 8
+        let bytesPerPixel = 4
+        var red = 0
+        var green = 0
+        var blue = 0
+        var count = 0
+
+        func accumulate(xRange: Range<Int>, yRange: Range<Int>) {
+            for y in yRange {
+                for x in xRange {
+                    let offset = y * bytesPerRow + x * bytesPerPixel
+                    red += Int(pixels[offset])
+                    green += Int(pixels[offset + 1])
+                    blue += Int(pixels[offset + 2])
+                    count += 1
+                }
+            }
+        }
+
+        accumulate(xRange: 0 ..< cornerSize, yRange: 0 ..< cornerSize)
+        accumulate(xRange: sampleSize - cornerSize ..< sampleSize, yRange: 0 ..< cornerSize)
+        accumulate(xRange: 0 ..< cornerSize, yRange: sampleSize - cornerSize ..< sampleSize)
+        accumulate(xRange: sampleSize - cornerSize ..< sampleSize, yRange: sampleSize - cornerSize ..< sampleSize)
+
+        guard count > 0 else { return (0, 0, 0) }
+        return (red / count, green / count, blue / count)
+    }
 
     static func updateDesktopSpaceWindowCache(with windowInfo: WindowInfo) {
+        let stageManagerOptimizationEnabled = Self.stageManagerOptimizationEnabled
+
         desktopSpaceWindowCacheManager.updateCache(pid: windowInfo.app.processIdentifier) { windowSet in
             if let matchingWindow = windowSet.first(where: { $0.axElement == windowInfo.axElement }) {
                 var matchingWindowCopy = matchingWindow
@@ -1080,7 +1333,21 @@ extension WindowUtil {
                     true
                 }
 
-                if newImageIsTiny, matchingWindow.image != nil {
+                let newImageIsBadStageManagerCapture = stageManagerOptimizationEnabled && (windowInfo.image.map {
+                    isLikelyBadStageManagerCapture($0, axWindow: windowInfo.axElement)
+                } ?? true)
+
+                if stageManagerOptimizationEnabled, newImageIsTiny || newImageIsBadStageManagerCapture {
+                    if let existingImage = matchingWindow.image,
+                       isLikelyBadStageManagerCapture(existingImage, axWindow: matchingWindow.axElement)
+                    {
+                        matchingWindowCopy.image = nil
+                        matchingWindowCopy.imageCapturedTime = windowInfo.imageCapturedTime
+                    } else if matchingWindow.image == nil {
+                        matchingWindowCopy.image = nil
+                        matchingWindowCopy.imageCapturedTime = windowInfo.imageCapturedTime
+                    }
+                } else if newImageIsTiny, matchingWindow.image != nil {
                     // Keep the existing cached image instead of replacing with a degenerate one
                 } else {
                     matchingWindowCopy.image = windowInfo.image
@@ -1090,7 +1357,14 @@ extension WindowUtil {
                 windowSet.remove(matchingWindow)
                 windowSet.insert(matchingWindowCopy)
             } else {
-                windowSet.insert(windowInfo)
+                var windowToInsert = windowInfo
+                if stageManagerOptimizationEnabled,
+                   let image = windowToInsert.image,
+                   isLikelyBadStageManagerCapture(image, axWindow: windowToInsert.axElement)
+                {
+                    windowToInsert.image = nil
+                }
+                windowSet.insert(windowToInsert)
             }
         }
     }
@@ -1293,6 +1567,8 @@ extension WindowUtil {
     }
 
     static func openNewWindow(app: NSRunningApplication) {
+        guard app.activationPolicy == .regular, !app.isTerminated else { return }
+
         let source = CGEventSource(stateID: .combinedSessionState)
         let keyDown = CGEvent(keyboardEventSource: source, virtualKey: 0x2D, keyDown: true)
         keyDown?.flags = .maskCommand

--- a/DockDoor/Views/Hover Window/Shared Components/SharedPreviewWindowCoordinator.swift
+++ b/DockDoor/Views/Hover Window/Shared Components/SharedPreviewWindowCoordinator.swift
@@ -25,6 +25,7 @@ final class SharedPreviewWindowCoordinator: NSPanel {
     private var onWindowTap: (() -> Void)?
     private var fullPreviewWindow: NSPanel?
     private var pendingShowWorkItem: DispatchWorkItem?
+    private var pendingFrameRefreshWorkItem: DispatchWorkItem?
 
     var windowSize: CGSize = getWindowSize()
 
@@ -78,7 +79,9 @@ final class SharedPreviewWindowCoordinator: NSPanel {
 
     private func setupFrameRefreshObserver() {
         windowSwitcherCoordinator.onFrameRefreshNeeded = { [weak self] in
-            self?.refreshPanelFrameToFitContent()
+            DispatchQueue.main.async {
+                self?.schedulePanelFrameRefresh()
+            }
         }
     }
 
@@ -168,12 +171,19 @@ final class SharedPreviewWindowCoordinator: NSPanel {
     }
 
     /// Refreshes the panel frame to match SwiftUI content's intrinsic size after window count changes.
-    @MainActor
+    private func schedulePanelFrameRefresh() {
+        pendingFrameRefreshWorkItem?.cancel()
+        let workItem = DispatchWorkItem { [weak self] in
+            self?.refreshPanelFrameToFitContent()
+        }
+        pendingFrameRefreshWorkItem = workItem
+        DispatchQueue.main.async(execute: workItem)
+    }
+
     private func refreshPanelFrameToFitContent() {
         guard let hostingView = contentView else { return }
 
-        hostingView.layoutSubtreeIfNeeded()
-        let fittingSize = hostingView.fittingSize
+        let fittingSize = measuredContentSize(for: hostingView)
 
         let screen = NSScreen.screenFromQuartzPoint(NSEvent.mouseLocation)
         let screenFrame = screen.frame
@@ -216,6 +226,14 @@ final class SharedPreviewWindowCoordinator: NSPanel {
         }
     }
 
+    private func measuredContentSize(for view: NSView) -> CGSize {
+        let expectedSize = windowSwitcherCoordinator.expectedContentSize
+        if expectedSize.width > 0, expectedSize.height > 0 {
+            return expectedSize
+        }
+        return view.fittingSize
+    }
+
     @MainActor
     private func performShowView(_ view: some View,
                                  mouseLocation: CGPoint?,
@@ -226,12 +244,6 @@ final class SharedPreviewWindowCoordinator: NSPanel {
                                  dockItemFrameOverride: CGRect? = nil)
     {
         let hostingView = NSHostingView(rootView: view)
-
-        if let oldContentView = contentView {
-            oldContentView.removeFromSuperview()
-        }
-        contentView = hostingView
-
         let newHoverWindowSize = hostingView.fittingSize
         let position: CGPoint
 
@@ -259,6 +271,11 @@ final class SharedPreviewWindowCoordinator: NSPanel {
         } else {
             position = centerWindowOnScreen(size: newHoverWindowSize, screen: mouseScreen)
         }
+
+        if let oldContentView = contentView {
+            oldContentView.removeFromSuperview()
+        }
+        contentView = hostingView
 
         let finalFrame = CGRect(origin: position, size: newHoverWindowSize)
         applyWindowFrame(finalFrame, animated: true, dockPositionOverride: dockPositionOverride)
@@ -300,20 +317,12 @@ final class SharedPreviewWindowCoordinator: NSPanel {
                                                     hasScreenRecordingPermission: hasScreenRecordingPermission)
         let newHostingView = NSHostingView(rootView: hoverView)
 
-        if let oldContentView = contentView {
-            oldContentView.removeFromSuperview()
-        }
-        contentView = newHostingView
-
-        let previousFrame = frame
-        setFrame(CGRect(origin: previousFrame.origin, size: CGSize(width: 1, height: 1)), display: false)
-
         elapsed = renderStartTime.map { (CFAbsoluteTimeGetCurrent() - $0) * 1000 } ?? 0
         DebugLogger.log("PreviewRender", details: "calculating fittingSize (+\(String(format: "%.1f", elapsed))ms)")
 
         let newHoverWindowSize: CGSize
         do {
-            let fittingSize = newHostingView.fittingSize
+            let fittingSize = measuredContentSize(for: newHostingView)
 
             elapsed = renderStartTime.map { (CFAbsoluteTimeGetCurrent() - $0) * 1000 } ?? 0
             DebugLogger.log("PreviewRender", details: "fittingSize done: \(fittingSize) (+\(String(format: "%.1f", elapsed))ms)")
@@ -344,6 +353,12 @@ final class SharedPreviewWindowCoordinator: NSPanel {
                 position = centerWindowOnScreen(size: newHoverWindowSize, screen: mouseScreen)
             }
         }
+
+        if let oldContentView = contentView {
+            oldContentView.removeFromSuperview()
+        }
+        contentView = newHostingView
+
         let finalFrame = CGRect(origin: position, size: newHoverWindowSize)
 
         setFrame(finalFrame, display: false)
@@ -395,7 +410,7 @@ final class SharedPreviewWindowCoordinator: NSPanel {
         fullPreviewWindow?.contentView = hostingView
 
         fullPreviewWindow?.setFrame(flippedIconRect, display: true)
-        fullPreviewWindow?.makeKeyAndOrderFront(nil)
+        fullPreviewWindow?.orderFront(nil)
     }
 
     @MainActor
@@ -571,7 +586,7 @@ final class SharedPreviewWindowCoordinator: NSPanel {
         }
 
         alphaValue = 1.0
-        makeKeyAndOrderFront(nil)
+        orderFront(nil)
     }
 
     @MainActor

--- a/DockDoor/Views/Hover Window/WindowPreview Supporting/Window Image Sizing Calculations.swift
+++ b/DockDoor/Views/Hover Window/WindowPreview Supporting/Window Image Sizing Calculations.swift
@@ -101,6 +101,12 @@ extension WindowPreviewHoverContainer {
                         CGSize(width: max(rendered.width, 50), height: rendered.height)
                     }
                     dimensionsMap[index] = WindowDimensions(size: windowSize, maxDimensions: maxDims)
+                } else if Defaults[.stageManagerOptimization] {
+                    let fallbackSize = CGSize(
+                        width: min(Defaults[.previewWidth], maxDims.width),
+                        height: min(Defaults[.previewHeight], maxDims.height)
+                    )
+                    dimensionsMap[index] = WindowDimensions(size: fallbackSize, maxDimensions: maxDims)
                 } else {
                     let compactRowHeight: CGFloat = 36
                     let fallbackSize = CGSize(width: min(300, maxDims.width), height: compactRowHeight)

--- a/DockDoor/Views/Hover Window/WindowPreview.swift
+++ b/DockDoor/Views/Hover Window/WindowPreview.swift
@@ -125,6 +125,7 @@ struct WindowPreview: View, Equatable {
     let mockPreviewActive: Bool
     let onHoverIndexChange: ((Int?, CGPoint?) -> Void)?
     let useLivePreview: Bool
+    let showStageManagerMissingPreviewTip: Bool
     var skeletonMode: Bool = false
     var appearance: PreviewAppearanceSettings
     let backgroundAppearance: BackgroundAppearance
@@ -139,6 +140,7 @@ struct WindowPreview: View, Equatable {
 
     static func == (l: Self, r: Self) -> Bool {
         l.index == r.index && l.isSelected == r.isSelected && l.useLivePreview == r.useLivePreview
+            && l.showStageManagerMissingPreviewTip == r.showStageManagerMissingPreviewTip
             && l.skeletonMode == r.skeletonMode && l.dimensions == r.dimensions
             && l.uniformCardRadius == r.uniformCardRadius && l.showAppIconOnly == r.showAppIconOnly
             && l.windowSwitcherActive == r.windowSwitcherActive
@@ -171,7 +173,7 @@ struct WindowPreview: View, Equatable {
 
     @ViewBuilder
     private func windowContent(isMinimized: Bool, isHidden: Bool, isSelected: Bool) -> some View {
-        let inactive = (isMinimized || isHidden) && appearance.showMinimizedHiddenLabels
+        let inactive = (isMinimized || isHidden) && appearance.showMinimizedHiddenLabels && !showStageManagerMissingPreviewTip
         let quality = appearance.livePreviewQuality
         let frameRate = appearance.livePreviewFrameRate
 
@@ -184,6 +186,9 @@ struct WindowPreview: View, Equatable {
                 Image(decorative: cgImage, scale: 1.0)
                     .resizable()
                     .scaledToFit()
+            } else if showStageManagerMissingPreviewTip {
+                StageManagerMissingPreviewTip()
+                    .frame(width: dimensions.size.width, height: dimensions.size.height)
             }
         }
         .markHidden(isHidden: inactive || (windowSwitcherActive && !isSelected))
@@ -873,5 +878,36 @@ struct WindowPreview: View, Equatable {
         dragTimer = nil
         isDraggingOver = false
         highlightOpacity = 0.0
+    }
+}
+
+private struct StageManagerMissingPreviewTip: View {
+    var body: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: CardRadius.image, style: .continuous)
+                .fill(Color.primary.opacity(0.045))
+                .overlay {
+                    RoundedRectangle(cornerRadius: CardRadius.image, style: .continuous)
+                        .strokeBorder(Color.primary.opacity(0.08), style: StrokeStyle(lineWidth: 1, dash: [4, 4]))
+                }
+
+            VStack(spacing: 8) {
+                Image(systemName: "rectangle.on.rectangle")
+                    .font(.title2)
+                    .symbolRenderingMode(.hierarchical)
+
+                Text(String(
+                    localized: "Bring this app to the front once to activate its preview.",
+                    comment: "Tip shown when Stage Manager optimization has no cached thumbnail yet"
+                ))
+                .font(.caption)
+                .lineLimit(3)
+                .minimumScaleFactor(0.8)
+            }
+            .foregroundStyle(.secondary)
+            .multilineTextAlignment(.center)
+            .padding(.horizontal, 18)
+            .padding(.vertical, 12)
+        }
     }
 }

--- a/DockDoor/Views/Hover Window/WindowPreviewHoverContainer.swift
+++ b/DockDoor/Views/Hover Window/WindowPreviewHoverContainer.swift
@@ -82,6 +82,7 @@ struct WindowPreviewHoverContainer: View {
     @Default(.enableLivePreview) var enableLivePreview
     @Default(.enableLivePreviewForDock) var enableLivePreviewForDock
     @Default(.enableLivePreviewForWindowSwitcher) var enableLivePreviewForWindowSwitcher
+    @Default(.stageManagerOptimization) var stageManagerOptimization
 
     // Compact mode thresholds (0 = disabled, 1+ = enable when window count >= threshold)
     @Default(.windowSwitcherCompactThreshold) var windowSwitcherCompactThreshold
@@ -1153,8 +1154,16 @@ struct WindowPreviewHoverContainer: View {
                     return true
                 }()
 
-                // Use compact mode if: container threshold triggered OR per-window fallback (no image and no live preview)
-                let useCompactForThisWindow = shouldUseCompactMode || (windowInfo.image == nil && !useLivePreview)
+                let shouldShowStageManagerMissingPreviewTip = stageManagerOptimization &&
+                    hasScreenRecordingPermission &&
+                    !disableImagePreview &&
+                    windowInfo.image == nil &&
+                    !useLivePreview &&
+                    !windowInfo.isWindowlessApp
+
+                // Use compact mode if: container threshold triggered OR per-window fallback (no image and no live preview).
+                let useCompactForThisWindow = shouldUseCompactMode ||
+                    (windowInfo.image == nil && !useLivePreview && !shouldShowStageManagerMissingPreviewTip)
 
                 let isSelected = index == previewStateCoordinator.currIndex
 
@@ -1212,6 +1221,7 @@ struct WindowPreviewHoverContainer: View {
                         mockPreviewActive: mockPreviewActive,
                         onHoverIndexChange: handleHoverIndexChange,
                         useLivePreview: useLivePreview,
+                        showStageManagerMissingPreviewTip: shouldShowStageManagerMissingPreviewTip,
                         appearance: appearance,
                         backgroundAppearance: backgroundAppearance
                     )

--- a/DockDoor/Views/Settings/AdvancedSettingsView.swift
+++ b/DockDoor/Views/Settings/AdvancedSettingsView.swift
@@ -19,6 +19,7 @@ struct AdvancedSettingsView: View {
     @Default(.windowPreviewImageScale) var windowPreviewImageScale
 
     @Default(.enableLivePreview) var enableLivePreview
+    @Default(.stageManagerOptimization) var stageManagerOptimization
     @Default(.enableLivePreviewForDock) var enableLivePreviewForDock
     @Default(.enableLivePreviewForWindowSwitcher) var enableLivePreviewForWindowSwitcher
     @Default(.dockLivePreviewQuality) var dockLivePreviewQuality
@@ -36,9 +37,10 @@ struct AdvancedSettingsView: View {
             VStack(alignment: .leading, spacing: 16) {
                 performanceTuningSection
                 previewQualitySection
+                stageManagerOptimizationSection
                 livePreviewSection
 
-                if enableLivePreview {
+                if enableLivePreview, !stageManagerOptimization {
                     dockLivePreviewSection
                     switcherLivePreviewSection
                     streamManagementSection
@@ -48,6 +50,10 @@ struct AdvancedSettingsView: View {
         .onAppear {
             if livePreviewStreamKeepAlive > 0 {
                 lastKeepAliveDuration = livePreviewStreamKeepAlive
+            }
+            if stageManagerOptimization, enableLivePreview {
+                enableLivePreview = false
+                Task { await LiveCaptureManager.shared.stopAllStreams() }
             }
         }
     }
@@ -146,6 +152,29 @@ struct AdvancedSettingsView: View {
         }
     }
 
+    // MARK: - Stage Manager
+
+    private var stageManagerOptimizationSection: some View {
+        SettingsGroup(header: "Stage Manager") {
+            VStack(alignment: .leading, spacing: 10) {
+                Toggle(isOn: $stageManagerOptimization) {
+                    Text("Optimization for Stage Manager")
+                }
+                .settingsSearchTarget("advanced.stageManagerOptimization")
+                .onChange(of: stageManagerOptimization) { newValue in
+                    if newValue, enableLivePreview {
+                        enableLivePreview = false
+                        Task { await LiveCaptureManager.shared.stopAllStreams() }
+                    }
+                }
+                Text("If DockDoor is opened while other apps are already minimized to the Stage Manager sidebar, bring them to front at least once to make them display properly.")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .padding(.leading, 20)
+            }
+        }
+    }
+
     // MARK: - Live Preview
 
     private var livePreviewSection: some View {
@@ -153,11 +182,18 @@ struct AdvancedSettingsView: View {
             VStack(alignment: .leading, spacing: 10) {
                 Toggle(isOn: $enableLivePreview) { Text("Enable Live Preview (Video)") }
                     .settingsSearchTarget("advanced.livePreview")
+                    .disabled(stageManagerOptimization)
                     .onChange(of: enableLivePreview) { newValue in
                         if !newValue {
                             Task { await LiveCaptureManager.shared.stopAllStreams() }
                         }
                     }
+                if stageManagerOptimization {
+                    Text("Live preview cannot be turned on when Optimization for Stage Manager is on.")
+                        .font(.caption)
+                        .foregroundColor(.red)
+                        .padding(.leading, 20)
+                }
                 Text("Window previews show live video instead of static screenshots. Uses ScreenCaptureKit for real-time capture.")
                     .font(.caption)
                     .foregroundColor(.secondary)

--- a/DockDoor/Views/Settings/Search/SettingsSearchCatalog.swift
+++ b/DockDoor/Views/Settings/Search/SettingsSearchCatalog.swift
@@ -1571,6 +1571,15 @@ enum SettingsSearchCatalog {
             icon: "arrow.up.left.and.arrow.down.right"
         ),
         SettingsSearchItem(
+            id: "advanced.stageManagerOptimization",
+            title: String(localized: "Optimization for Stage Manager"),
+            description: String(localized: "If DockDoor is opened while other apps are already minimized to the Stage Manager sidebar, bring them to front at least once to make them display properly."),
+            keywords: ["stage manager", "sidebar", "minimized", "thumbnail", "preview", "optimization"],
+            tab: "Advanced",
+            section: String(localized: "Stage Manager"),
+            icon: "rectangle.3.group"
+        ),
+        SettingsSearchItem(
             id: "advanced.livePreview",
             title: String(localized: "Enable Live Preview (Video)"),
             description: String(localized: "Window previews show live video instead of static screenshots. Uses ScreenCaptureKit for real-time capture."),

--- a/DockDoor/Views/Settings/SettingsView.swift
+++ b/DockDoor/Views/Settings/SettingsView.swift
@@ -55,6 +55,10 @@ class SettingsManager: NSObject, ObservableObject {
 }
 
 extension SettingsManager: NSToolbarDelegate {
+    func toolbar(_ toolbar: NSToolbar, itemForItemIdentifier itemIdentifier: NSToolbarItem.Identifier, willBeInsertedIntoToolbar flag: Bool) -> NSToolbarItem? {
+        nil
+    }
+
     func toolbarDefaultItemIdentifiers(_ toolbar: NSToolbar) -> [NSToolbarItem.Identifier] {
         []
     }

--- a/DockDoor/consts.swift
+++ b/DockDoor/consts.swift
@@ -64,6 +64,7 @@ extension Defaults.Keys {
     static let windowImageCaptureQuality = Key<WindowImageCaptureQuality>("windowImageCaptureQuality", default: .nominal)
 
     static let enableLivePreview = Key<Bool>("enableLivePreview", default: false)
+    static let stageManagerOptimization = Key<Bool>("stageManagerOptimization", default: false)
     static let enableLivePreviewForDock = Key<Bool>("enableLivePreviewForDock", default: true)
     static let enableLivePreviewForWindowSwitcher = Key<Bool>("enableLivePreviewForWindowSwitcher", default: false)
     static let dockLivePreviewQuality = Key<LivePreviewQuality>("dockLivePreviewQuality", default: .high)


### PR DESCRIPTION
## Describe your changes
This PR adds an opt-in Stage Manager optimization for DockDoor window previews.

### Design
This PR adds a new Advanced setting: "Optimization for Stage Manager"

The setting is off by default and must be enabled explicitly. When enabled, DockDoor treats likely Stage Manager sidebar captures as unusable preview images. Instead of replacing a good cached thumbnail with the tiny transformed capture, DockDoor preserves the last usable in-memory thumbnail when one exists.

The implementation is intentionally conservative. Normal behavior is unchanged when the setting is off Focused/frontmost windows still force-refresh so active windows update correctly. Bad Stage Manager sidebar captures are rejected instead of cached. If a previous good thumbnail exists, it is reused. If no good thumbnail exists yet, DockDoor shows a quiet placeholder tip in the thumbnail area.

The placeholder tells the user: Bring this app to the front once to activate its preview.

### How To Use
(1) Open DockDoor settings.
(2 ) Go to Advanced.
(3) Enable Optimization for Stage Manager.

### Limitations
macOS does not reliably provide a public API for capturing the full original window content after a window is already minimized into the Stage Manager sidebar.

Because of that, if DockDoor is launched after apps are already minimized into the Stage Manager sidebar, DockDoor may not have a good thumbnail cached yet. In that case, the preview shows an informative placeholder. The user needs to bring that app/window to the front once so DockDoor can capture a usable thumbnail.

## Related issue number(s) and link(s)

## Checklist before requesting a review
- [x] I have performed a self-review of my code and understand every line
- [x] If this change affects core functionality, I have added a description highlighting the changes
- [x] I have followed conventional commit guidelines
- [x] I have tested this PR on my own machine

## AI Assistance Disclosure

> **Policy**: AI-assisted contributions are welcome, but you must understand, test, and take full responsibility for your code. Pasting AI-generated code or PR descriptions without genuine human review and understanding will result in your PR being closed and may result in a ban from contributing.

**Did you use AI tools (ChatGPT, Claude, Copilot, Cursor, etc.) for this PR?**
- [ ] No AI tools were used
- [x] Yes - describe below how AI was used and confirm you reviewed/tested the output

<!-- If yes, briefly describe: What tool? What did it help with? Did you modify/review its output? -->
Codex was used to understand the current implementation and help design choices. I have fully reviewed the output.

## Core Functionality Changes
If this PR modifies core functionality, please provide a brief description of the changes and their impact below:
When enabled, DockDoor shows a good cached thumbnail for apps minimized by Stage Manage.

### Live Preview Interaction
This optimization is mutually exclusive with Live Preview.

When Optimization for Stage Manager is enabled: (1) Enable Live Preview (Video) is disabled. (2) Existing live preview streams are stopped. (3) A red note explains that Live Preview cannot be enabled while Stage Manager optimization is on. (4) This avoids competing capture paths and keeps the Stage Manager behavior predictable.