### PR TITLE
fix: position active app indicator across displays

### DIFF
--- a/DockDoor/Utilities/ActiveAppIndicator/ActiveAppIndicatorCoordinator.swift
+++ b/DockDoor/Utilities/ActiveAppIndicator/ActiveAppIndicatorCoordinator.swift
@@ -19,7 +19,6 @@ final class ActiveAppIndicatorCoordinator {
 
     private var delayedUpdateTimer: Timer?
     private let delayedUpdateInterval: TimeInterval = 0.6
-    private var shouldFadeInAfterDockScreenChange = false
 
     private static let animationDuration: TimeInterval = 0.25
 
@@ -239,7 +238,6 @@ final class ActiveAppIndicatorCoordinator {
         }
 
         indicatorWindow.alphaValue = 0
-        shouldFadeInAfterDockScreenChange = true
     }
 
     // MARK: - Dock Orientation Notifications
@@ -328,7 +326,6 @@ final class ActiveAppIndicatorCoordinator {
             )
             indicatorWindow.setFrame(collapsed, display: false)
             indicatorWindow.alphaValue = 1
-            shouldFadeInAfterDockScreenChange = false
             indicatorWindow.orderFront(self)
 
             NSAnimationContext.runAnimationGroup { context in
@@ -336,18 +333,10 @@ final class ActiveAppIndicatorCoordinator {
                 context.timingFunction = CAMediaTimingFunction(name: .easeOut)
                 indicatorWindow.animator().setFrame(targetFrame, display: true)
             }
-        } else if shouldFadeInAfterDockScreenChange {
+        } else if indicatorWindow.alphaValue == 0 {
             indicatorWindow.setFrame(targetFrame, display: false)
-            indicatorWindow.alphaValue = 0
+            indicatorWindow.alphaValue = 1
             indicatorWindow.orderFront(self)
-
-            NSAnimationContext.runAnimationGroup({ context in
-                context.duration = Self.animationDuration
-                context.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
-                indicatorWindow.animator().alphaValue = 1
-            }, completionHandler: { [weak self] in
-                self?.shouldFadeInAfterDockScreenChange = false
-            })
         } else {
             NSAnimationContext.runAnimationGroup { context in
                 context.duration = Self.animationDuration

--- a/DockDoor/Utilities/ActiveAppIndicator/ActiveAppIndicatorCoordinator.swift
+++ b/DockDoor/Utilities/ActiveAppIndicator/ActiveAppIndicatorCoordinator.swift
@@ -115,6 +115,7 @@ final class ActiveAppIndicatorCoordinator {
         let refcon = Unmanaged.passUnretained(self).toOpaque()
         AXObserverAddNotification(observer, dockList, kAXUIElementDestroyedNotification as CFString, refcon)
         AXObserverAddNotification(observer, dockList, kAXCreatedNotification as CFString, refcon)
+        AXObserverAddNotification(observer, dockList, kAXSelectedChildrenChangedNotification as CFString, refcon)
 
         CFRunLoopAddSource(CFRunLoopGetMain(), AXObserverGetRunLoopSource(observer), .defaultMode)
 
@@ -157,6 +158,7 @@ final class ActiveAppIndicatorCoordinator {
         if let observer = dockLayoutObserver, let dockList = observedDockList {
             AXObserverRemoveNotification(observer, dockList, kAXUIElementDestroyedNotification as CFString)
             AXObserverRemoveNotification(observer, dockList, kAXCreatedNotification as CFString)
+            AXObserverRemoveNotification(observer, dockList, kAXSelectedChildrenChangedNotification as CFString)
         }
         dockLayoutObserver = nil
         observedDockList = nil

--- a/DockDoor/Utilities/ActiveAppIndicator/ActiveAppIndicatorCoordinator.swift
+++ b/DockDoor/Utilities/ActiveAppIndicator/ActiveAppIndicatorCoordinator.swift
@@ -19,6 +19,7 @@ final class ActiveAppIndicatorCoordinator {
 
     private var delayedUpdateTimer: Timer?
     private let delayedUpdateInterval: TimeInterval = 0.6
+    private var shouldFadeInAfterDockScreenChange = false
 
     private static let animationDuration: TimeInterval = 0.25
 
@@ -124,6 +125,7 @@ final class ActiveAppIndicatorCoordinator {
     }
 
     private func handleDockLayoutChanged() {
+        hideIndicatorIfDockChangedScreens()
         scheduleDelayedUpdate()
     }
 
@@ -205,6 +207,39 @@ final class ActiveAppIndicatorCoordinator {
                 updateIndicatorPosition(for: app)
             }
         }
+    }
+
+    private func hideIndicatorIfDockChangedScreens() {
+        guard let indicatorWindow,
+              indicatorWindow.isVisible,
+              indicatorWindow.alphaValue > 0,
+              let app = currentActiveApp,
+              let currentScreen = CGPoint(
+                  x: indicatorWindow.frame.midX,
+                  y: indicatorWindow.frame.midY
+              ).screen()
+        else {
+            return
+        }
+
+        let dockPosition = DockUtils.getDockPosition()
+        guard ActiveAppIndicatorPositioning.isSupported(dockPosition),
+              let dockItemFrame = ActiveAppIndicatorDockDetection.getDockItemFrame(for: app),
+              let targetFrame = ActiveAppIndicatorDockDetection.calculateIndicatorFrame(
+                  relativeTo: dockItemFrame,
+                  dockPosition: dockPosition
+              ),
+              let targetScreen = CGPoint(
+                  x: targetFrame.midX,
+                  y: targetFrame.midY
+              ).screen(),
+              currentScreen.uniqueIdentifier() != targetScreen.uniqueIdentifier()
+        else {
+            return
+        }
+
+        indicatorWindow.alphaValue = 0
+        shouldFadeInAfterDockScreenChange = true
     }
 
     // MARK: - Dock Orientation Notifications
@@ -293,6 +328,7 @@ final class ActiveAppIndicatorCoordinator {
             )
             indicatorWindow.setFrame(collapsed, display: false)
             indicatorWindow.alphaValue = 1
+            shouldFadeInAfterDockScreenChange = false
             indicatorWindow.orderFront(self)
 
             NSAnimationContext.runAnimationGroup { context in
@@ -300,6 +336,18 @@ final class ActiveAppIndicatorCoordinator {
                 context.timingFunction = CAMediaTimingFunction(name: .easeOut)
                 indicatorWindow.animator().setFrame(targetFrame, display: true)
             }
+        } else if shouldFadeInAfterDockScreenChange {
+            indicatorWindow.setFrame(targetFrame, display: false)
+            indicatorWindow.alphaValue = 0
+            indicatorWindow.orderFront(self)
+
+            NSAnimationContext.runAnimationGroup({ context in
+                context.duration = Self.animationDuration
+                context.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+                indicatorWindow.animator().alphaValue = 1
+            }, completionHandler: { [weak self] in
+                self?.shouldFadeInAfterDockScreenChange = false
+            })
         } else {
             NSAnimationContext.runAnimationGroup { context in
                 context.duration = Self.animationDuration

--- a/DockDoor/Utilities/ActiveAppIndicator/ActiveAppIndicatorDockDetection.swift
+++ b/DockDoor/Utilities/ActiveAppIndicator/ActiveAppIndicatorDockDetection.swift
@@ -67,6 +67,18 @@ enum ActiveAppIndicatorDockDetection {
         return CGRect(origin: position, size: size)
     }
 
+    private static func appKitFrame(fromAccessibilityFrame frame: CGRect) -> CGRect {
+        let screen = NSScreen.screenFromQuartzPoint(
+            CGPoint(x: frame.midX, y: frame.midY)
+        )
+        let appKitOrigin = DockObserver.nsPointFromCGPoint(
+            CGPoint(x: frame.minX, y: frame.maxY),
+            forScreen: screen
+        )
+
+        return CGRect(origin: appKitOrigin, size: frame.size)
+    }
+
     /// Calculates indicator height, offset, and length based on dock size and position.
     /// Values derived from testing for dock sizes 36-156.
     /// - Parameters:
@@ -121,7 +133,13 @@ enum ActiveAppIndicatorDockDetection {
         let indicatorOffset: CGFloat
         let indicatorLength: CGFloat
 
-        let dockSize = DockUtils.getDockSize()
+        let appKitDockItemFrame = appKitFrame(fromAccessibilityFrame: dockItemFrame)
+        guard let screen = CGPoint(
+            x: appKitDockItemFrame.midX,
+            y: appKitDockItemFrame.midY
+        ).screen() else { return }
+
+        let dockSize = DockUtils.getDockSize(on: screen)
         let autoSize = calculateAutoSize(
             dockSize: dockSize,
             dockPosition: dockPosition
@@ -142,25 +160,15 @@ enum ActiveAppIndicatorDockDetection {
             indicatorLength = Defaults[.activeAppIndicatorLength]
         }
 
-        // Get the screen containing the dock
-        guard
-            let screen = NSScreen.screens.first(where: {
-                $0.frame.contains(dockItemFrame.origin)
-            }) ?? NSScreen.main
-        else {
-            return
-        }
-
         // Calculate the indicator frame using the positioning module
         guard
             var indicatorFrame =
             ActiveAppIndicatorPositioning.calculateIndicatorFrame(
-                for: dockItemFrame,
+                for: appKitDockItemFrame,
                 dockPosition: dockPosition,
                 indicatorThickness: indicatorThickness,
                 indicatorOffset: indicatorOffset,
-                indicatorLength: indicatorLength,
-                on: screen
+                indicatorLength: indicatorLength
             )
         else {
             indicatorWindow.orderOut(nil)
@@ -182,7 +190,13 @@ enum ActiveAppIndicatorDockDetection {
         let indicatorOffset: CGFloat
         let indicatorLength: CGFloat
 
-        let dockSize = DockUtils.getDockSize()
+        let appKitDockItemFrame = appKitFrame(fromAccessibilityFrame: dockItemFrame)
+        guard let screen = CGPoint(
+            x: appKitDockItemFrame.midX,
+            y: appKitDockItemFrame.midY
+        ).screen() else { return nil }
+
+        let dockSize = DockUtils.getDockSize(on: screen)
         let autoSize = calculateAutoSize(
             dockSize: dockSize,
             dockPosition: dockPosition
@@ -203,22 +217,13 @@ enum ActiveAppIndicatorDockDetection {
         }
 
         guard
-            let screen = NSScreen.screens.first(where: {
-                $0.frame.contains(dockItemFrame.origin)
-            }) ?? NSScreen.main
-        else {
-            return nil
-        }
-
-        guard
             var indicatorFrame =
             ActiveAppIndicatorPositioning.calculateIndicatorFrame(
-                for: dockItemFrame,
+                for: appKitDockItemFrame,
                 dockPosition: dockPosition,
                 indicatorThickness: indicatorThickness,
                 indicatorOffset: indicatorOffset,
-                indicatorLength: indicatorLength,
-                on: screen
+                indicatorLength: indicatorLength
             )
         else {
             return nil

--- a/DockDoor/Utilities/ActiveAppIndicator/ActiveAppIndicatorPositioning.swift
+++ b/DockDoor/Utilities/ActiveAppIndicator/ActiveAppIndicatorPositioning.swift
@@ -20,8 +20,7 @@ enum ActiveAppIndicatorPositioning {
         dockPosition: DockPosition,
         indicatorThickness: CGFloat,
         indicatorOffset: CGFloat,
-        indicatorLength: CGFloat,
-        on screen: NSScreen
+        indicatorLength: CGFloat
     ) -> CGRect? {
         switch dockPosition {
         case .bottom:
@@ -29,24 +28,21 @@ enum ActiveAppIndicatorPositioning {
                 dockItemFrame: dockItemFrame,
                 indicatorThickness: indicatorThickness,
                 indicatorOffset: indicatorOffset,
-                indicatorLength: indicatorLength,
-                screenHeight: screen.frame.height
+                indicatorLength: indicatorLength
             )
         case .left:
             calculateLeftIndicatorFrame(
                 dockItemFrame: dockItemFrame,
                 indicatorThickness: indicatorThickness,
                 indicatorOffset: indicatorOffset,
-                indicatorHeight: indicatorLength,
-                screenHeight: screen.frame.height
+                indicatorHeight: indicatorLength
             )
         case .right:
             calculateRightIndicatorFrame(
                 dockItemFrame: dockItemFrame,
                 indicatorThickness: indicatorThickness,
                 indicatorOffset: indicatorOffset,
-                indicatorHeight: indicatorLength,
-                screenHeight: screen.frame.height
+                indicatorHeight: indicatorLength
             )
         case .top, .cmdTab, .cli, .unknown:
             nil
@@ -61,21 +57,15 @@ enum ActiveAppIndicatorPositioning {
         dockItemFrame: CGRect,
         indicatorThickness: CGFloat,
         indicatorOffset: CGFloat,
-        indicatorLength: CGFloat,
-        screenHeight: CGFloat
+        indicatorLength: CGFloat
     ) -> CGRect {
         // Center horizontally below the dock icon
         let x = dockItemFrame.midX - (indicatorLength / 2)
 
-        // Convert from screen coordinates (Y from top) to AppKit coordinates (Y from bottom)
-        // The dock item frame uses screen coordinates where Y increases downward from top-left
-        let dockItemBottomInScreenCoords =
-            dockItemFrame.origin.y + dockItemFrame.height
-
         // Position just below the dock icon
         // Positive offset moves indicator up (adds to Y in AppKit coords), negative moves down
         let y =
-            screenHeight - dockItemBottomInScreenCoords - indicatorThickness - 2
+            dockItemFrame.minY - indicatorThickness - 2
                 + indicatorOffset // 2px base gap
 
         return CGRect(x: x, y: y, width: indicatorLength, height: indicatorThickness)
@@ -89,8 +79,7 @@ enum ActiveAppIndicatorPositioning {
         dockItemFrame: CGRect,
         indicatorThickness: CGFloat,
         indicatorOffset: CGFloat,
-        indicatorHeight: CGFloat?,
-        screenHeight: CGFloat
+        indicatorHeight: CGFloat?
     ) -> CGRect {
         // Use explicit height if provided, otherwise 60% of dock icon height
         let height = indicatorHeight ?? (dockItemFrame.height * 0.655)
@@ -100,11 +89,8 @@ enum ActiveAppIndicatorPositioning {
         let x =
             dockItemFrame.origin.x - indicatorThickness - 2 - indicatorOffset // 2px base gap
 
-        // Convert Y coordinate: screen coords (top-left origin) to AppKit coords (bottom-left origin)
         // Center vertically relative to the dock item
-        let dockItemCenterYInScreenCoords =
-            dockItemFrame.origin.y + (dockItemFrame.height / 2)
-        let y = screenHeight - dockItemCenterYInScreenCoords - (height / 2)
+        let y = dockItemFrame.midY - (height / 2)
 
         return CGRect(x: x, y: y, width: indicatorThickness, height: height)
     }
@@ -117,8 +103,7 @@ enum ActiveAppIndicatorPositioning {
         dockItemFrame: CGRect,
         indicatorThickness: CGFloat,
         indicatorOffset: CGFloat,
-        indicatorHeight: CGFloat?,
-        screenHeight: CGFloat
+        indicatorHeight: CGFloat?
     ) -> CGRect {
         // Use explicit height if provided, otherwise 60% of dock icon height
         let height = indicatorHeight ?? (dockItemFrame.height * 0.655)
@@ -129,11 +114,8 @@ enum ActiveAppIndicatorPositioning {
             dockItemFrame.origin.x + dockItemFrame.width
         let x = dockItemRightInScreenCoords + 2 + indicatorOffset // 2px base gap
 
-        // Convert Y coordinate: screen coords (top-left origin) to AppKit coords (bottom-left origin)
         // Center vertically relative to the dock item
-        let dockItemCenterYInScreenCoords =
-            dockItemFrame.origin.y + (dockItemFrame.height / 2)
-        let y = screenHeight - dockItemCenterYInScreenCoords - (height / 2)
+        let y = dockItemFrame.midY - (height / 2)
 
         return CGRect(x: x, y: y, width: indicatorThickness, height: height)
     }

--- a/DockDoor/Utilities/DockUtils.swift
+++ b/DockDoor/Utilities/DockUtils.swift
@@ -36,21 +36,31 @@ class DockUtils {
         }
     }
 
-    /// Returns the dock size in pixels based on the screen's visible frame.
-    static func getDockSize() -> CGFloat {
-        guard let screen = NSScreen.main else { return 0 }
+    /// Returns the dock size in points based on the screen's visible frame.
+    static func getDockSize(on screen: NSScreen? = nil) -> CGFloat {
         let dockPosition = getDockPosition()
+
+        if let screen {
+            return dockSize(on: screen, dockPosition: dockPosition)
+        }
+
+        return NSScreen.screens
+            .map { dockSize(on: $0, dockPosition: dockPosition) }
+            .max() ?? 0
+    }
+
+    private static func dockSize(on screen: NSScreen, dockPosition: DockPosition) -> CGFloat {
         switch dockPosition {
         case .right:
-            return screen.frame.width - screen.visibleFrame.width
+            screen.frame.maxX - screen.visibleFrame.maxX
         case .left:
-            return screen.visibleFrame.origin.x
+            screen.visibleFrame.minX - screen.frame.minX
         case .bottom:
-            return screen.visibleFrame.origin.y
+            screen.visibleFrame.minY - screen.frame.minY
         case .top:
-            return screen.frame.height - screen.visibleFrame.maxY
+            screen.frame.maxY - screen.visibleFrame.maxY
         case .cmdTab, .cli, .unknown:
-            return 0
+            0
         }
     }
 }


### PR DESCRIPTION
Hi there, just fixing a bug I missed when I created this feature.

I was having an issue where when I have two screens that have different resolutions and the Dock moves from one of the screens to the other screen (this happens for example when the dock is at the bottom and you put the cursor at the bottom of the screen that doesn't have the dock). 

Then the active app indicator in the Dock was showing up way offset from the actual Dock itself on the bigger screen. I addressed this with this PR and also tested it and ensured that the indicator shifts as soon as the Dock shifts to the other screen (listening for a notification for this, not using polling). The fix works for left and right side mounted docks, not just bottom docks. 

Closes #1269

## Summary
- Convert Dock accessibility frames to AppKit coordinates before positioning the active app indicator
- Resolve the dock item's actual screen from the converted frame
- Calculate auto sizing from the dock inset on that screen instead of assuming the primary display geometry

Used GPT 5.5 xhigh to resolve this issue but checked the code.