### PR TITLE
feat: collapse native macOS tabs into a single window preview

### DIFF
--- a/DockDoor.xcodeproj/project.pbxproj
+++ b/DockDoor.xcodeproj/project.pbxproj
@@ -60,6 +60,7 @@
 		AA11001122334455AA110022 /* DockLocker.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA11001122334455AA110011 /* DockLocker.swift */; };
 		AA11001122334455AA110044 /* DockLockingSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA11001122334455AA110033 /* DockLockingSettingsView.swift */; };
 		AA11001122334455AA110066 /* DockLockerGeometryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA11001122334455AA110055 /* DockLockerGeometryTests.swift */; };
+		555110B7F7B99C7BD510DBC7 /* NativeTabGroupingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D00D4B366E3CF5338182E065 /* NativeTabGroupingTests.swift */; };
 		B376D66B467C4587915220BC80D3B9CB /* ScriptCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = F098F8107F464776B5C18294427CAECD /* ScriptCommands.swift */; };
 		B3C9F20484F14266B941AFB170B66530 /* MediaRemoteService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC298B81953848F481EE849906E0AE77 /* MediaRemoteService.swift */; };
 		B84941090B484695B105D967 /* SettingsGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4258675B29E4A22ACF92845 /* SettingsGroup.swift */; };
@@ -168,6 +169,7 @@
 		BBA153FC2C12356100119C02 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBA153FB2C12356100119C02 /* main.swift */; };
 		BBAC6B452D15FA8900A0F370 /* AXValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBAC6B442D15FA8800A0F370 /* AXValue.swift */; };
 		BBB023AD2EDCCB9100317CF4 /* WindowInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBB023AC2EDCCB9100317CF4 /* WindowInfo.swift */; };
+		F1F4D845DBF89A1AA7266945 /* NativeTabGrouping.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3DF9E4E1388ECA326113A84 /* NativeTabGrouping.swift */; };
 		BBB6C5302DF3C884009E93C4 /* MediaInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBB6C52F2DF3C884009E93C4 /* MediaInfo.swift */; };
 		BBB6C5322DF3C8A4009E93C4 /* MediaControlsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBB6C5312DF3C8A4009E93C4 /* MediaControlsView.swift */; };
 		BBB6C5342DF3C8B4009E93C4 /* BaseHoverContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBB6C5332DF3C8B4009E93C4 /* BaseHoverContainer.swift */; };
@@ -283,6 +285,7 @@
 		AA11001122334455AA110011 /* DockLocker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockLocker.swift; sourceTree = "<group>"; };
 		AA11001122334455AA110033 /* DockLockingSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockLockingSettingsView.swift; sourceTree = "<group>"; };
 		AA11001122334455AA110055 /* DockLockerGeometryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockLockerGeometryTests.swift; sourceTree = "<group>"; };
+		D00D4B366E3CF5338182E065 /* NativeTabGroupingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeTabGroupingTests.swift; sourceTree = "<group>"; };
 		AA11001122334455AA110100 /* DockDoorTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DockDoorTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		AC298B81953848F481EE849906E0AE77 /* MediaRemoteService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaRemoteService.swift; sourceTree = "<group>"; };
 		B056906A7ACD4903BD5E1627B359AE2C /* AdvancedSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvancedSettingsView.swift; sourceTree = "<group>"; };
@@ -393,6 +396,7 @@
 		BBA153FB2C12356100119C02 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		BBAC6B442D15FA8800A0F370 /* AXValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AXValue.swift; sourceTree = "<group>"; };
 		BBB023AC2EDCCB9100317CF4 /* WindowInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowInfo.swift; sourceTree = "<group>"; };
+		A3DF9E4E1388ECA326113A84 /* NativeTabGrouping.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeTabGrouping.swift; sourceTree = "<group>"; };
 		BBB6C52F2DF3C884009E93C4 /* MediaInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaInfo.swift; sourceTree = "<group>"; };
 		BBB6C5312DF3C8A4009E93C4 /* MediaControlsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaControlsView.swift; sourceTree = "<group>"; };
 		BBB6C5332DF3C8B4009E93C4 /* BaseHoverContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseHoverContainer.swift; sourceTree = "<group>"; };
@@ -584,6 +588,7 @@
 			isa = PBXGroup;
 			children = (
 				AA11001122334455AA110055 /* DockLockerGeometryTests.swift */,
