### PR TITLE
feat: add configurable Dock preview trigger

### DIFF
--- a/DockDoor/Utilities/DockObserver.swift
+++ b/DockDoor/Utilities/DockObserver.swift
@@ -275,6 +275,19 @@ final class DockObserver {
             return
         }
 
+        guard Defaults[.dockPreviewActivationMode] == .hover else {
+            return
+        }
+
+        showPreviewForHoveredDockApp(
+            mouseLocation: currentMouseLocation,
+            overrideDelay: false,
+            refreshLogContext: "dock hover"
+        )
+    }
+
+    @MainActor
+    private func showPreviewForHoveredDockApp(mouseLocation currentMouseLocation: CGPoint, overrideDelay: Bool, refreshLogContext: String) {
         let appUnderMouseElement = DebugLogger.measureSlow("getDockItemAppStatusUnderMouse", thresholdMs: 100) {
             getDockItemAppStatusUnderMouse()
         }
@@ -284,6 +297,8 @@ final class DockObserver {
             return
         }
 
+        guard Defaults[.enableDockPreviews] else { return }
+
         if case let .notRunning(bundleIdentifier) = appUnderMouseElement.status {
             let isCalendar = bundleIdentifier == calendarAppIdentifier && Defaults[.enableCalendarWidget]
             let mr = MediaRemoteService.shared
@@ -291,7 +306,7 @@ final class DockObserver {
             let isActiveMedia = mediaSourceMatches
                 && Defaults[.enableMediaWidget]
                 && (!mr.isUniversalSource || Defaults[.mediaDetectionMode] == .universal)
-            if isCalendar || isActiveMedia, Defaults[.showSpecialAppControls], Defaults[.enableDockPreviews] {
+            if isCalendar || isActiveMedia, Defaults[.showSpecialAppControls] {
                 let mouseScreen = NSScreen.screenFromQuartzPoint(currentMouseLocation)
                 let convertedMouseLocation = DockObserver.nsPointFromCGPoint(currentMouseLocation, forScreen: mouseScreen)
                 let appName = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleIdentifier)
@@ -305,7 +320,7 @@ final class DockObserver {
                     mouseLocation: convertedMouseLocation,
                     mouseScreen: mouseScreen,
                     dockItemElement: dockItemElement,
-                    overrideDelay: false,
+                    overrideDelay: overrideDelay,
                     onWindowTap: { [weak self] in self?.hideWindowAndResetLastApp() },
                     bundleIdentifier: bundleIdentifier
                 )
@@ -371,8 +386,6 @@ final class DockObserver {
             cachedWindows = cachedWindows.filter { !$0.isHidden && !$0.isMinimized }
         }
 
-        guard Defaults[.enableDockPreviews] else { return }
-
         let mouseScreen = NSScreen.screenFromQuartzPoint(currentMouseLocation)
         let convertedMouseLocation = DockObserver.nsPointFromCGPoint(currentMouseLocation, forScreen: mouseScreen)
         let screenOrigin = mouseScreen.frame.origin
@@ -393,7 +406,7 @@ final class DockObserver {
                 mouseLocation: convertedMouseLocation,
                 mouseScreen: mouseScreen,
                 dockItemElement: dockItemElement,
-                overrideDelay: false,
+                overrideDelay: overrideDelay,
                 onWindowTap: { [weak self] in
                     self?.hideWindowAndResetLastApp()
                 },
@@ -408,7 +421,7 @@ final class DockObserver {
             do {
                 var windows: [WindowInfo] = []
                 for appInstance in appsToFetchWindowsFrom {
-                    try await windows.append(contentsOf: DebugLogger.measureAsync("getActiveWindows (dock hover)", details: "PID: \(appInstance.processIdentifier)") {
+                    try await windows.append(contentsOf: DebugLogger.measureAsync("getActiveWindows (\(refreshLogContext))", details: "PID: \(appInstance.processIdentifier)") {
                         try await WindowUtil.getActiveWindows(of: appInstance)
                     })
                 }
@@ -450,10 +463,10 @@ final class DockObserver {
                         dockPosition: dockPosition,
                         bestGuessMonitor: monitor
                     )
-                    DebugLogger.log("WindowRefresh", details: "dock hover final merge, PID: \(currentAppPID), windows: \(freshWindows.count), merged: \(didMerge)")
+                    DebugLogger.log("WindowRefresh", details: "\(refreshLogContext) final merge, PID: \(currentAppPID), windows: \(freshWindows.count), merged: \(didMerge)")
                 }
             } catch {
-                DebugLogger.log("DockObserver", details: "Failed to fetch windows for dock hover: \(error)")
+                DebugLogger.log("DockObserver", details: "Failed to fetch windows for \(refreshLogContext): \(error)")
             }
         }
     }
@@ -713,7 +726,8 @@ final class DockObserver {
 
     private func setupEventTap() {
         var eventMask: CGEventMask = (1 << CGEventType.leftMouseDown.rawValue) |
-            (1 << CGEventType.rightMouseDown.rawValue)
+            (1 << CGEventType.rightMouseDown.rawValue) |
+            (1 << CGEventType.otherMouseDown.rawValue)
 
         if Defaults[.enableDockScrollGesture] || Defaults[.enableTitleBarScrollGesture] {
             eventMask |= (1 << CGEventType.scrollWheel.rawValue)
@@ -768,6 +782,10 @@ final class DockObserver {
 
         let appUnderMouse = getDockItemAppStatusUnderMouse()
 
+        if handleDockPreviewActivation(type: type, event: event, appUnderMouse: appUnderMouse) {
+            return nil
+        }
+
         if case let .success(app) = appUnderMouse.status {
             if type == .rightMouseDown, event.flags.contains(.maskCommand), Defaults[.enableCmdRightClickQuit] {
                 handleCmdRightClickQuit(app: app, event: event)
@@ -790,6 +808,49 @@ final class DockObserver {
         }
 
         return Unmanaged.passUnretained(event)
+    }
+
+    private func handleDockPreviewActivation(type: CGEventType, event: CGEvent, appUnderMouse: ApplicationReturnType) -> Bool {
+        guard Defaults[.enableDockPreviews],
+              !previewCoordinator.windowSwitcherCoordinator.windowSwitcherActive,
+              appUnderMouse.dockItemElement != nil
+        else {
+            return false
+        }
+
+        switch appUnderMouse.status {
+        case .success, .notRunning:
+            break
+        case .notFound:
+            return false
+        }
+
+        let shouldActivate = switch Defaults[.dockPreviewActivationMode] {
+        case .hover:
+            false
+        case .middleClick:
+            type == .otherMouseDown &&
+                event.getIntegerValueField(.mouseEventButtonNumber) == Int64(CGMouseButton.center.rawValue)
+        case .modifierClick:
+            type == .leftMouseDown && modifierFlagsExactlyMatch(event.flags, Defaults[.dockPreviewActivationModifier].eventFlag)
+        }
+
+        guard shouldActivate else { return false }
+
+        let mouseLocation = DockObserver.getMousePosition()
+        Task { @MainActor [weak self] in
+            self?.showPreviewForHoveredDockApp(
+                mouseLocation: mouseLocation,
+                overrideDelay: true,
+                refreshLogContext: "dock preview trigger"
+            )
+        }
+        return true
+    }
+
+    private func modifierFlagsExactlyMatch(_ flags: CGEventFlags, _ expectedModifier: CGEventFlags) -> Bool {
+        let activeModifiers = flags.intersection([.maskShift, .maskControl, .maskAlternate, .maskCommand])
+        return activeModifiers == expectedModifier
     }
 
     private func handleDockClick(app: NSRunningApplication) -> Bool {

--- a/DockDoor/Utilities/DockObserver.swift
+++ b/DockDoor/Utilities/DockObserver.swift
@@ -271,11 +271,11 @@ final class DockObserver {
             return
         }
 
-        if handleHoveredFolderDockItemIfNeeded(mouseLocation: currentMouseLocation) {
+        guard Defaults[.dockPreviewActivationMode] == .hover else {
             return
         }
 
-        guard Defaults[.dockPreviewActivationMode] == .hover else {
+        if handleHoveredFolderDockItemIfNeeded(mouseLocation: currentMouseLocation) {
             return
         }
 
@@ -475,14 +475,26 @@ final class DockObserver {
     private func handleHoveredFolderDockItemIfNeeded(mouseLocation: CGPoint) -> Bool {
         guard let folderItem = getHoveredFolderDockItem() else { return false }
 
+        _ = showFolderPreviewIfPossible(folderItem: folderItem, mouseLocation: mouseLocation)
+        return true
+    }
+
+    @MainActor
+    private func showHoveredFolderDockItemPreviewIfPossible(mouseLocation: CGPoint) -> Bool {
+        guard let folderItem = getHoveredFolderDockItem() else { return false }
+        return showFolderPreviewIfPossible(folderItem: folderItem, mouseLocation: mouseLocation)
+    }
+
+    @MainActor
+    private func showFolderPreviewIfPossible(folderItem: FolderDockItemInfo, mouseLocation: CGPoint) -> Bool {
         guard Defaults[.enableDockPreviews],
               Defaults[.enableFolderWidget]
         else {
-            return true
+            return false
         }
 
         guard let accessibleURL = FolderWidgetAuthorization.accessibleURL(for: folderItem.url) else {
-            return true
+            return false
         }
 
         let mouseScreen = NSScreen.screenFromQuartzPoint(mouseLocation)
@@ -812,16 +824,8 @@ final class DockObserver {
 
     private func handleDockPreviewActivation(type: CGEventType, event: CGEvent, appUnderMouse: ApplicationReturnType) -> Bool {
         guard Defaults[.enableDockPreviews],
-              !previewCoordinator.windowSwitcherCoordinator.windowSwitcherActive,
-              appUnderMouse.dockItemElement != nil
+              !previewCoordinator.windowSwitcherCoordinator.windowSwitcherActive
         else {
-            return false
-        }
-
-        switch appUnderMouse.status {
-        case .success, .notRunning:
-            break
-        case .notFound:
             return false
         }
 
@@ -838,6 +842,31 @@ final class DockObserver {
         guard shouldActivate else { return false }
 
         let mouseLocation = DockObserver.getMousePosition()
+
+        if let folderItem = getHoveredFolderDockItem() {
+            guard Defaults[.enableFolderWidget],
+                  FolderWidgetAuthorization.accessibleURL(for: folderItem.url) != nil
+            else {
+                return false
+            }
+
+            Task { @MainActor [weak self] in
+                self?.showHoveredFolderDockItemPreviewIfPossible(mouseLocation: mouseLocation)
+            }
+            return true
+        }
+
+        guard appUnderMouse.dockItemElement != nil else {
+            return false
+        }
+
+        switch appUnderMouse.status {
+        case .success, .notRunning:
+            break
+        case .notFound:
+            return false
+        }
+
         Task { @MainActor [weak self] in
             self?.showPreviewForHoveredDockApp(
                 mouseLocation: mouseLocation,

--- a/DockDoor/Views/Settings/DockPreviewsSettingsView.swift
+++ b/DockDoor/Views/Settings/DockPreviewsSettingsView.swift
@@ -194,16 +194,15 @@ struct DockPreviewsSettingsView: View {
                     .foregroundColor(.secondary)
                     .padding(.leading, 20)
 
-                if dockPreviewActivationMode == .modifierClick {
-                    Picker("Dock Preview Modifier", selection: $dockPreviewActivationModifier) {
-                        ForEach(DockPreviewActivationModifier.allCases, id: \.self) {
-                            Text($0.localizedName).tag($0)
-                        }
+                Picker("Dock Preview Modifier", selection: $dockPreviewActivationModifier) {
+                    ForEach(DockPreviewActivationModifier.allCases, id: \.self) {
+                        Text($0.localizedName).tag($0)
                     }
-                    .pickerStyle(MenuPickerStyle())
-                    .settingsSearchTarget("dockPreviews.activationModifier")
-                    .padding(.leading, 20)
                 }
+                .pickerStyle(MenuPickerStyle())
+                .settingsSearchTarget("dockPreviews.activationModifier")
+                .padding(.leading, 20)
+                .disabled(dockPreviewActivationMode != .modifierClick)
 
                 Picker("Dock Preview Hover Action", selection: $previewHoverAction) {
                     ForEach(PreviewHoverAction.allCases, id: \.self) { Text($0.localizedName).tag($0) }

--- a/DockDoor/Views/Settings/DockPreviewsSettingsView.swift
+++ b/DockDoor/Views/Settings/DockPreviewsSettingsView.swift
@@ -11,6 +11,8 @@ struct DockPreviewsSettingsView: View {
     @Default(.collapseNativeTabsIntoSingleWindow) var collapseNativeTabsIntoSingleWindow
     @Default(.includeHiddenWindowsInDockPreview) var includeHiddenWindowsInDockPreview
     @Default(.showWindowlessAppsInDockPreview) var showWindowlessAppsInDockPreview
+    @Default(.dockPreviewActivationMode) var dockPreviewActivationMode
+    @Default(.dockPreviewActivationModifier) var dockPreviewActivationModifier
     @Default(.previewHoverAction) var previewHoverAction
     @Default(.tapEquivalentInterval) var tapEquivalentInterval
     @Default(.shouldHideOnDockItemClick) var shouldHideOnDockItemClick
@@ -53,7 +55,7 @@ struct DockPreviewsSettingsView: View {
                 title: "Enable Dock Previews",
                 imageName: "DockPreviews"
             ) {
-                Text("Show window previews when hovering over Dock icons.")
+                Text("Show window previews for Dock icons.")
             }
             .settingsSearchTarget("dockPreviews.enable")
             .onChange(of: enableDockPreviews) { _ in askUserToRestartApplication() }
@@ -179,6 +181,30 @@ struct DockPreviewsSettingsView: View {
     private var dockInteractionSection: some View {
         SettingsGroup(header: "Dock Interaction") {
             VStack(alignment: .leading, spacing: 10) {
+                Picker("Dock Preview Trigger", selection: $dockPreviewActivationMode) {
+                    ForEach(DockPreviewActivationMode.allCases, id: \.self) {
+                        Text($0.localizedName).tag($0)
+                    }
+                }
+                .pickerStyle(MenuPickerStyle())
+                .settingsSearchTarget("dockPreviews.activationTrigger")
+
+                Text("Show previews automatically on hover, or require a click trigger on the Dock icon.")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .padding(.leading, 20)
+
+                if dockPreviewActivationMode == .modifierClick {
+                    Picker("Dock Preview Modifier", selection: $dockPreviewActivationModifier) {
+                        ForEach(DockPreviewActivationModifier.allCases, id: \.self) {
+                            Text($0.localizedName).tag($0)
+                        }
+                    }
+                    .pickerStyle(MenuPickerStyle())
+                    .settingsSearchTarget("dockPreviews.activationModifier")
+                    .padding(.leading, 20)
+                }
+
                 Picker("Dock Preview Hover Action", selection: $previewHoverAction) {
                     ForEach(PreviewHoverAction.allCases, id: \.self) { Text($0.localizedName).tag($0) }
                 }

--- a/DockDoor/Views/Settings/MainSettingsView.swift
+++ b/DockDoor/Views/Settings/MainSettingsView.swift
@@ -99,6 +99,8 @@ struct MainSettingsView: View {
                 Defaults[.dockClickAction] = Defaults.Keys.dockClickAction.defaultValue
                 Defaults[.restoreAllMinimizedWindowsOnDockClick] = Defaults.Keys.restoreAllMinimizedWindowsOnDockClick.defaultValue
                 Defaults[.enableCmdRightClickQuit] = Defaults.Keys.enableCmdRightClickQuit.defaultValue
+                Defaults[.dockPreviewActivationMode] = Defaults.Keys.dockPreviewActivationMode.defaultValue
+                Defaults[.dockPreviewActivationModifier] = Defaults.Keys.dockPreviewActivationModifier.defaultValue
                 Defaults[.previewHoverAction] = Defaults.Keys.previewHoverAction.defaultValue
 
                 showMenuBarIcon = Defaults.Keys.showMenuBarIcon.defaultValue

--- a/DockDoor/Views/Settings/Search/SettingsSearchCatalog.swift
+++ b/DockDoor/Views/Settings/Search/SettingsSearchCatalog.swift
@@ -123,7 +123,7 @@ enum SettingsSearchCatalog {
         SettingsSearchItem(
             id: "dockPreviews.enable",
             title: String(localized: "Enable Dock Previews"),
-            description: String(localized: "Show window previews when hovering over Dock icons."),
+            description: String(localized: "Show window previews for Dock icons."),
             keywords: ["dock", "hover", "preview"],
             tab: "DockPreviews",
             section: "",
@@ -207,6 +207,23 @@ enum SettingsSearchCatalog {
             tab: "DockPreviews",
             section: String(localized: "Window Display"),
             icon: "1.square"
+        ),
+        SettingsSearchItem(
+            id: "dockPreviews.activationTrigger",
+            title: String(localized: "Dock Preview Trigger"),
+            description: String(localized: "Show previews automatically on hover, or require a click trigger on the Dock icon."),
+            keywords: ["trigger", "hover", "middle", "click", "modifier", "dock"],
+            tab: "DockPreviews",
+            section: String(localized: "Dock Interaction"),
+            icon: "cursorarrow.click"
+        ),
+        SettingsSearchItem(
+            id: "dockPreviews.activationModifier",
+            title: String(localized: "Dock Preview Modifier"),
+            keywords: ["modifier", "option", "control", "shift", "command", "click"],
+            tab: "DockPreviews",
+            section: String(localized: "Dock Interaction"),
+            icon: "keyboard"
         ),
         SettingsSearchItem(
             id: "dockPreviews.hoverAction",

--- a/DockDoor/consts.swift
+++ b/DockDoor/consts.swift
@@ -110,6 +110,8 @@ extension Defaults.Keys {
     static let enableWindowSwitcher = Key<Bool>("enableWindowSwitcher", default: true)
     static let instantWindowSwitcher = Key<Bool>("instantWindowSwitcher", default: false)
     static let enableDockPreviews = Key<Bool>("enableDockPreviews", default: true)
+    static let dockPreviewActivationMode = Key<DockPreviewActivationMode>("dockPreviewActivationMode", default: .hover)
+    static let dockPreviewActivationModifier = Key<DockPreviewActivationModifier>("dockPreviewActivationModifier", default: .option)
     static let showWindowsFromCurrentSpaceOnly = Key<Bool>("showWindowsFromCurrentSpaceOnly", default: false)
     static let showWindowsFromCurrentMonitorOnly = Key<Bool>("showWindowsFromCurrentMonitorOnly", default: false)
     static let windowPreviewSortOrder = Key<WindowPreviewSortOrder>("windowPreviewSortOrder", default: .recentlyUsed)
@@ -723,6 +725,56 @@ enum DockClickAction: String, CaseIterable, Defaults.Serializable {
             String(localized: "Minimize windows", comment: "Dock click action option")
         case .hide:
             String(localized: "Hide application", comment: "Dock click action option")
+        }
+    }
+}
+
+enum DockPreviewActivationMode: String, CaseIterable, Defaults.Serializable {
+    case hover
+    case middleClick
+    case modifierClick
+
+    var localizedName: String {
+        switch self {
+        case .hover:
+            String(localized: "Hover", comment: "Dock preview activation mode option")
+        case .middleClick:
+            String(localized: "Middle Click", comment: "Dock preview activation mode option")
+        case .modifierClick:
+            String(localized: "Modifier Click", comment: "Dock preview activation mode option")
+        }
+    }
+}
+
+enum DockPreviewActivationModifier: String, CaseIterable, Defaults.Serializable {
+    case option
+    case control
+    case shift
+    case command
+
+    var localizedName: String {
+        switch self {
+        case .option:
+            String(localized: "Option ⌥", comment: "Dock preview activation modifier option")
+        case .control:
+            String(localized: "Control ⌃", comment: "Dock preview activation modifier option")
+        case .shift:
+            String(localized: "Shift ⇧", comment: "Dock preview activation modifier option")
+        case .command:
+            String(localized: "Command ⌘", comment: "Dock preview activation modifier option")
+        }
+    }
+
+    var eventFlag: CGEventFlags {
+        switch self {
+        case .option:
+            .maskAlternate
+        case .control:
+            .maskControl
+        case .shift:
+            .maskShift
+        case .command:
+            .maskCommand
         }
     }
 }


### PR DESCRIPTION
## Summary
- add a Dock Preview Trigger setting with Hover, Middle Click, and Modifier Click modes
- apply trigger-mode handling to app and folder Dock previews
- add Dock Preview Modifier settings/search support and reset-to-defaults handling

## Motivation
Hover previews can be easy to mis-trigger when moving the mouse around near the Dock. The new trigger modes let users keep the native Dock behavior unless they intentionally request a DockDoor preview.

Closes #1487

## Setting Change

Added a "Dock Preview Trigger" setting under the "Dock Interaction" section on the "Dock Previews" page. The default value is set to "Hover" for UX backward compatibility.

<img width="529" height="176" alt="image" src="https://github.com/user-attachments/assets/14977a54-baca-46f3-aa4e-8bc7c1fb417d" />

## Testing
- Confirmed with manual Xcode run that middle-click trigger mode opens Dock previews
- Ran `git diff --check`