### PR TITLE
feat: add middle-click open window action

### DIFF
--- a/DockDoor/Utilities/Window Management/WindowUtil.swift
+++ b/DockDoor/Utilities/Window Management/WindowUtil.swift
@@ -33,6 +33,7 @@ enum WindowAction: String, Hashable, CaseIterable, Defaults.Serializable {
     case minimize
     case toggleFullScreen
     case hide
+    case openAppWindow
     case openNewWindow
     case maximize
     case bringToCurrentSpace
@@ -63,6 +64,8 @@ enum WindowAction: String, Hashable, CaseIterable, Defaults.Serializable {
             String(localized: "Toggle Full Screen", comment: "Window action")
         case .hide:
             String(localized: "Hide App", comment: "Window action")
+        case .openAppWindow:
+            String(localized: "Open App Window", comment: "Window action")
         case .openNewWindow:
             String(localized: "Open New Window", comment: "Window action")
         case .maximize:
@@ -99,6 +102,7 @@ enum WindowAction: String, Hashable, CaseIterable, Defaults.Serializable {
         case .minimize: "minus.circle"
         case .toggleFullScreen: "arrow.up.left.and.arrow.down.right"
         case .hide: "eye.slash"
+        case .openAppWindow: "macwindow"
         case .openNewWindow: "plus.rectangle.on.rectangle"
         case .maximize: "arrow.up.backward.and.arrow.down.forward"
         case .bringToCurrentSpace: "arrow.right.to.line"
@@ -118,6 +122,13 @@ enum WindowAction: String, Hashable, CaseIterable, Defaults.Serializable {
     /// Actions that can be assigned to trackpad gestures
     static var gestureActions: [WindowAction] {
         [.none, .close, .minimize, .maximize, .toggleFullScreen, .hide, .quit,
+         .fillLeftHalf, .fillRightHalf, .fillTopHalf, .fillBottomHalf,
+         .fillTopLeftQuarter, .fillTopRightQuarter, .fillBottomLeftQuarter, .fillBottomRightQuarter, .center]
+    }
+
+    /// Actions that can be assigned to middle-clicking a window preview
+    static var middleClickActions: [WindowAction] {
+        [.none, .openAppWindow, .close, .minimize, .maximize, .toggleFullScreen, .hide, .quit,
          .fillLeftHalf, .fillRightHalf, .fillTopHalf, .fillBottomHalf,
          .fillTopLeftQuarter, .fillTopRightQuarter, .fillBottomLeftQuarter, .fillBottomRightQuarter, .center]
     }
@@ -179,6 +190,25 @@ enum WindowAction: String, Hashable, CaseIterable, Defaults.Serializable {
                 return .windowUpdated(updatedWindow)
             }
             return .noChange
+
+        case .openAppWindow:
+            if window.isWindowlessApp {
+                window.app.activate(options: [.activateIgnoringOtherApps])
+                return .dismissed
+            }
+
+            if window.isMinimized {
+                var updatedWindow = window
+                return updatedWindow.toggleMinimize() != nil ? .dismissed : .noChange
+            }
+
+            if window.isHidden {
+                var updatedWindow = window
+                return updatedWindow.toggleHidden() != nil ? .dismissed : .noChange
+            }
+
+            window.bringToFront()
+            return .dismissed
 
         case .openNewWindow:
             WindowUtil.openNewWindow(app: window.app)

--- a/DockDoor/Views/Hover Window/WindowlessAppPreview.swift
+++ b/DockDoor/Views/Hover Window/WindowlessAppPreview.swift
@@ -15,6 +15,8 @@ struct WindowlessAppPreview: View, Equatable {
     var appearance: PreviewAppearanceSettings
     let backgroundAppearance: BackgroundAppearance
 
+    @Default(.middleClickAction) private var middleClickAction
+
     @State private var isHovering = false
 
     static func == (l: Self, r: Self) -> Bool {
@@ -216,6 +218,11 @@ struct WindowlessAppPreview: View, Equatable {
                 windowInfo.app.activate(options: [.activateIgnoringOtherApps])
             }
             onTap?()
+        }
+        .onMiddleClick {
+            if middleClickAction != .none {
+                handleWindowAction(middleClickAction)
+            }
         }
         .contextMenu {
             Button(action: {

--- a/DockDoor/Views/Settings/Gestures/MouseActionsSection.swift
+++ b/DockDoor/Views/Settings/Gestures/MouseActionsSection.swift
@@ -18,7 +18,7 @@ struct MouseActionsSection: View {
                     }
 
                     Picker("", selection: $middleClickAction) {
-                        ForEach(WindowAction.gestureActions, id: \.self) { windowAction in
+                        ForEach(WindowAction.middleClickActions, id: \.self) { windowAction in
                             HStack(spacing: 6) {
                                 Image(systemName: windowAction.iconName)
                                 Text(windowAction.localizedName)

--- a/DockDoor/Views/Settings/Search/SettingsSearchCatalog.swift
+++ b/DockDoor/Views/Settings/Search/SettingsSearchCatalog.swift
@@ -1204,7 +1204,7 @@ enum SettingsSearchCatalog {
             id: "gestures.middleClick",
             title: String(localized: "Middle Click"),
             description: String(localized: "Action performed when middle-clicking on a window preview."),
-            keywords: ["middle", "click", "mouse", "button"],
+            keywords: ["middle", "click", "mouse", "button", "open", "activate", "window", "app"],
             tab: "GesturesKeybinds",
             section: String(localized: "Mouse Actions"),
             icon: "computermouse"


### PR DESCRIPTION
## Summary
- add an `Open App Window` middle-click action for window previews
- expose the new action only in the Mouse Actions > Middle Click picker
- activate, restore, or unhide the selected previewed window depending on its current state
- keep the Middle Click setting searchable with open/activate/window/app keywords

## Motivation
This complements the configurable Dock preview trigger work in #1488. That PR lets users middle-click a Dock icon to intentionally show previews; this PR lets users middle-click a visible preview to open the selected app window directly.

Closes #1489
Related to #1487
Related to #1488

## Testing
- User-tested locally: selecting the new Middle Click action successfully opens the app window from a window preview
- Ran `git diff --check`
- Confirmed the new action is only exposed in the middle-click picker; trackpad gestures and Cmd shortcut action pickers continue using the existing gesture action list