+				D00D4B366E3CF5338182E065 /* NativeTabGroupingTests.swift */,
 			);
 			path = DockDoorTests;
 			sourceTree = "<group>";
@@ -896,6 +901,7 @@
 				BB49747C2E81CE5100308326 /* WindowSeeder.swift */,
 				BB49747D2F01AB0100308326 /* WindowOrderPersistence.swift */,
 				BBB023AC2EDCCB9100317CF4 /* WindowInfo.swift */,
+				A3DF9E4E1388ECA326113A84 /* NativeTabGrouping.swift */,
 				3A1622972C8BF71000D318EE /* SwiftUIWindow.swift */,
 				BB2CBB082C48128D004502C5 /* SpaceWindowCacheManager.swift */,
 				BB7CA33C2C31F1B00012E303 /* WindowManipulationObservers.swift */,
@@ -1092,6 +1098,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				AA11001122334455AA110066 /* DockLockerGeometryTests.swift in Sources */,
+				555110B7F7B99C7BD510DBC7 /* NativeTabGroupingTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1163,6 +1170,7 @@
 				BBDF65732E7E212400DD6D6D /* DockObserver+CmdTab.swift in Sources */,
 				BB3968022C2A6CC2004F1AB6 /* Marquee.swift in Sources */,
 				BBB023AD2EDCCB9100317CF4 /* WindowInfo.swift in Sources */,
+				F1F4D845DBF89A1AA7266945 /* NativeTabGrouping.swift in Sources */,
 				BB709B3D2EF21E9E007809A2 /* VolumeScrollModifier.swift in Sources */,
 				BB0440602C77AD2C009F1D33 /* CodableColor.swift in Sources */,
 				BB52EDF02C5BEFE3006A64A4 /* HiddenModifier.swift in Sources */,

--- a/DockDoor/Utilities/Window Management/NativeTabGrouping.swift
+++ b/DockDoor/Utilities/Window Management/NativeTabGrouping.swift
@@ -1,0 +1,84 @@
+import CoreGraphics
+import Foundation
+
+/// Detects native macOS window-tab groups and selects one representative window per group.
+///
+/// macOS native window tabbing (`NSWindow` tabbing, used by Ghostty, Finder, Terminal,
+/// Safari, and others) models each tab as a distinct window. The Accessibility API reports
+/// each of those windows separately, which is why a single tabbed window otherwise shows up
+/// as one preview per tab.
+///
+/// There is no Accessibility attribute that exposes tab-group membership for arbitrary apps,
+/// so membership is inferred from a reliable side effect: the windows in one visible tab group
+/// are stacked at the exact same screen frame. Windows that share a process and an
+/// (integer-rounded) frame are therefore treated as a single group, and callers can keep just
+/// the representative to collapse a tabbed app down to one entry.
+enum NativeTabGrouping {
+    /// The minimal window facts needed to detect tab groups, kept free of Accessibility and
+    /// AppKit types so the grouping logic stays pure and unit-testable.
+    struct Candidate {
+        let id: CGWindowID
+        let pid: pid_t
+        let frame: CGRect
+        /// Used to pick which member represents its group; the most recently accessed window
+        /// (typically the active tab) wins.
+        let recency: Date
+        /// Whether this window may be collapsed into a group. Minimized, hidden, windowless,
+        /// and zero-sized windows are never collapsed and are always kept as-is.
+        let groupable: Bool
+    }
+
+    private struct GroupKey: Hashable {
+        let pid: pid_t
+        let x: Int
+        let y: Int
+        let width: Int
+        let height: Int
+    }
+
+    /// Returns the window IDs to keep: every non-groupable window, plus a single representative
+    /// per detected tab group.
+    ///
+    /// The representative is the most recently accessed window in the group; ties are broken by
+    /// the larger window ID so the result is deterministic regardless of input ordering.
+    static func representativeIDs(from candidates: [Candidate]) -> Set<CGWindowID> {
+        var keptIDs = Set<CGWindowID>()
+        var representativeByGroup: [GroupKey: Candidate] = [:]
+
+        for candidate in candidates {
+            guard candidate.groupable else {
+                keptIDs.insert(candidate.id)
+                continue
+            }
+
+            let key = GroupKey(
+                pid: candidate.pid,
+                x: Int(candidate.frame.origin.x.rounded()),
+                y: Int(candidate.frame.origin.y.rounded()),
+                width: Int(candidate.frame.size.width.rounded()),
+                height: Int(candidate.frame.size.height.rounded())
+            )
+
+            if let current = representativeByGroup[key] {
+                if isBetterRepresentative(candidate, than: current) {
+                    representativeByGroup[key] = candidate
+                }
+            } else {
+                representativeByGroup[key] = candidate
+            }
+        }
+
+        for representative in representativeByGroup.values {
+            keptIDs.insert(representative.id)
+        }
+
+        return keptIDs
+    }
+
+    private static func isBetterRepresentative(_ candidate: Candidate, than current: Candidate) -> Bool {
+        if candidate.recency != current.recency {
+            return candidate.recency > current.recency
+        }
+        return candidate.id > current.id
+    }
+}

