### PR TITLE
fix: honor screen recording skip for compact mode

### DIFF
--- a/DockDoor/Components/PermissionsView/PermissionsView.swift
+++ b/DockDoor/Components/PermissionsView/PermissionsView.swift
@@ -1,9 +1,11 @@
+import Defaults
 import SwiftUI
 
 struct PermissionsView: View {
     var nextTab: (() -> Void)?
     var disableShine: Bool = false
     var showSkipOption: Bool = true
+    @Default(.disableImagePreview) private var disableImagePreview
     @StateObject private var permissionsChecker = PermissionsChecker()
 
     var body: some View {
@@ -30,7 +32,7 @@ struct PermissionsView: View {
                 if showSkipOption, !permissionsChecker.screenRecordingPermission {
                     HStack {
                         Spacer()
-                        Button(action: { nextTab?() }) {
+                        Button(action: skipScreenRecording) {
                             Text("Skip (use list view only)")
                                 .font(.caption)
                         }
@@ -66,5 +68,10 @@ struct PermissionsView: View {
 
     private func openScreenRecordingPreferences() {
         SystemPreferencesHelper.openScreenRecordingPreferences()
+    }
+
+    private func skipScreenRecording() {
+        disableImagePreview = true
+        nextTab?()
     }
 }

--- a/DockDoor/Utilities/Window Management/LiveWindowCapture.swift
+++ b/DockDoor/Utilities/Window Management/LiveWindowCapture.swift
@@ -166,7 +166,7 @@ final class WindowLiveCapture: ObservableObject {
     func startCapture() async {
         stopGeneration += 1
         guard stream == nil else { return }
-        guard WindowUtil.hasScreenRecordingPermission() else { return }
+        guard WindowUtil.shouldCaptureWindowImages() else { return }
 
         guard let content = await WindowUtil.getShareableContent(onScreenWindowsOnly: false),
               let scWindow = content.windows.first(where: { $0.windowID == windowID })

--- a/DockDoor/Utilities/Window Management/WindowUtil.swift
+++ b/DockDoor/Utilities/Window Management/WindowUtil.swift
@@ -267,6 +267,10 @@ enum WindowUtil {
         PermissionsChecker.hasScreenRecordingPermission()
     }
 
+    static func shouldCaptureWindowImages() -> Bool {
+        !Defaults[.disableImagePreview] && hasScreenRecordingPermission()
+    }
+
     static func matchesAppFilters(bundleIdentifier: String?, appName: String, filters: [String]) -> Bool {
         guard !filters.isEmpty else { return false }
 
@@ -472,7 +476,7 @@ extension WindowUtil {
 
     static func captureWindowImage(windowID: CGWindowID, pid: pid_t, windowTitle: String? = nil, forceRefresh: Bool = false) async throws -> CGImage {
         // CGSHWCaptureWindowList requires screen recording permission
-        guard hasScreenRecordingPermission() else {
+        guard shouldCaptureWindowImages() else {
             throw captureError
         }
 
@@ -742,7 +746,7 @@ extension WindowUtil {
         var sckWindowIDs = Set<CGWindowID>()
 
         // Skip SCK if user has disabled image previews (compact mode only) or screen recording permission not granted
-        if !Defaults[.disableImagePreview], hasScreenRecordingPermission() {
+        if shouldCaptureWindowImages() {
             if let content = await getShareableContent(onScreenWindowsOnly: true) {
                 // Build set of SCK window IDs
                 let appWindows = content.windows.filter {
@@ -824,7 +828,7 @@ extension WindowUtil {
     }
 
     static func updateNewWindowsForApp(_ app: NSRunningApplication) async {
-        if hasScreenRecordingPermission() {
+        if shouldCaptureWindowImages() {
             if let content = await getShareableContent(onScreenWindowsOnly: false) {
                 let appWindows = content.windows.filter { window in
                     WindowOwnerResolver.windowBelongsToDisplayApp(window, displayApp: app)
@@ -854,7 +858,7 @@ extension WindowUtil {
     static func updateAllWindowsInCurrentSpace() async {
         var processedPIDs = Set<pid_t>()
 
-        if hasScreenRecordingPermission() {
+        if shouldCaptureWindowImages() {
             if let content = await getShareableContent(onScreenWindowsOnly: false) {
                 let windowAppPairs: [(window: SCWindow, displayApp: NSRunningApplication, ownerApp: NSRunningApplication)] = content.windows.compactMap { window in
                     guard let scApp = window.owningApplication,
@@ -914,6 +918,7 @@ extension WindowUtil {
     private static func refreshAXFallbackWindowImages(for pid: pid_t) async {
         let windows = desktopSpaceWindowCacheManager.readCache(pid: pid)
         guard !windows.isEmpty else { return }
+        guard shouldCaptureWindowImages() else { return }
 
         // Pre-compute fresh cached IDs to skip - use already-fetched windows
         let freshCachedIDs = freshCachedWindowIDs(for: pid, from: windows)

--- a/DockDoor/Views/Intro/Tabs/FirstTimePermissionsTabView.swift
+++ b/DockDoor/Views/Intro/Tabs/FirstTimePermissionsTabView.swift
@@ -1,7 +1,9 @@
+import Defaults
 import SwiftUI
 
 struct FirstTimePermissionsTabView: View {
     var nextTab: () -> Void
+    @Default(.disableImagePreview) private var disableImagePreview
     @StateObject private var permissionsChecker = PermissionsChecker()
 
     var body: some View {
@@ -60,7 +62,7 @@ struct FirstTimePermissionsTabView: View {
                         .foregroundColor(.secondary)
                 }
 
-                Button(action: nextTab) {
+                Button(action: continueToNextTab) {
                     HStack {
                         Text("Continue")
                         Image(systemName: "arrow.right")
@@ -71,6 +73,13 @@ struct FirstTimePermissionsTabView: View {
         }
         .padding(.horizontal, 32)
         .padding(.vertical, 16)
+    }
+
+    private func continueToNextTab() {
+        if !permissionsChecker.screenRecordingPermission {
+            disableImagePreview = true
+        }
+        nextTab()
     }
 }
 


### PR DESCRIPTION
Hey @ejbills!
Hope you're doing great 🙏🏻

I'm having an issue where every time I launch Dockdoor, even though I skipped the recording permission request previously and I don't want to grant it because it's not necessary for my use of the application, it keeps asking for this permission every time.

This PR basically addresses this so that it doesn't require you to grant this access and it doesn't show you the pop-up if you are not using the features that require this permission to be enabled.

## Summary
- Persist compact/list-only mode when first-time setup continues without Screen Recording permission
- Make the reusable Screen Recording skip action set compact mode before continuing
- Gate still-image and live preview capture paths on both Screen Recording permission and the compact-mode preference

Used GPT 5.5 xhigh to resolve this issue but checked the code.