### PR TITLE
feat: add configurable dock preview trigger

### DIFF
--- a/DockDoor/Utilities/DockObserver.swift
+++ b/DockDoor/Utilities/DockObserver.swift
@@ -275,6 +275,19 @@ final class DockObserver {
             return
         }
 
+        guard Defaults[.dockPreviewActivationMode] == .hover else {
+            return
+        }
+
+        showPreviewForHoveredDockApp(
+            mouseLocation: currentMouseLocation,
+            overrideDelay: false,
+            refreshLogContext: "dock hover"
+        )
+    }
+
+    @MainActor
+    private func showPreviewForHoveredDockApp(mouseLocation currentMouseLocation: CGPoint, overrideDelay: Bool, refreshLogContext: String) {
         let appUnderMouseElement = DebugLogger.measureSlow("getDockItemAppStatusUnderMouse", thresholdMs: 100) {
             getDockItemAppStatusUnderMouse()
         }
@@ -284,6 +297,8 @@ final class DockObserver {
             return
         }
 
+        guard Defaults[.enableDockPreviews] else { return }
+
         if case let .notRunning(bundleIdentifier) = appUnderMouseElement.status {
             let isCalendar = bundleIdentifier == calendarAppIdentifier && Defaults[.enableCalendarWidget]
             let mr = MediaRemoteService.shared
@@ -291,7 +306,7 @@ final class DockObserver {
             let isActiveMedia = mediaSourceMatches
                 && Defaults[.enableMediaWidget]
                 && (!mr.isUniversalSource || Defaults[.mediaDetectionMode] == .universal)
-            if isCalendar || isActiveMedia, Defaults[.showSpecialAppControls], Defaults[.enableDockPreviews] {
+            if isCalendar || isActiveMedia, Defaults[.showSpecialAppControls] {
                 let mouseScreen = NSScreen.screenFromQuartzPoint(currentMouseLocation)
                 let convertedMouseLocation = DockObserver.nsPointFromCGPoint(currentMouseLocation, forScreen: mouseScreen)
                 let appName = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleIdentifier)
@@ -305,7 +320,7 @@ final class DockObserver {
                     mouseLocation: convertedMouseLocation,
                     mouseScreen: mouseScreen,
                     dockItemElement: dockItemElement,
-                    overrideDelay: false,
+                    overrideDelay: overrideDelay,
                     onWindowTap: { [weak self] in self?.hideWindowAndResetLastApp() },
                     bundleIdentifier: bundleIdentifier
                 )
@@ -371,8 +386,6 @@ final class DockObserver {
             cachedWindows = cachedWindows.filter { !$0.isHidden && !$0.isMinimized }
         }
 
-        guard Defaults[.enableDockPreviews] else { return }
-
         let mouseScreen = NSScreen.screenFromQuartzPoint(currentMouseLocation)
         let convertedMouseLocation = DockObserver.nsPointFromCGPoint(currentMouseLocation, forScreen: mouseScreen)
         let screenOrigin = mouseScreen.frame.origin
@@ -393,7 +406,7 @@ final class DockObserver {
                 mouseLocation: convertedMouseLocation,
                 mouseScreen: mouseScreen,
                 dockItemElement: dockItemElement,
-                overrideDelay: false,
+                overrideDelay: overrideDelay,
                 onWindowTap: { [weak self] in
                     self?.hideWindowAndResetLastApp()
                 },
@@ -408,7 +421,7 @@ final class DockObserver {
             do {
                 var windows: [WindowInfo] = []
                 for appInstance in appsToFetchWindowsFrom {
-                    try await windows.append(contentsOf: DebugLogger.measureAsync("getActiveWindows (dock hover)", details: "PID: \(appInstance.processIdentifier)") {
+                    try await windows.append(contentsOf: DebugLogger.measureAsync("getActiveWindows (\(refreshLogContext))", details: "PID: \(appInstance.processIdentifier)") {
                         try await WindowUtil.getActiveWindows(of: appInstance)
                     })
                 }
@@ -450,10 +463,10 @@ final class DockObserver {
                         dockPosition: dockPosition,
                         bestGuessMonitor: monitor
                     )
-                    DebugLogger.log("WindowRefresh", details: "dock hover final merge, PID: \(currentAppPID), windows: \(freshWindows.count), merged: \(didMerge)")
+                    DebugLogger.log("WindowRefresh", details: "\(refreshLogContext) final merge, PID: \(currentAppPID), windows: \(freshWindows.count), merged: \(didMerge)")
                 }
             } catch {
-                DebugLogger.log("DockObserver", details: "Failed to fetch windows for dock hover: \(error)")
+                DebugLogger.log("DockObserver", details: "Failed to fetch windows for \(refreshLogContext): \(error)")
             }
         }
     }
@@ -713,7 +726,8 @@ final class DockObserver {
 
     private func setupEventTap() {
         var eventMask: CGEventMask = (1 << CGEventType.leftMouseDown.rawValue) |
-            (1 << CGEventType.rightMouseDown.rawValue)
+            (1 << CGEventType.rightMouseDown.rawValue) |
+            (1 << CGEventType.otherMouseDown.rawValue)
 
         if Defaults[.enableDockScrollGesture] || Defaults[.enableTitleBarScrollGesture] {
             eventMask |= (1 << CGEventType.scrollWheel.rawValue)
@@ -768,6 +782,10 @@ final class DockObserver {
 
         let appUnderMouse = getDockItemAppStatusUnderMouse()
 
+        if handleDockPreviewActivation(type: type, event: event, appUnderMouse: appUnderMouse) {
+            return nil
+        }
+
         if case let .success(app) = appUnderMouse.status {
             if type == .rightMouseDown, event.flags.contains(.maskCommand), Defaults[.enableCmdRightClickQuit] {
                 handleCmdRightClickQuit(app: app, event: event)
@@ -790,6 +808,49 @@ final class DockObserver {
         }
 
         return Unmanaged.passUnretained(event)
+    }
+
+    private func handleDockPreviewActivation(type: CGEventType, event: CGEvent, appUnderMouse: ApplicationReturnType) -> Bool {
+        guard Defaults[.enableDockPreviews],
+              !previewCoordinator.windowSwitcherCoordinator.windowSwitcherActive,
+              appUnderMouse.dockItemElement != nil
+        else {
+            return false
+        }
+
+        switch appUnderMouse.status {
+        case .success, .notRunning:
+            break
+        case .notFound:
+            return false
+        }
+
+        let shouldActivate = switch Defaults[.dockPreviewActivationMode] {
+        case .hover:
+            false
+        case .middleClick:
+            type == .otherMouseDown &&
+                event.getIntegerValueField(.mouseEventButtonNumber) == Int64(CGMouseButton.center.rawValue)
+        case .modifierClick:
+            type == .leftMouseDown && modifierFlagsExactlyMatch(event.flags, Defaults[.dockPreviewActivationModifier].eventFlag)
+        }
+
+        guard shouldActivate else { return false }
+
+        let mouseLocation = DockObserver.getMousePosition()
+        Task { @MainActor [weak self] in
+            self?.showPreviewForHoveredDockApp(
+                mouseLocation: mouseLocation,
+                overrideDelay: true,
+                refreshLogContext: "dock preview trigger"
+            )
+        }
+        return true
+    }
+
+    private func modifierFlagsExactlyMatch(_ flags: CGEventFlags, _ expectedModifier: CGEventFlags) -> Bool {
+        let activeModifiers = flags.intersection([.maskShift, .maskControl, .maskAlternate, .maskCommand])
+        return activeModifiers == expectedModifier
     }
 
     private func handleDockClick(app: NSRunningApplication) -> Bool {

--- a/DockDoor/Utilities/DockObserver.swift
+++ b/DockDoor/Utilities/DockObserver.swift
@@ -271,11 +271,11 @@ final class DockObserver {
             return
         }
 
-        if handleHoveredFolderDockItemIfNeeded(mouseLocation: currentMouseLocation) {
+        guard Defaults[.dockPreviewActivationMode] == .hover else {
             return
         }
 
-        guard Defaults[.dockPreviewActivationMode] == .hover else {
+        if handleHoveredFolderDockItemIfNeeded(mouseLocation: currentMouseLocation) {
             return
         }
 
@@ -475,14 +475,26 @@ final class DockObserver {
     private func handleHoveredFolderDockItemIfNeeded(mouseLocation: CGPoint) -> Bool {
         guard let folderItem = getHoveredFolderDockItem() else { return false }
 
+        _ = showFolderPreviewIfPossible(folderItem: folderItem, mouseLocation: mouseLocation)
+        return true
+    }
+
+    @MainActor
+    private func showHoveredFolderDockItemPreviewIfPossible(mouseLocation: CGPoint) -> Bool {
+        guard let folderItem = getHoveredFolderDockItem() else { return false }
+        return showFolderPreviewIfPossible(folderItem: folderItem, mouseLocation: mouseLocation)
+    }
+
+    @MainActor
+    private func showFolderPreviewIfPossible(folderItem: FolderDockItemInfo, mouseLocation: CGPoint) -> Bool {
         guard Defaults[.enableDockPreviews],
               Defaults[.enableFolderWidget]
         else {
-            return true
+            return false
         }
 
         guard let accessibleURL = FolderWidgetAuthorization.accessibleURL(for: folderItem.url) else {
-            return true
+            return false
         }
 
         let mouseScreen = NSScreen.screenFromQuartzPoint(mouseLocation)
@@ -812,16 +824,8 @@ final class DockObserver {
 
     private func handleDockPreviewActivation(type: CGEventType, event: CGEvent, appUnderMouse: ApplicationReturnType) -> Bool {
         guard Defaults[.enableDockPreviews],
-              !previewCoordinator.windowSwitcherCoordinator.windowSwitcherActive,
-              appUnderMouse.dockItemElement != nil
+              !previewCoordinator.windowSwitcherCoordinator.windowSwitcherActive
         else {
-            return false
-        }
-
-        switch appUnderMouse.status {
-        case .success, .notRunning:
-            break
-        case .notFound:
             return false
         }
 
@@ -838,6 +842,31 @@ final class DockObserver {
         guard shouldActivate else { return false }
 
         let mouseLocation = DockObserver.getMousePosition()
+
+        if let folderItem = getHoveredFolderDockItem() {
+            guard Defaults[.enableFolderWidget],
+                  FolderWidgetAuthorization.accessibleURL(for: folderItem.url) != nil
+            else {
+                return false
+            }
+
+            Task { @MainActor [weak self] in
+                self?.showHoveredFolderDockItemPreviewIfPossible(mouseLocation: mouseLocation)
+            }
+            return true
+        }
+
+        guard appUnderMouse.dockItemElement != nil else {
+            return false
+        }
+
+        switch appUnderMouse.status {
+        case .success, .notRunning:
+            break
+        case .notFound:
+            return false
+        }
+
         Task { @MainActor [weak self] in
             self?.showPreviewForHoveredDockApp(
                 mouseLocation: mouseLocation,

--- a/DockDoor/Utilities/DockObserver.swift
+++ b/DockDoor/Utilities/DockObserver.swift
@@ -300,13 +300,7 @@ final class DockObserver {
         guard Defaults[.enableDockPreviews] else { return }
 
         if case let .notRunning(bundleIdentifier) = appUnderMouseElement.status {
-            let isCalendar = bundleIdentifier == calendarAppIdentifier && Defaults[.enableCalendarWidget]
-            let mr = MediaRemoteService.shared
-            let mediaSourceMatches = mr.matchesMediaSource(bundleIdentifier: bundleIdentifier)
-            let isActiveMedia = mediaSourceMatches
-                && Defaults[.enableMediaWidget]
-                && (!mr.isUniversalSource || Defaults[.mediaDetectionMode] == .universal)
-            if isCalendar || isActiveMedia, Defaults[.showSpecialAppControls] {
+            if canShowSpecialPreview(forNotRunningBundleIdentifier: bundleIdentifier) {
                 let mouseScreen = NSScreen.screenFromQuartzPoint(currentMouseLocation)
                 let convertedMouseLocation = DockObserver.nsPointFromCGPoint(currentMouseLocation, forScreen: mouseScreen)
                 let appName = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleIdentifier)
@@ -865,8 +859,12 @@ final class DockObserver {
         }
 
         switch appUnderMouse.status {
-        case .success, .notRunning:
+        case .success:
             break
+        case let .notRunning(bundleIdentifier):
+            guard canShowSpecialPreview(forNotRunningBundleIdentifier: bundleIdentifier) else {
+                return false
+            }
         case .notFound:
             return false
         }
@@ -879,6 +877,19 @@ final class DockObserver {
             )
         }
         return true
+    }
+
+    private func canShowSpecialPreview(forNotRunningBundleIdentifier bundleIdentifier: String) -> Bool {
+        guard Defaults[.showSpecialAppControls] else { return false }
+
+        let isCalendar = bundleIdentifier == calendarAppIdentifier && Defaults[.enableCalendarWidget]
+        let mr = MediaRemoteService.shared
+        let mediaSourceMatches = mr.matchesMediaSource(bundleIdentifier: bundleIdentifier)
+        let isActiveMedia = mediaSourceMatches
+            && Defaults[.enableMediaWidget]
+            && (!mr.isUniversalSource || Defaults[.mediaDetectionMode] == .universal)
+
+        return isCalendar || isActiveMedia
     }
 
     private func modifierFlagsExactlyMatch(_ flags: CGEventFlags, _ expectedModifier: CGEventFlags) -> Bool {

--- a/DockDoor/Utilities/DockObserver.swift
+++ b/DockDoor/Utilities/DockObserver.swift
@@ -773,6 +773,10 @@ final class DockObserver {
             return passthrough
         }
 
+        if previewCoordinator.containsQuartzPoint(event.location) {
+            return Unmanaged.passUnretained(event)
+        }
+
         if type == .scrollWheel {
             if Defaults[.enableTitleBarScrollGesture], handleTitleBarScroll(event) {
                 return nil

--- a/DockDoor/Utilities/Window Management/WindowUtil.swift
+++ b/DockDoor/Utilities/Window Management/WindowUtil.swift
@@ -33,6 +33,7 @@ enum WindowAction: String, Hashable, CaseIterable, Defaults.Serializable {
     case minimize
     case toggleFullScreen
     case hide
+    case openAppWindow
     case openNewWindow
     case maximize
     case bringToCurrentSpace
@@ -63,6 +64,8 @@ enum WindowAction: String, Hashable, CaseIterable, Defaults.Serializable {
             String(localized: "Toggle Full Screen", comment: "Window action")
         case .hide:
             String(localized: "Hide App", comment: "Window action")
+        case .openAppWindow:
+            String(localized: "Open App Window", comment: "Window action")
         case .openNewWindow:
             String(localized: "Open New Window", comment: "Window action")
         case .maximize:
@@ -99,6 +102,7 @@ enum WindowAction: String, Hashable, CaseIterable, Defaults.Serializable {
         case .minimize: "minus.circle"
         case .toggleFullScreen: "arrow.up.left.and.arrow.down.right"
         case .hide: "eye.slash"
+        case .openAppWindow: "macwindow"
         case .openNewWindow: "plus.rectangle.on.rectangle"
         case .maximize: "arrow.up.backward.and.arrow.down.forward"
         case .bringToCurrentSpace: "arrow.right.to.line"
@@ -118,6 +122,13 @@ enum WindowAction: String, Hashable, CaseIterable, Defaults.Serializable {
     /// Actions that can be assigned to trackpad gestures
     static var gestureActions: [WindowAction] {
         [.none, .close, .minimize, .maximize, .toggleFullScreen, .hide, .quit,
+         .fillLeftHalf, .fillRightHalf, .fillTopHalf, .fillBottomHalf,
+         .fillTopLeftQuarter, .fillTopRightQuarter, .fillBottomLeftQuarter, .fillBottomRightQuarter, .center]
+    }
+
+    /// Actions that can be assigned to middle-clicking a window preview
+    static var middleClickActions: [WindowAction] {
+        [.none, .openAppWindow, .close, .minimize, .maximize, .toggleFullScreen, .hide, .quit,
          .fillLeftHalf, .fillRightHalf, .fillTopHalf, .fillBottomHalf,
          .fillTopLeftQuarter, .fillTopRightQuarter, .fillBottomLeftQuarter, .fillBottomRightQuarter, .center]
     }
@@ -179,6 +190,25 @@ enum WindowAction: String, Hashable, CaseIterable, Defaults.Serializable {
                 return .windowUpdated(updatedWindow)
             }
             return .noChange
+
+        case .openAppWindow:
+            if window.isWindowlessApp {
+                window.app.activate(options: [.activateIgnoringOtherApps])
+                return .dismissed
+            }
+
+            if window.isMinimized {
+                var updatedWindow = window
+                return updatedWindow.toggleMinimize() != nil ? .dismissed : .noChange
+            }
+
+            if window.isHidden {
+                var updatedWindow = window
+                return updatedWindow.toggleHidden() != nil ? .dismissed : .noChange
+            }
+
+            window.bringToFront()
+            return .dismissed
 
         case .openNewWindow:
             WindowUtil.openNewWindow(app: window.app)

--- a/DockDoor/Views/Hover Window/Shared Components/SharedPreviewWindowCoordinator.swift
+++ b/DockDoor/Views/Hover Window/Shared Components/SharedPreviewWindowCoordinator.swift
@@ -107,6 +107,33 @@ final class SharedPreviewWindowCoordinator: NSPanel {
         return searchWindow.frame
     }
 
+    func containsQuartzPoint(_ point: CGPoint) -> Bool {
+        guard isVisible else { return false }
+
+        let screen = NSScreen.screenFromQuartzPoint(point)
+        let appKitPoint = DockObserver.nsPointFromCGPoint(point, forScreen: screen)
+        let hitSlop: CGFloat = 2
+
+        if frame.insetBy(dx: -hitSlop, dy: -hitSlop).contains(appKitPoint) {
+            return true
+        }
+
+        if let fullPreviewWindow,
+           fullPreviewWindow.isVisible,
+           fullPreviewWindow.frame.insetBy(dx: -hitSlop, dy: -hitSlop).contains(appKitPoint)
+        {
+            return true
+        }
+
+        if let searchWindowFrame,
+           searchWindowFrame.insetBy(dx: -hitSlop, dy: -hitSlop).contains(appKitPoint)
+        {
+            return true
+        }
+
+        return false
+    }
+
     private func isCalendarApp(bundleIdentifier: String?) -> Bool {
         guard let bundleId = bundleIdentifier else { return false }
         return bundleId == calendarAppIdentifier

--- a/DockDoor/Views/Hover Window/WindowlessAppPreview.swift
+++ b/DockDoor/Views/Hover Window/WindowlessAppPreview.swift
@@ -15,6 +15,8 @@ struct WindowlessAppPreview: View, Equatable {
     var appearance: PreviewAppearanceSettings
     let backgroundAppearance: BackgroundAppearance
 
+    @Default(.middleClickAction) private var middleClickAction
+
     @State private var isHovering = false
 
     static func == (l: Self, r: Self) -> Bool {
@@ -216,6 +218,11 @@ struct WindowlessAppPreview: View, Equatable {
                 windowInfo.app.activate(options: [.activateIgnoringOtherApps])
             }
             onTap?()
+        }
+        .onMiddleClick {
+            if middleClickAction != .none {
+                handleWindowAction(middleClickAction)
+            }
         }
         .contextMenu {
             Button(action: {

--- a/DockDoor/Views/Settings/DockPreviewsSettingsView.swift
+++ b/DockDoor/Views/Settings/DockPreviewsSettingsView.swift
@@ -194,16 +194,15 @@ struct DockPreviewsSettingsView: View {
                     .foregroundColor(.secondary)
                     .padding(.leading, 20)
 
-                if dockPreviewActivationMode == .modifierClick {
-                    Picker("Dock Preview Modifier", selection: $dockPreviewActivationModifier) {
-                        ForEach(DockPreviewActivationModifier.allCases, id: \.self) {
-                            Text($0.localizedName).tag($0)
-                        }
+                Picker("Dock Preview Modifier", selection: $dockPreviewActivationModifier) {
+                    ForEach(DockPreviewActivationModifier.allCases, id: \.self) {
+                        Text($0.localizedName).tag($0)
                     }
-                    .pickerStyle(MenuPickerStyle())
-                    .settingsSearchTarget("dockPreviews.activationModifier")
-                    .padding(.leading, 20)
                 }
+                .pickerStyle(MenuPickerStyle())
+                .settingsSearchTarget("dockPreviews.activationModifier")
+                .padding(.leading, 20)
+                .disabled(dockPreviewActivationMode != .modifierClick)
 
                 Picker("Dock Preview Hover Action", selection: $previewHoverAction) {
                     ForEach(PreviewHoverAction.allCases, id: \.self) { Text($0.localizedName).tag($0) }

--- a/DockDoor/Views/Settings/DockPreviewsSettingsView.swift
+++ b/DockDoor/Views/Settings/DockPreviewsSettingsView.swift
@@ -11,6 +11,8 @@ struct DockPreviewsSettingsView: View {
     @Default(.collapseNativeTabsIntoSingleWindow) var collapseNativeTabsIntoSingleWindow
     @Default(.includeHiddenWindowsInDockPreview) var includeHiddenWindowsInDockPreview
     @Default(.showWindowlessAppsInDockPreview) var showWindowlessAppsInDockPreview
+    @Default(.dockPreviewActivationMode) var dockPreviewActivationMode
+    @Default(.dockPreviewActivationModifier) var dockPreviewActivationModifier
     @Default(.previewHoverAction) var previewHoverAction
     @Default(.tapEquivalentInterval) var tapEquivalentInterval
     @Default(.shouldHideOnDockItemClick) var shouldHideOnDockItemClick
@@ -53,7 +55,7 @@ struct DockPreviewsSettingsView: View {
                 title: "Enable Dock Previews",
                 imageName: "DockPreviews"
             ) {
-                Text("Show window previews when hovering over Dock icons.")
+                Text("Show window previews for Dock icons.")
             }
             .settingsSearchTarget("dockPreviews.enable")
             .onChange(of: enableDockPreviews) { _ in askUserToRestartApplication() }
@@ -179,6 +181,30 @@ struct DockPreviewsSettingsView: View {
     private var dockInteractionSection: some View {
         SettingsGroup(header: "Dock Interaction") {
             VStack(alignment: .leading, spacing: 10) {
+                Picker("Dock Preview Trigger", selection: $dockPreviewActivationMode) {
+                    ForEach(DockPreviewActivationMode.allCases, id: \.self) {
+                        Text($0.localizedName).tag($0)
+                    }
+                }
+                .pickerStyle(MenuPickerStyle())
+                .settingsSearchTarget("dockPreviews.activationTrigger")
+
+                Text("Show previews automatically on hover, or require a click trigger on the Dock icon.")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .padding(.leading, 20)
+
+                if dockPreviewActivationMode == .modifierClick {
+                    Picker("Dock Preview Modifier", selection: $dockPreviewActivationModifier) {
+                        ForEach(DockPreviewActivationModifier.allCases, id: \.self) {
+                            Text($0.localizedName).tag($0)
+                        }
+                    }
+                    .pickerStyle(MenuPickerStyle())
+                    .settingsSearchTarget("dockPreviews.activationModifier")
+                    .padding(.leading, 20)
+                }
+
                 Picker("Dock Preview Hover Action", selection: $previewHoverAction) {
                     ForEach(PreviewHoverAction.allCases, id: \.self) { Text($0.localizedName).tag($0) }
                 }

--- a/DockDoor/Views/Settings/Gestures/MouseActionsSection.swift
+++ b/DockDoor/Views/Settings/Gestures/MouseActionsSection.swift
@@ -18,7 +18,7 @@ struct MouseActionsSection: View {
                     }
 
                     Picker("", selection: $middleClickAction) {
-                        ForEach(WindowAction.gestureActions, id: \.self) { windowAction in
+                        ForEach(WindowAction.middleClickActions, id: \.self) { windowAction in
                             HStack(spacing: 6) {
                                 Image(systemName: windowAction.iconName)
                                 Text(windowAction.localizedName)

--- a/DockDoor/Views/Settings/MainSettingsView.swift
+++ b/DockDoor/Views/Settings/MainSettingsView.swift
@@ -99,6 +99,8 @@ struct MainSettingsView: View {
                 Defaults[.dockClickAction] = Defaults.Keys.dockClickAction.defaultValue
                 Defaults[.restoreAllMinimizedWindowsOnDockClick] = Defaults.Keys.restoreAllMinimizedWindowsOnDockClick.defaultValue
                 Defaults[.enableCmdRightClickQuit] = Defaults.Keys.enableCmdRightClickQuit.defaultValue
+                Defaults[.dockPreviewActivationMode] = Defaults.Keys.dockPreviewActivationMode.defaultValue
+                Defaults[.dockPreviewActivationModifier] = Defaults.Keys.dockPreviewActivationModifier.defaultValue
                 Defaults[.previewHoverAction] = Defaults.Keys.previewHoverAction.defaultValue
 
                 showMenuBarIcon = Defaults.Keys.showMenuBarIcon.defaultValue

--- a/DockDoor/Views/Settings/Search/SettingsSearchCatalog.swift
+++ b/DockDoor/Views/Settings/Search/SettingsSearchCatalog.swift
@@ -1221,7 +1221,7 @@ enum SettingsSearchCatalog {
             id: "gestures.middleClick",
             title: String(localized: "Middle Click"),
             description: String(localized: "Action performed when middle-clicking on a window preview."),
-            keywords: ["middle", "click", "mouse", "button"],
+            keywords: ["middle", "click", "mouse", "button", "open", "activate", "window", "app"],
             tab: "GesturesKeybinds",
             section: String(localized: "Mouse Actions"),
             icon: "computermouse"

--- a/DockDoor/Views/Settings/Search/SettingsSearchCatalog.swift
+++ b/DockDoor/Views/Settings/Search/SettingsSearchCatalog.swift
@@ -123,7 +123,7 @@ enum SettingsSearchCatalog {
         SettingsSearchItem(
             id: "dockPreviews.enable",
             title: String(localized: "Enable Dock Previews"),
-            description: String(localized: "Show window previews when hovering over Dock icons."),
+            description: String(localized: "Show window previews for Dock icons."),
             keywords: ["dock", "hover", "preview"],
             tab: "DockPreviews",
             section: "",
@@ -207,6 +207,23 @@ enum SettingsSearchCatalog {
             tab: "DockPreviews",
             section: String(localized: "Window Display"),
             icon: "1.square"
+        ),
+        SettingsSearchItem(
+            id: "dockPreviews.activationTrigger",
+            title: String(localized: "Dock Preview Trigger"),
+            description: String(localized: "Show previews automatically on hover, or require a click trigger on the Dock icon."),
+            keywords: ["trigger", "hover", "middle", "click", "modifier", "dock"],
+            tab: "DockPreviews",
+            section: String(localized: "Dock Interaction"),
+            icon: "cursorarrow.click"
+        ),
+        SettingsSearchItem(
+            id: "dockPreviews.activationModifier",
+            title: String(localized: "Dock Preview Modifier"),
+            keywords: ["modifier", "option", "control", "shift", "command", "click"],
+            tab: "DockPreviews",
+            section: String(localized: "Dock Interaction"),
+            icon: "keyboard"
         ),
         SettingsSearchItem(
             id: "dockPreviews.hoverAction",

--- a/DockDoor/consts.swift
+++ b/DockDoor/consts.swift
@@ -110,6 +110,8 @@ extension Defaults.Keys {
     static let enableWindowSwitcher = Key<Bool>("enableWindowSwitcher", default: true)
     static let instantWindowSwitcher = Key<Bool>("instantWindowSwitcher", default: false)
     static let enableDockPreviews = Key<Bool>("enableDockPreviews", default: true)
+    static let dockPreviewActivationMode = Key<DockPreviewActivationMode>("dockPreviewActivationMode", default: .hover)
+    static let dockPreviewActivationModifier = Key<DockPreviewActivationModifier>("dockPreviewActivationModifier", default: .option)
     static let showWindowsFromCurrentSpaceOnly = Key<Bool>("showWindowsFromCurrentSpaceOnly", default: false)
     static let showWindowsFromCurrentMonitorOnly = Key<Bool>("showWindowsFromCurrentMonitorOnly", default: false)
     static let windowPreviewSortOrder = Key<WindowPreviewSortOrder>("windowPreviewSortOrder", default: .recentlyUsed)
@@ -723,6 +725,56 @@ enum DockClickAction: String, CaseIterable, Defaults.Serializable {
             String(localized: "Minimize windows", comment: "Dock click action option")
         case .hide:
             String(localized: "Hide application", comment: "Dock click action option")
+        }
+    }
+}
+
+enum DockPreviewActivationMode: String, CaseIterable, Defaults.Serializable {
+    case hover
+    case middleClick
+    case modifierClick
+
+    var localizedName: String {
+        switch self {
+        case .hover:
+            String(localized: "Hover", comment: "Dock preview activation mode option")
+        case .middleClick:
+            String(localized: "Middle Click", comment: "Dock preview activation mode option")
+        case .modifierClick:
+            String(localized: "Modifier Click", comment: "Dock preview activation mode option")
+        }
+    }
+}
+
+enum DockPreviewActivationModifier: String, CaseIterable, Defaults.Serializable {
+    case option
+    case control
+    case shift
+    case command
+
+    var localizedName: String {
+        switch self {
+        case .option:
+            String(localized: "Option ⌥", comment: "Dock preview activation modifier option")
+        case .control:
+            String(localized: "Control ⌃", comment: "Dock preview activation modifier option")
+        case .shift:
+            String(localized: "Shift ⇧", comment: "Dock preview activation modifier option")
+        case .command:
+            String(localized: "Command ⌘", comment: "Dock preview activation modifier option")
+        }
+    }
+
+    var eventFlag: CGEventFlags {
+        switch self {
+        case .option:
+            .maskAlternate
+        case .control:
+            .maskControl
+        case .shift:
+            .maskShift
+        case .command:
+            .maskCommand
         }
     }
 }


### PR DESCRIPTION
## Describe your changes

Adds an explicit Dock preview trigger setting so previews can keep the existing hover behavior or require a deliberate mouse action. The new setting lives under Dock Previews > Dock Interaction and supports:

- Hover, kept as the default for backward compatibility
- Middle Click on a Dock icon
- Modifier Click on a Dock icon, with configurable Option, Control, Shift, or Command modifier

This also adds an "Open App Window" middle-click action for visible window previews, so users can middle-click a Dock icon to show previews and then middle-click a preview to open the selected app window.

These changes solves the issues mentioned in #1487 and #1489:

> DockDoor currently shows Dock previews automatically when the mouse moves over a Dock icon. This can be easy to trigger accidentally when user moving the mouse around near the Dock, which is distracting for users who only want previews when they intentionally request them. E.g. in hover mode, window preview can be easily mis-triggered when user wants to resize the border of the window which is close to dock, or operate at the edge of the large window.

The implementation also handles the edge cases found during testing:

- Folder previews respect the selected Dock preview trigger.
- Modifier settings remain discoverable through Settings search.
- Middle-clicks inside the preview are passed through to the preview UI immediately instead of being swallowed by Dock event handling.
- Non-running Dock apps that cannot show a special DockDoor preview are no longer intercepted, preserving native Dock launch/modifier behavior.

<img width="591" height="138" alt="image" src="https://github.com/user-attachments/assets/67f7c82a-8bb8-4c4d-8f13-7bdf27bc04cb" />
<img width="610" height="142" alt="image" src="https://github.com/user-attachments/assets/270d1a32-c98e-4083-b588-c2026a534805" />
<img width="621" height="214" alt="image" src="https://github.com/user-attachments/assets/9ad0a44f-1a43-4492-8c79-e54e8e359aa6" />
<img width="457" height="154" alt="image" src="https://github.com/user-attachments/assets/1114f635-7be1-46df-a4f8-e13e4f90fd17" />


## Related issue number(s) and link(s)

Closes #1487
Closes #1489


## Checklist before requesting a review
- [x] I have performed a self-review of my code and understand every line
- [x] If this change affects core functionality, I have added a description highlighting the changes
- [x] I have followed conventional commit guidelines
- [x] I have tested this PR on my own machine

## AI Assistance Disclosure

> **Policy**: AI-assisted contributions are welcome, but you must understand, test, and take full responsibility for your code. Pasting AI-generated code or PR descriptions without genuine human review and understanding will result in your PR being closed and may result in a ban from contributing.

**Did you use AI tools (ChatGPT, Claude, Copilot, Cursor, etc.) for this PR?**
- [ ] No AI tools were used
- [x] Yes - describe below how AI was used and confirm you reviewed/tested the output

Used ChatGPT/Codex to help inspect the Dock event routing code, identify likely causes for review/test issues, and draft targeted fixes. I reviewed the changes, manually tested the Dock preview trigger flow, the preview middle-click open-window action, and the non-running app pass-through behavior, and I take responsibility for the submitted code.

<!-- If yes, briefly describe: What tool? What did it help with? Did you modify/review its output? -->

### What "genuine human review" means:
- You can explain any line of code if asked
- You tested the changes yourself and verified they work
- You understand how your changes interact with existing code
- Your PR description reflects your actual understanding, not AI-generated summaries

### Examples of acceptable AI use:
- "Used Copilot for autocomplete suggestions, reviewed each one"
- "Asked Claude to explain how ScreenCaptureKit works, wrote the implementation myself"
- "Used ChatGPT to help debug an issue, verified the fix myself"

### What will get your PR closed (and possibly banned):
- Pasting AI output directly without review or understanding
- PR descriptions that are clearly AI-generated (overly formal, generic explanations you can't elaborate on)
- Unable to explain your own code changes when asked
- Submitting large refactors with undocumented behavioral changes

## Core Functionality Changes
If this PR modifies core functionality, please provide a brief description of the changes and their impact below:

This changes Dock preview activation behavior by adding an explicit trigger mode. Existing users keep the same hover behavior by default. Users who choose Middle Click or Modifier Click no longer get DockDoor previews from simple hover, so macOS Dock behavior remains unchanged until the configured trigger is used.

This also changes window preview mouse-action behavior by adding an "Open App Window" middle-click action. When selected, it brings the selected preview window forward, restores minimized windows, unhides hidden apps, or activates a running windowless app without creating a new window.
