### PR TITLE
fix: crash from unsafe try! in dock element role check

### DIFF
--- a/DockDoor/Utilities/DockObserver.swift
+++ b/DockDoor/Utilities/DockObserver.swift
@@ -233,9 +233,11 @@ final class DockObserver {
             return
         }
 
-        guard let children = try? dockAppElement.children(), let axList = children.first(where: { element in
-            try! element.role() == kAXListRole
-        }) else {
+        guard let children = try? dockAppElement.children(),
+              let axList = children.first(where: { element in
+                  (try? element.role()) == kAXListRole
+              })
+        else {
             return
         }
 


### PR DESCRIPTION
Changed the dock element filter in `DockObserver.swift` to use safe error handling (`try?`) instead of force-unwrap (`try!`). The old code would crash if `element.role()` threw an error (which happened from time to time); the new code safely handles the error and continues filtering.

**The change:**
- Replaced `try! element.role() == kAXListRole` with `(try? element.role()) == kAXListRole`
- Reformatted the guard statement for improved readability

This prevents app crashes when Accessibility APIs fail, which is critical since these APIs are inherently unreliable—elements disappear, states change, memory conditions vary. Using force-unwrap on fallible APIs is a common crash pattern that should always be avoided.

## Checklist before requesting a review
- [x] I have performed a self-review of my code and understand every line
- [x] If this change affects core functionality, I have added a description highlighting the changes
- [x] I have followed conventional commit guidelines
- [x] I have tested this PR on my own machine

## AI Assistance Disclosure

**Did you use AI tools (ChatGPT, Claude, Copilot, Cursor, etc.) for this PR?**
- [x] Yes - describe below how AI was used and confirm you reviewed/tested the output

Copilot identified this as an unsafe pattern and suggested the `try?` fix. I reviewed the change, verified it's semantically correct (the comparison still works when `try?` returns nil), tested it locally to confirm it prevents crashes, and understand why this pattern is necessary for Accessibility API code.

## Core Functionality Changes

This fix improves reliability of the dock observer, which is core functionality. Previously, any accessibility error in element role checking could crash the app. Now it gracefully handles errors and continues, making the dock preview and Alt+Tab features more stable.

<img width="423" height="268" alt="Screenshot 2026-05-29 at 11 03 17 PM" src="https://github.com/user-attachments/assets/307956ff-bab9-4cd6-bcad-563cc43391b7" />

**Before fix:** Stack trace showing crash in DockObserver.setupSelectedDockItemObserver() 
from the unsafe try! in the dock element role check.