### PR TITLE
fix(media): playpause skipping

### DIFF
--- a/DockDoor/Utilities/Media/MediaRemoteService.swift
+++ b/DockDoor/Utilities/Media/MediaRemoteService.swift
@@ -38,6 +38,8 @@ final class MediaRemoteService: ObservableObject {
     /// (or `seekDebounceInterval` lapses).
     private var playbackIntent: (isPlaying: Bool, date: Date)?
 
+    private var resyncWork: DispatchWorkItem?
+
     var interpolatedElapsedTime: TimeInterval {
         if let seek = seekBase, seek.rate == 0 || isWithinSeekWindow {
             return max(0, seek.position + Date().timeIntervalSince(seek.date) * seek.rate)
@@ -127,6 +129,21 @@ final class MediaRemoteService: ObservableObject {
         seekBase = (position: interpolatedElapsedTime, date: now, rate: rate)
         isPlaying = targetIsPlaying
         playbackRate = rate
+        resyncTrackInfo()
+    }
+
+    /// Pulls a fresh authoritative snapshot shortly after a command so the gate converges onto the
+    /// player's real position promptly, instead of waiting for it to emit a state-change event.
+    private func resyncTrackInfo() {
+        resyncWork?.cancel()
+        let work = DispatchWorkItem { [weak self] in
+            self?.controller.getTrackInfo { [weak self] info in
+                guard let info else { return }
+                self?.handleTrackInfo(info)
+            }
+        }
+        resyncWork = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3, execute: work)
     }
 
     func nextTrack() {
@@ -180,10 +197,17 @@ final class MediaRemoteService: ObservableObject {
         let sameSource = payload.bundleIdentifier == activeBundleIdentifier
         let sameTrack = sameSource && payload.title == title && payload.artist == artist
 
-        // Hold the pre-pause position while paused (the feed's paused elapsed is unreliable); clear
-        // the hold on resume so the live position flows again. Our own commands seed this above.
+        // Manage the local position base across transitions. While paused, hold the pre-pause
+        // position (the feed's paused elapsed is unreliable). On resume, converge the optimistic
+        // pin onto the feed's live position the moment the player genuinely reports playing, so the
+        // elapsed time doesn't jump when the pin's window lapses onto the feed; `lastSeekTime` is
+        // left untouched so the window still expires on schedule, now onto a matching line.
         if incomingIsPlaying {
-            if seekBase?.rate == 0 { seekBase = nil }
+            if let base = seekBase, base.rate != 0, payload.isPlaying == true, sameTrack {
+                seekBase = (position: incomingElapsed, date: Date(), rate: incomingRate)
+            } else if seekBase?.rate == 0 {
+                seekBase = nil
+            }
         } else if isPlaying, sameTrack {
             lastSeekTime = Date()
             seekBase = (position: priorElapsed, date: Date(), rate: 0)

--- a/DockDoor/Utilities/Media/MediaRemoteService.swift
+++ b/DockDoor/Utilities/Media/MediaRemoteService.swift
@@ -27,18 +27,26 @@ final class MediaRemoteService: ObservableObject {
 
     private var currentTrackInfo: TrackInfo?
 
-    /// After a seek, we interpolate locally until the next track info event arrives.
+    /// After a seek or pause, we interpolate locally instead of trusting the feed's reported
+    /// position, which is briefly unreliable around transitions. A moving base (rate > 0) is honored
+    /// only until `seekDebounceInterval` lapses; a paused base (rate 0) is held until playback
+    /// resumes, since the feed's paused elapsed stays unreliable (it reports 0 or stale values).
     private var seekBase: (position: TimeInterval, date: Date, rate: Double)?
 
+    /// After we issue a play/pause, the feed emits a few events still carrying the previous state.
+    /// We record the state we asked for and ignore contradicting reports until the feed confirms it
+    /// (or `seekDebounceInterval` lapses).
+    private var playbackIntent: (isPlaying: Bool, date: Date)?
+
     var interpolatedElapsedTime: TimeInterval {
-        if let seek = seekBase,
-           let seekTime = lastSeekTime,
-           Date().timeIntervalSince(seekTime) < seekDebounceInterval
-        {
-            let elapsed = Date().timeIntervalSince(seek.date)
-            return max(0, seek.position + elapsed * seek.rate)
+        if let seek = seekBase, seek.rate == 0 || isWithinSeekWindow {
+            return max(0, seek.position + Date().timeIntervalSince(seek.date) * seek.rate)
         }
         return currentTrackInfo?.payload.currentElapsedTime ?? 0
+    }
+
+    private var isWithinSeekWindow: Bool {
+        lastSeekTime.map { Date().timeIntervalSince($0) < seekDebounceInterval } ?? false
     }
 
     var hasActiveMedia: Bool { !title.isEmpty }
@@ -95,15 +103,30 @@ final class MediaRemoteService: ObservableObject {
     // MARK: - Playback Controls
 
     func togglePlayPause() {
+        beginPlaybackIntent(targetIsPlaying: !isPlaying)
         controller.togglePlayPause()
     }
 
     func play() {
+        beginPlaybackIntent(targetIsPlaying: true)
         controller.play()
     }
 
     func pause() {
+        beginPlaybackIntent(targetIsPlaying: false)
         controller.pause()
+    }
+
+    /// Optimistically applies a play/pause: records the expected state and pins the elapsed time so
+    /// the feed's transient transition events don't flicker the state or jump the time.
+    private func beginPlaybackIntent(targetIsPlaying: Bool) {
+        let now = Date()
+        let rate = targetIsPlaying ? (playbackRate > 0 ? playbackRate : 1.0) : 0.0
+        playbackIntent = (isPlaying: targetIsPlaying, date: now)
+        lastSeekTime = now
+        seekBase = (position: interpolatedElapsedTime, date: now, rate: rate)
+        isPlaying = targetIsPlaying
+        playbackRate = rate
     }
 
     func nextTrack() {
@@ -128,26 +151,49 @@ final class MediaRemoteService: ObservableObject {
 
     private func handleTrackInfo(_ trackInfo: TrackInfo?) {
         guard let trackInfo else {
-            currentTrackInfo = nil
-            seekBase = nil
             clearState()
             return
         }
 
-        currentTrackInfo = trackInfo
         let payload = trackInfo.payload
+        let priorElapsed = interpolatedElapsedTime // capture before currentTrackInfo updates
+        currentTrackInfo = trackInfo
 
-        let incomingRate = payload.playbackRate ?? ((payload.isPlaying ?? false) ? 1.0 : 0.0)
+        // Trust the explicit isPlaying flag: on the first pause event the player still reports a
+        // playbackRate of 1.0, so deriving the state from the rate would misread a pause as playing.
+        var incomingIsPlaying = payload.isPlaying ?? ((payload.playbackRate ?? 0) > 0)
+        var incomingRate = incomingIsPlaying ? (payload.playbackRate ?? 1.0) : 0.0
         let incomingDuration = (payload.durationMicros ?? 0) / 1_000_000.0
         let incomingElapsed = payload.currentElapsedTime ?? 0
 
-        let shouldIgnorePosition = lastSeekTime.map { Date().timeIntervalSince($0) < seekDebounceInterval } ?? false
-        if !shouldIgnorePosition {
-            seekBase = nil
+        // While a play/pause we issued is settling, ignore reports that contradict it; accept and
+        // clear the intent once the feed confirms it (or the window lapses).
+        if let intent = playbackIntent {
+            if incomingIsPlaying == intent.isPlaying || Date().timeIntervalSince(intent.date) >= seekDebounceInterval {
+                playbackIntent = nil
+            } else {
+                incomingIsPlaying = isPlaying
+                incomingRate = playbackRate
+            }
         }
 
         let sameSource = payload.bundleIdentifier == activeBundleIdentifier
         let sameTrack = sameSource && payload.title == title && payload.artist == artist
+
+        // Hold the pre-pause position while paused (the feed's paused elapsed is unreliable); clear
+        // the hold on resume so the live position flows again. Our own commands seed this above.
+        if incomingIsPlaying {
+            if seekBase?.rate == 0 { seekBase = nil }
+        } else if isPlaying, sameTrack {
+            lastSeekTime = Date()
+            seekBase = (position: priorElapsed, date: Date(), rate: 0)
+        }
+
+        let shouldIgnorePosition = seekBase?.rate == 0 || isWithinSeekWindow
+        if !shouldIgnorePosition {
+            seekBase = nil
+        }
+
         let resolvedArtwork: NSImage? = if let incoming = payload.artwork {
             incoming
         } else if sameTrack {
@@ -172,12 +218,12 @@ final class MediaRemoteService: ObservableObject {
             artist = payload.artist ?? ""
             album = payload.album ?? ""
             playbackRate = incomingRate
-            isPlaying = incomingRate > 0
+            isPlaying = incomingIsPlaying
             duration = incomingDuration
             artwork = resolvedArtwork
         } else if incomingRate != playbackRate {
             playbackRate = incomingRate
-            isPlaying = incomingRate > 0
+            isPlaying = incomingIsPlaying
         }
 
         if !shouldIgnorePosition {
@@ -207,6 +253,7 @@ final class MediaRemoteService: ObservableObject {
     private func clearState() {
         currentTrackInfo = nil
         seekBase = nil
+        playbackIntent = nil
         activeBundleIdentifier = nil
         activeAppName = nil
         title = ""


### PR DESCRIPTION
When you press pause via dockdoor the media preview flickers. Further, after a pausing event, the track briefly skips back to its initial state (before playing started) and then goes back to its finishing state.

## Describe your changes

Trust the payload's explicit isPlaying flag instead of deriving play-state from playbackRate: the first pause event still reports a rate of 1.0, which was misread as "playing" and flickered the controls.

Hold the pre-pause position locally while paused (reusing seekBase with a rate of 0) because the feed's paused elapsed snapshot is unreliable (0 or stale), which made the displayed time skip around. Optimistically apply DockDoor-issued play/pause via playbackIntent so transient transition events can't revert the state before the feed settles.

**Files Touched**: `DockDoor/Utilities/Media/MediaRemoteService.swift`
- Simplified conditional interpolatedElapsedTime by introducing isWithinSeekWindow
- Added playbackIntent variable which represents a Play/Pause event and is used to discard/disregard the media player not handling the play/pause yet
- Added beginPlaybackIntent which is just a helper to optimistically update the ui
- Added the playbackIntent to the handleTrackInfo function, ensuring that we let the state settle after a play/pause event


## Related issue number(s) and link(s)

None found / matched. Including a gif of what the issue looks like (before & after).

<img width="702" height="388" alt="CleanShot 2026-06-20 at 14 24 20" src="https://github.com/user-attachments/assets/42b188e3-98eb-4b91-bf82-5cfe22bcd967" />

<img width="702" height="388" alt="CleanShot 2026-06-20 at 16 04 12" src="https://github.com/user-attachments/assets/fb51f757-d735-45be-a765-b22194629126" />

## Checklist before requesting a review
- [X] I have performed a self-review of my code and understand every line
- [X] If this change affects core functionality, I have added a description highlighting the changes
- [X] I have followed conventional commit guidelines
- [X] I have tested this PR on my own machine

## AI Assistance Disclosure

> **Policy**: AI-assisted contributions are welcome, but you must understand, test, and take full responsibility for your code. Pasting AI-generated code or PR descriptions without genuine human review and understanding will result in your PR being closed and may result in a ban from contributing.

**Did you use AI tools (ChatGPT, Claude, Copilot, Cursor, etc.) for this PR?**
- [ ] No AI tools were used
- [X] Yes - describe below how AI was used and confirm you reviewed/tested the output

I had Claude Code write (under supervision), the below changes. I built the new version, and tested on my machine locally. I refactored in order to best match the current state.

Disclosure: I am not a swift developer so am unfamiliar with conventions. Please let me know if there is some best practice not adhered to below, and I will fix it.

