### PR TITLE
fix: refresh window switcher state on activation

### DIFF
--- a/DockDoor/Utilities/KeybindHelper.swift
+++ b/DockDoor/Utilities/KeybindHelper.swift
@@ -18,12 +18,10 @@ struct UserKeyBind: Codable, Defaults.Serializable {
 private class WindowSwitchingCoordinator {
     private var isProcessingSwitcher = false
     private var uiRenderingTask: Task<Void, Never>?
+    private var windowRefreshTask: Task<Void, Never>?
     private var currentSessionId = UUID()
     /// When true, initialization should complete but immediately select the window instead of showing UI
     private var shouldSelectImmediately = false
-
-    private static var lastUpdateAllWindowsTime: Date?
-    private static let updateAllWindowsThrottleInterval: TimeInterval = 60.0
 
     @MainActor
     func handleWindowSwitching(
@@ -62,51 +60,28 @@ private class WindowSwitchingCoordinator {
     ) async {
         // Reset the immediate-select flag at start of initialization
         shouldSelectImmediately = false
-
-        var windows = WindowUtil.getAllWindowsOfAllApps()
-        let windowsForWindowlessDetection = windows
-
-        let filterBySpace = (mode == .currentSpaceOnly || mode == .activeAppCurrentSpace)
-            || (mode == .allWindows && Defaults[.showWindowsFromCurrentSpaceOnlyInSwitcher])
-        if filterBySpace {
-            windows = WindowUtil.filterWindowsByCurrentSpace(windows)
-        }
-
-        if mode == .allWindows, Defaults[.showWindowsFromCurrentMonitorOnlyInSwitcher] {
-            windows = WindowUtil.filterWindowsByCurrentMonitor(windows)
-        }
-
-        let filterByApp = (mode == .activeAppOnly || mode == .activeAppCurrentSpace)
-            || (mode == .allWindows && Defaults[.limitSwitcherToFrontmostApp])
-        if filterByApp {
-            windows = WindowUtil.getWindowsForFrontmostApp(from: windows)
-        }
-
-        if !Defaults[.includeHiddenWindowsInSwitcher] {
-            windows = windows.filter { !$0.isHidden && !$0.isMinimized }
-        }
-
-        windows = WindowUtil.sortWindowsForSwitcher(windows)
-
-        // Group windows for selected apps (only in multi-app modes)
-        let isActiveAppMode = (mode == .activeAppOnly || mode == .activeAppCurrentSpace)
-            || (mode == .allWindows && Defaults[.limitSwitcherToFrontmostApp])
-        if !isActiveAppMode {
-            windows = WindowUtil.groupWindowsByApp(windows)
-        }
-
-        if !isActiveAppMode, Defaults[.showWindowlessAppsInSwitcher] {
-            windows.append(contentsOf: WindowUtil.getWindowlessRunningApps(existingWindows: windowsForWindowlessDetection))
-        }
-
-        guard !windows.isEmpty else { return }
+        windowRefreshTask?.cancel()
 
         currentSessionId = UUID()
         let sessionId = currentSessionId
+        let targetScreen = getTargetScreenForSwitcher()
+        let currentMouseLocation = DockObserver.getMousePosition()
+        let dockPosition = DockUtils.getDockPosition()
+
+        var didRefreshBeforeInitialization = false
+        var windows = buildSwitcherWindows(mode: mode)
+        if windows.isEmpty {
+            // The switcher normally opens from cache. If the cache has nothing usable,
+            // do one discovery pass before giving up so late-observed GUI apps can appear.
+            await WindowUtil.updateAllWindowsInCurrentSpace()
+            guard sessionId == currentSessionId else { return }
+            didRefreshBeforeInitialization = true
+            windows = buildSwitcherWindows(mode: mode)
+        }
+        guard !windows.isEmpty else { return }
 
         let coordinator = previewCoordinator.windowSwitcherCoordinator
-        let targetScreen = getTargetScreenForSwitcher()
-        coordinator.initializeForWindowSwitcher(with: windows, dockPosition: DockUtils.getDockPosition(), bestGuessMonitor: targetScreen)
+        coordinator.initializeForWindowSwitcher(with: windows, dockPosition: dockPosition, bestGuessMonitor: targetScreen)
         coordinator.activateKeybindSession()
 
         // If modifier was released during initialization, immediately select and exit
@@ -124,19 +99,16 @@ private class WindowSwitchingCoordinator {
             return
         }
 
-        let currentMouseLocation = DockObserver.getMousePosition()
-
-        Task.detached(priority: .low) {
-            let now = Date()
-            let shouldUpdate: Bool = if let lastUpdate = WindowSwitchingCoordinator.lastUpdateAllWindowsTime {
-                now.timeIntervalSince(lastUpdate) >= WindowSwitchingCoordinator.updateAllWindowsThrottleInterval
-            } else {
-                true
-            }
-
-            guard shouldUpdate else { return }
-            WindowSwitchingCoordinator.lastUpdateAllWindowsTime = now
-            await WindowUtil.updateAllWindowsInCurrentSpace()
+        if !didRefreshBeforeInitialization {
+            // Non-empty snapshots render immediately; refresh in the background so the
+            // active session can correct stale or missing cache entries without delaying open.
+            scheduleWindowRefresh(
+                previewCoordinator: previewCoordinator,
+                mode: mode,
+                dockPosition: dockPosition,
+                targetScreen: targetScreen,
+                sessionId: sessionId
+            )
         }
 
         uiRenderingTask?.cancel()
@@ -146,22 +118,124 @@ private class WindowSwitchingCoordinator {
             }
             await renderWindowSwitcherUI(
                 previewCoordinator: previewCoordinator,
-                windows: windows,
                 currentMouseLocation: currentMouseLocation,
                 targetScreen: targetScreen,
-                initialIndex: coordinator.currIndex,
                 sessionId: sessionId
             )
         }
     }
 
     @MainActor
+    private func buildSwitcherWindows(mode: SwitcherInvocationMode) -> [WindowInfo] {
+        var windows = WindowUtil.getAllWindowsOfAllApps()
+        let windowsForWindowlessDetection = windows
+
+        let filterBySpace = (mode == .currentSpaceOnly || mode == .activeAppCurrentSpace)
+            || (mode == .allWindows && Defaults[.showWindowsFromCurrentSpaceOnlyInSwitcher])
+        if filterBySpace {
+            windows = WindowUtil.filterWindowsByCurrentSpace(windows)
+        }
+
+        if mode == .allWindows, Defaults[.showWindowsFromCurrentMonitorOnlyInSwitcher] {
+            windows = WindowUtil.filterWindowsByCurrentMonitor(windows)
+        }
+
+        let filterByApp = isActiveAppMode(mode)
+        if filterByApp {
+            windows = WindowUtil.getWindowsForFrontmostApp(from: windows)
+        }
+
+        if !Defaults[.includeHiddenWindowsInSwitcher] {
+            windows = windows.filter { !$0.isHidden && !$0.isMinimized }
+        }
+
+        windows = WindowUtil.sortWindowsForSwitcher(windows)
+
+        if !filterByApp {
+            windows = WindowUtil.groupWindowsByApp(windows)
+        }
+
+        if !filterByApp, Defaults[.showWindowlessAppsInSwitcher] {
+            windows.append(contentsOf: WindowUtil.getWindowlessRunningApps(existingWindows: windowsForWindowlessDetection))
+        }
+
+        return windows
+    }
+
+    private func isActiveAppMode(_ mode: SwitcherInvocationMode) -> Bool {
+        (mode == .activeAppOnly || mode == .activeAppCurrentSpace)
+            || (mode == .allWindows && Defaults[.limitSwitcherToFrontmostApp])
+    }
+
+    @MainActor
+    private func scheduleWindowRefresh(
+        previewCoordinator: SharedPreviewWindowCoordinator,
+        mode: SwitcherInvocationMode,
+        dockPosition: DockPosition,
+        targetScreen: NSScreen,
+        sessionId: UUID
+    ) {
+        windowRefreshTask?.cancel()
+        windowRefreshTask = Task.detached(priority: .low) { [weak self, weak previewCoordinator, mode, dockPosition, targetScreen, sessionId] in
+            await WindowUtil.updateAllWindowsInCurrentSpace()
+            guard !Task.isCancelled else { return }
+
+            await MainActor.run {
+                guard let self, let previewCoordinator else { return }
+                guard sessionId == self.currentSessionId else { return }
+
+                let coordinator = previewCoordinator.windowSwitcherCoordinator
+                guard coordinator.isKeybindSessionActive else { return }
+
+                let freshWindows = self.buildSwitcherWindows(mode: mode)
+                guard !freshWindows.isEmpty else { return }
+
+                self.applyRefreshedSwitcherWindows(
+                    freshWindows,
+                    coordinator: coordinator,
+                    dockPosition: dockPosition,
+                    bestGuessMonitor: targetScreen
+                )
+            }
+        }
+    }
+
+    @MainActor
+    private func applyRefreshedSwitcherWindows(
+        _ freshWindows: [WindowInfo],
+        coordinator: PreviewStateCoordinator,
+        dockPosition: DockPosition,
+        bestGuessMonitor: NSScreen
+    ) {
+        let selectedWindow = coordinator.getCurrentWindow()
+        let previousWindowCount = coordinator.windows.count
+
+        // Replace the global switcher list rather than using the single-app merge path.
+        // Windowless entries can share window ID 0, so preserving the full rebuilt list is safer.
+        coordinator.setWindows(freshWindows, dockPosition: dockPosition, bestGuessMonitor: bestGuessMonitor)
+
+        if let selectedWindow,
+           let newIndex = coordinator.windows.firstIndex(where: { isSameSwitcherWindow($0, selectedWindow) })
+        {
+            coordinator.setIndex(to: newIndex)
+        }
+
+        if coordinator.windows.count != previousWindowCount {
+            coordinator.onFrameRefreshNeeded?()
+        }
+    }
+
+    private func isSameSwitcherWindow(_ first: WindowInfo, _ second: WindowInfo) -> Bool {
+        // Window ID alone is not enough here because placeholder/windowless entries use 0.
+        first.id == second.id &&
+            first.app.processIdentifier == second.app.processIdentifier
+    }
+
+    @MainActor
     private func renderWindowSwitcherUI(
         previewCoordinator: SharedPreviewWindowCoordinator,
-        windows: [WindowInfo],
         currentMouseLocation: CGPoint,
         targetScreen: NSScreen,
-        initialIndex: Int,
         sessionId: UUID
     ) async {
         guard sessionId == currentSessionId else { return }
@@ -172,6 +246,8 @@ private class WindowSwitchingCoordinator {
             return
         }
         let showWindowLambda = { (mouseLocation: NSPoint?, mouseScreen: NSScreen?) in
+            let windows = coordinator.windows
+            guard !windows.isEmpty else { return }
             previewCoordinator.showWindow(
                 appName: "Window Switcher",
                 windows: windows,
@@ -226,6 +302,7 @@ private class WindowSwitchingCoordinator {
         currentSessionId = UUID()
         coordinator.deactivateKeybindSession()
         uiRenderingTask?.cancel()
+        windowRefreshTask?.cancel()
         return selectedWindow
     }
 
@@ -239,6 +316,7 @@ private class WindowSwitchingCoordinator {
         shouldSelectImmediately = false
         previewCoordinator.windowSwitcherCoordinator.deactivateKeybindSession()
         uiRenderingTask?.cancel()
+        windowRefreshTask?.cancel()
     }
 
     /// Signals that the modifier was released during initialization.
@@ -249,6 +327,7 @@ private class WindowSwitchingCoordinator {
         currentSessionId = UUID()
         shouldSelectImmediately = true
         uiRenderingTask?.cancel()
+        windowRefreshTask?.cancel()
     }
 }
 


### PR DESCRIPTION
## Describe your changes
Refresh global window discovery when starting a window switcher session and rebuild the switcher list with the same filtering rules used for the initial cached snapshot.

The switcher previously opened from cached window state only, which could leave it out of sync with the current desktop. This showed up as terminal-spawned GUI windows, such as mpv or non-bundled game windows, missing until Dock hover or Cmd+Tab refreshed that app. It could also leave stale windows from separate app instances, such as WezTerm launched with `open -a -n`, in the switcher after they were gone.

Preserve the current selection across refreshes by matching both PID and window ID, and cancel the refresh task when the switcher session ends.

<!-- Write this section yourself. Explain WHAT you changed and WHY in your own words. -->

## Related issue number(s) and link(s)

## Checklist before requesting a review
- [x] I have performed a self-review of my code and understand every line
- [x] If this change affects core functionality, I have added a description highlighting the changes
- [x] I have followed conventional commit guidelines
- [x] I have tested this PR on my own machine

## AI Assistance Disclosure

> **Policy**: AI-assisted contributions are welcome, but you must understand, test, and take full responsibility for your code. Pasting AI-generated code or PR descriptions without genuine human review and understanding will result in your PR being closed and may result in a ban from contributing.

**Did you use AI tools (ChatGPT, Claude, Copilot, Cursor, etc.) for this PR?**
- [ ] No AI tools were used
- [x] Yes - describe below how AI was used and confirm you reviewed/tested the output

<!-- If yes, briefly describe: What tool? What did it help with? Did you modify/review its output? -->

OpenAI's Codex with GPT 5.5, sent it to hunt for the bug where windows switcher cache is stale, does not show all windows up until I hover mouse over dock and after the preview pop ups it start to show the missing windows in windows switcher, same workaround with cmd+tab as well as having a phantom windows that I spawned with `open -a -n wezterm` that were long closed but window switcher were still showing them up until I hover on the dock's wezterm icon.

It found the bug, brainstormed with me potential solutions, I then decided to go with the one that have the least blast radius, narrowed to a single file since all the building blocks were already there, made local Debug build, copied preferences and then confirmed that it works and bug is fixed after running my Debug type build.

This is how I tested the change:

- Built the project in Debug mode

```
  xcodebuild build \
    -project DockDoor.xcodeproj \
    -scheme DockDoor \
    -configuration Debug \
    -destination 'platform=macOS' \
    -derivedDataPath ./DerivedData \
    CODE_SIGN_IDENTITY=- \
    CODE_SIGNING_REQUIRED=NO \
    CODE_SIGNING_ALLOWED=NO
```
- Then I run it and closed so the preferences file is created.

- Followed up by coping the preferences from non-debug DockDoor into the Debug variant

```
defaults export com.ethanbills.DockDoor /tmp/DockDoor-prefs.plist
defaults import com.ethanbills.DockDoor.debug /tmp/DockDoor-prefs.plist
killall cfprefsd
```

- then stopped the real DockDoor and launched my debug build

```
killall DockDoor
open ./DerivedData/Build/Products/Debug/DockDoor.app
```

- Granted the permissions to it, afterward again killed the DockDoor and re-started via `open` above and confirmed that the bug ix fixed. As in, the windows switcher pops up but right after that it refreshes with the missing windows. I also confirmed that I no longer get a phantom windows. I used to see wezterm there after I closed some of it's instances (`open -a -n wezterm`), same for some system preferences prompts that were in windows switcher up until I used cmd+tab or hover over settings app in dock.

### What "genuine human review" means:
- You can explain any line of code if asked
- You tested the changes yourself and verified they work
- You understand how your changes interact with existing code
- Your PR description reflects your actual understanding, not AI-generated summaries

### Examples of acceptable AI use:
- "Used Copilot for autocomplete suggestions, reviewed each one"
- "Asked Claude to explain how ScreenCaptureKit works, wrote the implementation myself"
- "Used ChatGPT to help debug an issue, verified the fix myself"

### What will get your PR closed (and possibly banned):
- Pasting AI output directly without review or understanding
- PR descriptions that are clearly AI-generated (overly formal, generic explanations you can't elaborate on)
- Unable to explain your own code changes when asked
- Submitting large refactors with undocumented behavioral changes

## Core Functionality Changes
If this PR modifies core functionality, please provide a brief description of the changes and their impact below:

This updates window switcher activation to refresh global window discovery and rebuild the displayed list from fresh cache state. It fixes missing newly discovered windows and stale closed windows in the switcher.