--- a/DockDoor/Utilities/Window Management/NativeTabGrouping.swift
+++ b/DockDoor/Utilities/Window Management/NativeTabGrouping.swift
@@ -76,9 +76,8 @@ enum NativeTabGrouping {
     }
 
     private static func isBetterRepresentative(_ candidate: Candidate, than current: Candidate) -> Bool {
-        if candidate.recency != current.recency {
-            return candidate.recency > current.recency
-        }
-        return candidate.id > current.id
+        // Most recently accessed wins; the larger window ID breaks ties so the result is
+        // deterministic regardless of input ordering.
+        (candidate.recency, candidate.id) > (current.recency, current.id)
     }
 }

--- a/DockDoor/Utilities/Window Management/WindowUtil.swift
+++ b/DockDoor/Utilities/Window Management/WindowUtil.swift
@@ -832,7 +832,7 @@ extension WindowUtil {
             }
 
             guard ignoreSingleWindowFilter || !shouldIgnoreSingleWindowApp || finalWindows.count > 1 else { return [] }
-            return sortWindows(Set(collapseNativeTabsIfNeeded(Array(finalWindows))), for: context)
+            return sortWindows(collapseNativeTabsIfNeeded(Array(finalWindows)), for: context)
         }
 
         return []
@@ -1437,6 +1437,10 @@ extension WindowUtil {
 extension WindowUtil {
     /// Centralized sorting for dock preview and cmd+tab contexts (single app windows)
     static func sortWindows(_ windows: Set<WindowInfo>, for context: WindowFetchContext) -> [WindowInfo] {
+        sortWindows(Array(windows), for: context)
+    }
+
+    static func sortWindows(_ windows: [WindowInfo], for context: WindowFetchContext) -> [WindowInfo] {
         let sortOrder: WindowPreviewSortOrder = switch context {
         case .dockPreview:
             Defaults[.windowPreviewSortOrder]
@@ -1444,7 +1448,7 @@ extension WindowUtil {
             Defaults[.cmdTabSortOrder]
         }
 
-        return sortWindowsWithOptions(Array(windows), sortOrder: sortOrder)
+        return sortWindowsWithOptions(windows, sortOrder: sortOrder)
     }
 
     /// Centralized sorting for window switcher context (all apps windows)

--- a/DockDoor/Utilities/Window Management/WindowUtil.swift
+++ b/DockDoor/Utilities/Window Management/WindowUtil.swift
@@ -647,7 +647,7 @@ extension WindowUtil {
             filteredWindows = getWindowsForFrontmostApp(from: filteredWindows)
         }
 
-        return sortWindowsForSwitcher(filteredWindows)
+        return sortWindowsForSwitcher(collapseNativeTabsIfNeeded(filteredWindows))
     }
 
     static func getWindowsForFrontmostApp(from windows: [WindowInfo]) -> [WindowInfo] {
@@ -744,6 +744,31 @@ extension WindowUtil {
         return windows.filter { windowBelongsToScreen($0, screenIdentifier: id) }
     }
 
+    // Collapses native macOS window-tab groups (e.g. Ghostty, Finder, Terminal) so a tabbed
+    // window appears as a single entry instead of one per tab. Grouping is keyed by process and
+    // frame, so windows from different apps are never merged and passing a multi-app list is safe.
+    static func collapseNativeTabsIfNeeded(_ windows: [WindowInfo]) -> [WindowInfo] {
+        guard Defaults[.collapseNativeTabsIntoSingleWindow] else { return windows }
+
+        let candidates = windows.map { window in
+            NativeTabGrouping.Candidate(
+                id: window.id,
+                pid: window.app.processIdentifier,
+                frame: window.frame,
+                recency: window.lastAccessedTime,
+                groupable: !window.isMinimized
+                    && !window.isHidden
+                    && !window.isWindowlessApp
+                    && window.frame.width > 0
+                    && window.frame.height > 0
+            )
+        }
+
+        let keptIDs = NativeTabGrouping.representativeIDs(from: candidates)
+        guard keptIDs.count < windows.count else { return windows }
+        return windows.filter { keptIDs.contains($0.id) }
+    }
+
     static func getActiveWindows(of app: NSRunningApplication, context: WindowFetchContext = .dockPreview, ignoreSingleWindowFilter: Bool = false) async throws -> [WindowInfo] {
         if isAppFiltered(app) {
             purgeAppCache(with: app.processIdentifier)
@@ -807,7 +832,7 @@ extension WindowUtil {
             }
 
             guard ignoreSingleWindowFilter || !shouldIgnoreSingleWindowApp || finalWindows.count > 1 else { return [] }
-            return sortWindows(finalWindows, for: context)
+            return sortWindows(Set(collapseNativeTabsIfNeeded(Array(finalWindows))), for: context)
         }
 
         return []

--- a/DockDoor/Views/Settings/DockPreviewsSettingsView.swift
+++ b/DockDoor/Views/Settings/DockPreviewsSettingsView.swift
@@ -8,6 +8,7 @@ struct DockPreviewsSettingsView: View {
     @Default(.windowPreviewSortOrder) var windowPreviewSortOrder
     @Default(.keepPreviewOnAppTerminate) var keepPreviewOnAppTerminate
     @Default(.groupAppInstancesInDock) var groupAppInstancesInDock
+    @Default(.collapseNativeTabsIntoSingleWindow) var collapseNativeTabsIntoSingleWindow
     @Default(.includeHiddenWindowsInDockPreview) var includeHiddenWindowsInDockPreview
     @Default(.showWindowlessAppsInDockPreview) var showWindowlessAppsInDockPreview
     @Default(.previewHoverAction) var previewHoverAction
@@ -100,6 +101,13 @@ struct DockPreviewsSettingsView: View {
                 Toggle(isOn: $groupAppInstancesInDock) { Text("Group multiple app instances together") }
                     .settingsSearchTarget("dockPreviews.groupInstances")
                 Text("Show windows from all instances of an app when hovering its dock icon.")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .padding(.leading, 20)
+
+                Toggle(isOn: $collapseNativeTabsIntoSingleWindow) { Text("Collapse native tabs into a single window") }
+                    .settingsSearchTarget("dockPreviews.collapseNativeTabs")
+                Text("Show one preview for apps that use native macOS window tabs (e.g. Ghostty, Finder, Terminal) instead of one preview per tab. Restart the app for this to take effect.")
                     .font(.caption)
                     .foregroundColor(.secondary)
                     .padding(.leading, 20)

--- a/DockDoor/Views/Settings/Search/SettingsSearchCatalog.swift
+++ b/DockDoor/Views/Settings/Search/SettingsSearchCatalog.swift
@@ -191,6 +191,15 @@ enum SettingsSearchCatalog {
             icon: "square.stack"
         ),
         SettingsSearchItem(
+            id: "dockPreviews.collapseNativeTabs",
+            title: String(localized: "Collapse native tabs into a single window"),
+            description: String(localized: "Show one preview for apps that use native macOS window tabs (e.g. Ghostty, Finder, Terminal) instead of one preview per tab."),
+            keywords: ["tab", "tabs", "native", "collapse", "ghostty", "finder", "terminal"],
+            tab: "DockPreviews",
+            section: String(localized: "Window Display"),
+            icon: "square.on.square"
+        ),
+        SettingsSearchItem(
             id: "dockPreviews.ignoreSingleWindow",
             title: String(localized: "Ignore apps with one window"),
             description: String(localized: "Prevents apps that only ever have a single window from appearing in previews."),

--- a/DockDoor/consts.swift
+++ b/DockDoor/consts.swift
@@ -154,6 +154,7 @@ extension Defaults.Keys {
     static let ignoreAppsWithSingleWindow = Key<Bool>("ignoreAppsWithSingleWindow", default: false)
     static let ignoreAppsWithSingleWindowInCmdTab = Key<Bool>("ignoreAppsWithSingleWindowInCmdTab", default: false)
     static let groupAppInstancesInDock = Key<Bool>("groupAppInstancesInDock", default: true)
+    static let collapseNativeTabsIntoSingleWindow = Key<Bool>("collapseNativeTabsIntoSingleWindow", default: false)
     static let showMenuBarIcon = Key<Bool>("showMenuBarIcon", default: true)
     static let hideDockDoorProBanner = Key<Bool>("hideDockDoorProBanner", default: false)
     static let raisedWindowLevel = Key<Bool>("raisedWindowLevel", default: true)

--- a/DockDoorTests/NativeTabGroupingTests.swift
+++ b/DockDoorTests/NativeTabGroupingTests.swift
@@ -1,0 +1,84 @@
+import CoreGraphics
+@testable import DockDoor
+import Foundation
+import Testing
+
+// MARK: - NativeTabGrouping Tests
+
+struct NativeTabGroupingTests {
+    private func candidate(
+        id: CGWindowID,
+        pid: pid_t = 100,
+        frame: CGRect = CGRect(x: 0, y: 0, width: 800, height: 600),
+        recency: TimeInterval = 0,
+        groupable: Bool = true
+    ) -> NativeTabGrouping.Candidate {
+        NativeTabGrouping.Candidate(
+            id: id,
+            pid: pid,
+            frame: frame,
+            recency: Date(timeIntervalSinceReferenceDate: recency),
+            groupable: groupable
+        )
+    }
+
+    @Test func collapsesSameFrameSameProcessIntoOne() {
+        let frame = CGRect(x: 10, y: 20, width: 800, height: 600)
+        let kept = NativeTabGrouping.representativeIDs(from: [
+            candidate(id: 1, frame: frame, recency: 0),
+            candidate(id: 2, frame: frame, recency: 5),
+            candidate(id: 3, frame: frame, recency: 2),
+        ])
+        #expect(kept == [2]) // most recently accessed represents the group
+    }
+
+    @Test func keepsWindowsWithDifferentFrames() {
+        let kept = NativeTabGrouping.representativeIDs(from: [
+            candidate(id: 1, frame: CGRect(x: 0, y: 0, width: 800, height: 600)),
+            candidate(id: 2, frame: CGRect(x: 100, y: 100, width: 800, height: 600)),
+        ])
+        #expect(kept == [1, 2])
+    }
+
+    @Test func doesNotMergeAcrossProcesses() {
+        let frame = CGRect(x: 0, y: 0, width: 800, height: 600)
+        let kept = NativeTabGrouping.representativeIDs(from: [
+            candidate(id: 1, pid: 100, frame: frame),
+            candidate(id: 2, pid: 200, frame: frame),
+        ])
+        #expect(kept == [1, 2])
+    }
+
+    @Test func nonGroupableWindowsAreAlwaysKept() {
+        let frame = CGRect(x: 0, y: 0, width: 800, height: 600)
+        let kept = NativeTabGrouping.representativeIDs(from: [
+            candidate(id: 1, frame: frame, recency: 0, groupable: true),
+            candidate(id: 2, frame: frame, recency: 9, groupable: false),
+            candidate(id: 3, frame: frame, recency: 1, groupable: true),
+        ])
+        // The minimized/hidden window (id 2) is always kept; the two groupable
+        // tabs collapse to the more recent one (id 3).
+        #expect(kept == [2, 3])
+    }
+
+    @Test func roundsSubpixelFrameDifferences() {
+        let kept = NativeTabGrouping.representativeIDs(from: [
+            candidate(id: 1, frame: CGRect(x: 10.2, y: 20.1, width: 800.4, height: 600.3), recency: 1),
+            candidate(id: 2, frame: CGRect(x: 9.8, y: 20.4, width: 799.6, height: 600.0), recency: 2),
+        ])
+        #expect(kept == [2])
+    }
+
+    @Test func tieBreaksOnLargerIDDeterministically() {
+        let frame = CGRect(x: 0, y: 0, width: 400, height: 400)
+        let kept = NativeTabGrouping.representativeIDs(from: [
+            candidate(id: 7, frame: frame, recency: 3),
+            candidate(id: 42, frame: frame, recency: 3),
+        ])
+        #expect(kept == [42])
+    }
+
+    @Test func emptyInputYieldsEmpty() {
+        #expect(NativeTabGrouping.representativeIDs(from: []).isEmpty)
+    }
+}


### PR DESCRIPTION
## What

Adds an opt-in setting that collapses native macOS window-tab groups so a tabbed window shows up as a single preview instead of one preview per tab.

Closes #1434. Also addresses #1034 (Ghostty tabs counted as separate windows) and #1405.

## Why

Apps that use native macOS window tabbing (Ghostty, Finder, Terminal, Safari, and others) model each tab as a distinct `NSWindow`. The Accessibility API reports each of those windows separately, and window discovery had no tab-group awareness, so one tabbed window surfaced as one preview per tab.

There is no Accessibility attribute that exposes tab-group membership for arbitrary apps, so membership is inferred from a reliable side effect: the windows in one visible tab group are stacked at the exact same screen frame. Windows that share a process and an integer-rounded frame are treated as one group.

## How

- New `NativeTabGrouping` enum holds the grouping logic as a pure function over a minimal `Candidate` value type (id, pid, frame, recency, groupable), so it is unit-testable without Accessibility or AppKit types.
- `WindowUtil.collapseNativeTabsIfNeeded(_:)` adapts `WindowInfo` to `Candidate` and applies the grouping at both discovery choke points: the per-app path (`getActiveWindowsUpdatingCache`, used by dock previews and Cmd+Tab) and the all-apps switcher path (`getAllWindowsOfAllApps`). Because the group key includes the process id, passing the multi-app switcher list never merges windows from different apps.
- The representative kept per group is the most recently accessed window (typically the active tab); ties break on the larger window id for determinism.
- Minimized, hidden, windowless, and zero-sized windows are never collapsed.
- New toggle "Collapse native tabs into a single window" under Dock Previews > Window Display, plus a settings-search entry. Defaults to off.

## Trade-off

Collapsing a tab group also collapses genuinely separate windows of the same app that happen to share a frame. The active-app window-switcher hotkey still cycles individual windows, which is why this ships as an opt-in default-off setting.

## Testing

- `NativeTabGroupingTests` covers same-frame collapsing, distinct frames, cross-process isolation, non-groupable pass-through, subpixel rounding, deterministic tie-break, and empty input.
- Full app target and test target build clean; `xcodebuild test` passes locally (Xcode 26.5, macOS arm64).
