### PR TITLE
feat: media-spacebar

### DIFF
--- a/DockDoor/Utilities/KeybindHelper.swift
+++ b/DockDoor/Utilities/KeybindHelper.swift
@@ -435,8 +435,7 @@ class KeybindHelper {
             let flags = event.flags
             let shouldRouteCmdTabToWindowSwitcher = isCmdTabWindowSwitcherKeybind(keyCode: keyCode, flags: flags)
 
-            // Bare spacebar toggles play/pause for a visible media preview. Consume it so it
-            // doesn't also reach the focused app (which would double-toggle the media player).
+            // Consume bare spacebar for a visible media preview so it doesn't also reach the focused app and double-toggle playback.
             if keyCode == Int64(kVK_Space),
                event.getIntegerValueField(.keyboardEventAutorepeat) == 0,
                !flags.hasSuperfluousModifiers(),

--- a/DockDoor/Utilities/KeybindHelper.swift
+++ b/DockDoor/Utilities/KeybindHelper.swift
@@ -435,6 +435,16 @@ class KeybindHelper {
             let flags = event.flags
             let shouldRouteCmdTabToWindowSwitcher = isCmdTabWindowSwitcherKeybind(keyCode: keyCode, flags: flags)
 
+            // Bare spacebar toggles play/pause for a visible media preview. Consume it so it
+            // doesn't also reach the focused app (which would double-toggle the media player).
+            if keyCode == Int64(kVK_Space),
+               event.getIntegerValueField(.keyboardEventAutorepeat) == 0,
+               !flags.hasSuperfluousModifiers(),
+               MediaKeyboardShortcutCoordinator.shared.handleSpaceKeyDown()
+            {
+                return nil
+            }
+
             let backwardKeyCode = Defaults[.switcherBackwardKeyCode]
             if Self.eventFlagForKeyCode(backwardKeyCode) == nil,
                keyCode == Int64(backwardKeyCode),

--- a/DockDoor/Views/Hover Window/Special Hover Windows/Media/VolumeScrollModifier.swift
+++ b/DockDoor/Views/Hover Window/Special Hover Windows/Media/VolumeScrollModifier.swift
@@ -16,10 +16,7 @@ struct MediaScrollModifier: ViewModifier {
                 setupMonitor()
                 shortcutRegistration = MediaKeyboardShortcutCoordinator.shared.register(mediaInfo)
             }
-            // `hitTestView` is populated asynchronously by ScrollHitTestHelper, so it's nil at
-            // onAppear; onChange carries the resolved view into the registration. Resetting it on
-            // disappear guarantees this fires again on every reappearance, even if SwiftUI reuses
-            // the same NSView.
+            // hitTestView resolves asynchronously after onAppear, and is reset on disappear so this refires even when SwiftUI reuses the NSView.
             .onChange(of: hitTestView) { newView in
                 shortcutRegistration?.hostView = newView
             }
@@ -102,52 +99,35 @@ struct MediaScrollModifier: ViewModifier {
     }
 }
 
-/// One live media view's claim on the spacebar shortcut. `hostView` resolves the preview
-/// window the media is rendered in, so the coordinator can scope the shortcut per preview.
-final class MediaShortcutRegistration: Hashable {
+/// One live media view's claim on the spacebar shortcut; `hostView` resolves which preview window it's rendered in.
+final class MediaShortcutRegistration {
     let mediaInfo: MediaInfo
     weak var hostView: NSView?
 
     init(mediaInfo: MediaInfo) {
         self.mediaInfo = mediaInfo
     }
-
-    static func == (lhs: MediaShortcutRegistration, rhs: MediaShortcutRegistration) -> Bool {
-        lhs === rhs
-    }
-
-    func hash(into hasher: inout Hasher) {
-        hasher.combine(ObjectIdentifier(self))
-    }
 }
 
-/// Tracks the media views currently on screen and resolves the spacebar play/pause shortcut.
-///
-/// The decision runs from the global key event tap in `KeybindHelper` (on the main thread) so
-/// the spacebar can be *consumed* — otherwise it would also reach the focused app and, when
-/// that app is the media player, double-toggle playback. The shortcut acts only when a single
-/// preview is on screen rendering exactly one distinct media source; two apps within one
-/// preview (or several previews) is ambiguous, so it's left alone and the key passes through.
+/// Tracks on-screen media views and toggles play/pause from the spacebar, but only when a single visible preview resolves to one distinct media source.
 final class MediaKeyboardShortcutCoordinator {
     static let shared = MediaKeyboardShortcutCoordinator()
 
-    private var registrations: Set<MediaShortcutRegistration> = []
+    private var registrations: [MediaShortcutRegistration] = []
 
     private init() {}
 
     func register(_ mediaInfo: MediaInfo) -> MediaShortcutRegistration {
         let registration = MediaShortcutRegistration(mediaInfo: mediaInfo)
-        registrations.insert(registration)
+        registrations.append(registration)
         return registration
     }
 
     func unregister(_ registration: MediaShortcutRegistration) {
-        registrations.remove(registration)
+        registrations.removeAll { $0 === registration }
     }
 
-    /// Called for a bare spacebar key-down from the global event tap. Returns `true` when an
-    /// unambiguous media preview handled it, signalling the caller to consume the event. The
-    /// toggle is hopped to the main actor since `MediaInfo` is main-actor isolated.
+    /// Returns `true` when a media preview handled the spacebar, signalling the event tap to consume the event.
     func handleSpaceKeyDown() -> Bool {
         guard let mediaInfo = unambiguousVisibleSource() else { return false }
 
@@ -160,23 +140,19 @@ final class MediaKeyboardShortcutCoordinator {
         return true
     }
 
-    /// The single media source to control, or `nil` when the target is ambiguous: the visible
-    /// media views must all live in one preview window and resolve to one distinct source.
+    /// The single media source to control, or `nil` when the target is ambiguous (multiple previews, or multiple sources in one preview).
     private func unambiguousVisibleSource() -> MediaInfo? {
-        var windowID: ObjectIdentifier?
-        var sources: Set<ObjectIdentifier> = []
+        var window: NSWindow?
         var source: MediaInfo?
 
         for registration in registrations {
-            guard let window = registration.hostView?.window else { continue }
+            guard let hostWindow = registration.hostView?.window else { continue }
 
-            let id = ObjectIdentifier(window)
-            if windowID == nil { windowID = id }
-            guard windowID == id else { return nil } // spans multiple previews
+            if window == nil { window = hostWindow }
+            guard window === hostWindow else { return nil }
 
-            sources.insert(ObjectIdentifier(registration.mediaInfo))
-            guard sources.count == 1 else { return nil } // multiple apps in one preview
-            source = registration.mediaInfo
+            if source == nil { source = registration.mediaInfo }
+            guard source === registration.mediaInfo else { return nil }
         }
 
         return source

--- a/DockDoor/Views/Hover Window/Special Hover Windows/Media/VolumeScrollModifier.swift
+++ b/DockDoor/Views/Hover Window/Special Hover Windows/Media/VolumeScrollModifier.swift
@@ -7,12 +7,26 @@ struct MediaScrollModifier: ViewModifier {
     @State private var scrollMonitor: Any?
     @State private var seekDebounceWork: DispatchWorkItem?
     @State private var hitTestView: NSView?
+    @State private var shortcutRegistration: MediaShortcutRegistration?
 
     func body(content: Content) -> some View {
         content
             .background(ScrollHitTestHelper(view: $hitTestView))
-            .onAppear { setupMonitor() }
-            .onDisappear { removeMonitor() }
+            .onAppear {
+                setupMonitor()
+                shortcutRegistration = MediaKeyboardShortcutCoordinator.shared.register(mediaInfo)
+                shortcutRegistration?.hostView = hitTestView
+            }
+            .onChange(of: hitTestView) { newView in
+                shortcutRegistration?.hostView = newView
+            }
+            .onDisappear {
+                removeMonitor()
+                if let shortcutRegistration {
+                    MediaKeyboardShortcutCoordinator.shared.unregister(shortcutRegistration)
+                    self.shortcutRegistration = nil
+                }
+            }
     }
 
     private func setupMonitor() {
@@ -81,6 +95,87 @@ struct MediaScrollModifier: ViewModifier {
         }
         seekDebounceWork = work
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.2, execute: work)
+    }
+}
+
+/// One live media view's claim on the spacebar shortcut. `hostView` resolves the preview
+/// window the media is rendered in, so the coordinator can scope the shortcut per preview.
+final class MediaShortcutRegistration: Hashable {
+    let mediaInfo: MediaInfo
+    weak var hostView: NSView?
+
+    init(mediaInfo: MediaInfo) {
+        self.mediaInfo = mediaInfo
+    }
+
+    static func == (lhs: MediaShortcutRegistration, rhs: MediaShortcutRegistration) -> Bool {
+        lhs === rhs
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(ObjectIdentifier(self))
+    }
+}
+
+/// Tracks the media views currently on screen and resolves the spacebar play/pause shortcut.
+///
+/// The decision runs from the global key event tap in `KeybindHelper` (on the main thread) so
+/// the spacebar can be *consumed* — otherwise it would also reach the focused app and, when
+/// that app is the media player, double-toggle playback. The shortcut acts only when a single
+/// preview is on screen rendering exactly one distinct media source; two apps within one
+/// preview (or several previews) is ambiguous, so it's left alone and the key passes through.
+final class MediaKeyboardShortcutCoordinator {
+    static let shared = MediaKeyboardShortcutCoordinator()
+
+    private var registrations: Set<MediaShortcutRegistration> = []
+
+    private init() {}
+
+    func register(_ mediaInfo: MediaInfo) -> MediaShortcutRegistration {
+        let registration = MediaShortcutRegistration(mediaInfo: mediaInfo)
+        registrations.insert(registration)
+        return registration
+    }
+
+    func unregister(_ registration: MediaShortcutRegistration) {
+        registrations.remove(registration)
+    }
+
+    /// Called for a bare spacebar key-down from the global event tap. Returns `true` when an
+    /// unambiguous media preview handled it, signalling the caller to consume the event. The
+    /// toggle is hopped to the main actor since `MediaInfo` is main-actor isolated.
+    func handleSpaceKeyDown() -> Bool {
+        guard let mediaInfo = unambiguousVisibleSource() else { return false }
+
+        Task { @MainActor in
+            withAnimation(Defaults[.showAnimations] ? .easeInOut(duration: 0.2) : nil) {
+                mediaInfo.isPlaying.toggle()
+            }
+            mediaInfo.playPause()
+        }
+        return true
+    }
+
+    /// The single media source to control, or `nil` when the target is ambiguous: the visible
+    /// media views must all live in one preview window and resolve to one distinct source.
+    private func unambiguousVisibleSource() -> MediaInfo? {
+        var windowID: ObjectIdentifier?
+        var sources: Set<ObjectIdentifier> = []
+        var source: MediaInfo?
+
+        for registration in registrations {
+            guard let window = registration.hostView?.window else { continue }
+
+            let id = ObjectIdentifier(window)
+            if windowID == nil { windowID = id }
+            guard windowID == id else { return nil } // spans multiple previews
+
+            sources.insert(ObjectIdentifier(registration.mediaInfo))
+            guard sources.count == 1 else { return nil } // multiple apps in one preview
+            source = registration.mediaInfo
+        }
+
+        return source
     }
 }
 

--- a/DockDoor/Views/Hover Window/Special Hover Windows/Media/VolumeScrollModifier.swift
+++ b/DockDoor/Views/Hover Window/Special Hover Windows/Media/VolumeScrollModifier.swift
@@ -15,13 +15,17 @@ struct MediaScrollModifier: ViewModifier {
             .onAppear {
                 setupMonitor()
                 shortcutRegistration = MediaKeyboardShortcutCoordinator.shared.register(mediaInfo)
-                shortcutRegistration?.hostView = hitTestView
             }
+            // `hitTestView` is populated asynchronously by ScrollHitTestHelper, so it's nil at
+            // onAppear; onChange carries the resolved view into the registration. Resetting it on
+            // disappear guarantees this fires again on every reappearance, even if SwiftUI reuses
+            // the same NSView.
             .onChange(of: hitTestView) { newView in
                 shortcutRegistration?.hostView = newView
             }
             .onDisappear {
                 removeMonitor()
+                hitTestView = nil
                 if let shortcutRegistration {
                     MediaKeyboardShortcutCoordinator.shared.unregister(shortcutRegistration)
                     self.shortcutRegistration = nil


### PR DESCRIPTION
## Describe your changes

I want the spacebar to play/pause media when hovered in preview.  

Files Touched: 
1. `DockDoor/Utilities/KeybindHelper.swift`

While it is possible to implement this all within a single file, in order to ensure that the SPACEBAR press is actually consumed, we must hook it into the global keybind helper. (We could do this without hooking it in here but would result in a lot of duplicated code).

2. DockDoor/Views/Hover Window/Special Hover Windows/Media/VolumeScrollModifier.swift

Added a new idea `ShortcutRegistration`. The idea here is that in case an app has multiple media objects associated with it, we want to ensure that using SPACEBAR to play / pause is skipped because the target is ambiguous. Whenever a media is previewed, we register it as a shortcut (in our ShortcutRegistration) and if it meets certain conditions (e.g. there is only one media preview object), the SPACEBAR will act as a play/pause button.

## Related issue number(s) and link(s)

## Checklist before requesting a review
- [X] I have performed a self-review of my code and understand every line
- [X] If this change affects core functionality, I have added a description highlighting the changes
- [X] I have followed conventional commit guidelines
- [X] I have tested this PR on my own machine

## AI Assistance Disclosure

> **Policy**: AI-assisted contributions are welcome, but you must understand, test, and take full responsibility for your code. Pasting AI-generated code or PR descriptions without genuine human review and understanding will result in your PR being closed and may result in a ban from contributing.

**Did you use AI tools (ChatGPT, Claude, Copilot, Cursor, etc.) for this PR?**
- [ ] No AI tools were used
- [X] Yes - describe below how AI was used and confirm you reviewed/tested the output

I had Claude Code write (under supervision), the below changes. I built the new version, and tested on my machine locally. I had it refactor some of its logic into the output which can be seen below. 

**Disclosure**: I am not a swift developer so am unfamiliar with conventions. Please let me know if there is some best practice not adhered to below, and I will fix it.

Note: there is an existing bug that causes the play/pause flicker when the media preview is used to play/pause media. I have another PR for that. This is unrelated to the below changes.