### PR TITLE
feat: Add glass variant 20: native-style blurred liquid glass

### DIFF
--- a/DockDoor/Components/BlurView.swift
+++ b/DockDoor/Components/BlurView.swift
@@ -27,7 +27,7 @@ struct BackgroundAppearance: Equatable {
     /// as the border, so `borderedBackground` should be skipped.
     static let syntheticBlurVariant = 20
 
-    var usesSyntheticBlur: Bool { glassVariant == Self.syntheticBlurVariant }
+    var usesSyntheticBlur: Bool { style == .liquidGlass && glassVariant == Self.syntheticBlurVariant }
 
     static func resolve() -> BackgroundAppearance {
         BackgroundAppearance(
@@ -148,6 +148,7 @@ class LiquidGlassContainerView: NSView {
     var blurRadius: CGFloat = 0
     var saturation: CGFloat = 1.0
     var glassVariant: Int = 4
+    private var appliedNativeVariant: Int?
 
     private var hasConfigured = false
     private var glass: NSGlassEffectView?
@@ -184,9 +185,14 @@ class LiquidGlassContainerView: NSView {
 
     func applyGlassVariant() {
         guard let glass else { return }
-        setNativeVariant(on: glass, effectiveNativeVariant)
-        syncBlurUnderlay()
-        refreshBackdropLayers()
+        let target = effectiveNativeVariant
+        let variantChanged = appliedNativeVariant != target
+        if variantChanged {
+            setNativeVariant(on: glass, target)
+            appliedNativeVariant = target
+            syncBlurUnderlay()
+            refreshBackdropLayers()
+        }
     }
 
     /// Sets the corner radius on the clipping container. For variant 20 the

--- a/DockDoor/Components/BlurView.swift
+++ b/DockDoor/Components/BlurView.swift
@@ -22,6 +22,13 @@ struct BackgroundAppearance: Equatable {
         .useOpaquePreviewBackground, .customBackgroundColor,
     ]
 
+    /// Variant 20 is a synthetic variant handled by DockDoor (not a native
+    /// NSGlassEffectView value). The glass shader's own edge refraction serves
+    /// as the border, so `borderedBackground` should be skipped.
+    static let syntheticBlurVariant = 20
+
+    var usesSyntheticBlur: Bool { glassVariant == Self.syntheticBlurVariant }
+
     static func resolve() -> BackgroundAppearance {
         BackgroundAppearance(
             style: Defaults[.dockBackgroundStyle],
@@ -84,6 +91,8 @@ struct BlurView: View {
     }
 }
 
+// MARK: - Liquid Glass NSViewRepresentable
+
 @available(macOS 26.0, *)
 struct LiquidGlassRepresentable: NSViewRepresentable {
     let cornerRadius: CGFloat
@@ -120,8 +129,16 @@ struct LiquidGlassRepresentable: NSViewRepresentable {
     }
 }
 
+// MARK: - Liquid Glass Container
+
+/// Variant 20 is a synthetic variant that pairs the specular look of variant 19
+/// with a separate blur underlay (a manually-inserted CABackdropLayer beneath
+/// the glass). Variants 0-19 are native NSGlassEffectView `_variant` values
+/// whose backdrop layers are managed by the system.
 @available(macOS 26.0, *)
 class LiquidGlassContainerView: NSView {
+    private static let nativeVariantForSynthetic = 19
+
     var cornerRadius: CGFloat = 14
     var glassOpacity: CGFloat = 0.95
     var tintOpacity: CGFloat = 0.3 {
@@ -136,18 +153,24 @@ class LiquidGlassContainerView: NSView {
     private var glass: NSGlassEffectView?
     private var tintLayer: NSView?
     private var backdropLayers: [CALayer] = []
+    private var blurUnderlayLayer: CALayer?
+
+    private var isSyntheticVariant: Bool { glassVariant == BackgroundAppearance.syntheticBlurVariant }
+    private var effectiveNativeVariant: Int {
+        isSyntheticVariant ? Self.nativeVariantForSynthetic : glassVariant
+    }
 
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
-        wantsLayer = true
-        layer?.cornerRadius = cornerRadius
-        layer?.cornerCurve = .continuous
-        layer?.masksToBounds = true
-        setupGlass()
+        commonInit()
     }
 
     required init?(coder: NSCoder) {
         super.init(coder: coder)
+        commonInit()
+    }
+
+    private func commonInit() {
         wantsLayer = true
         layer?.cornerRadius = cornerRadius
         layer?.cornerCurve = .continuous
@@ -161,21 +184,34 @@ class LiquidGlassContainerView: NSView {
 
     func applyGlassVariant() {
         guard let glass else { return }
-        applyGlassVariant(to: glass, variant: glassVariant)
+        setNativeVariant(on: glass, effectiveNativeVariant)
+        syncBlurUnderlay()
+        refreshBackdropLayers()
     }
 
-    func applyBackdropOverrides() {
-        for backdrop in backdropLayers {
-            if blurRadius > 0 {
-                backdrop.setValue(blurRadius, forKey: "gaussianRadius")
-            }
-            backdrop.setValue(saturation, forKey: "saturationFactor")
+    /// Sets the corner radius on the clipping container. For variant 20 the
+    /// radius is also forwarded to the glass view so the shader renders edge
+    /// refraction along the curve.
+    func updateCornerRadius() {
+        layer?.cornerRadius = cornerRadius
+        if isSyntheticVariant {
+            glass?.cornerRadius = cornerRadius
         }
     }
 
-    func updateCornerRadius() {
-        layer?.cornerRadius = cornerRadius
+    /// Routes user blur/saturation overrides to the correct backend: native
+    /// variants (0-19) are unchanged from upstream and use KVC on the glass
+    /// view's own CABackdropLayers; the synthetic variant (20) uses CAFilters
+    /// on its separate blur underlay instead.
+    func applyBackdropOverrides() {
+        if isSyntheticVariant {
+            applyBlurUnderlayFilters()
+        } else {
+            applyNativeBackdropOverrides()
+        }
     }
+
+    // MARK: - Setup
 
     private func setupGlass() {
         let tint = NSView()
@@ -185,7 +221,13 @@ class LiquidGlassContainerView: NSView {
 
         let glassView = NSGlassEffectView()
         glassView.style = .clear
-        applyGlassVariant(to: glassView, variant: glassVariant)
+        setNativeVariant(on: glassView, effectiveNativeVariant)
+        if isSyntheticVariant {
+            glassView.contentView = NSView()
+            glassView.cornerRadius = cornerRadius
+            glassView.wantsLayer = true
+            glassView.layer?.masksToBounds = true
+        }
         glassView.translatesAutoresizingMaskIntoConstraints = false
         addSubview(glassView)
 
@@ -203,14 +245,87 @@ class LiquidGlassContainerView: NSView {
         updateTintColor()
     }
 
-    // Selects a private NSGlassEffectView variant for a richer specular look
-    // than the public `.clear`/`.regular` styles expose. No-ops (leaving the
-    // public style) if the selector is unavailable.
-    private func applyGlassVariant(to view: NSView, variant: Int) {
+    // MARK: - Native variant helpers (0-19)
+
+    /// Calls the private `set_variant:` on NSGlassEffectView. No-ops if the
+    /// selector is unavailable.
+    private func setNativeVariant(on view: NSView, _ variant: Int) {
         let sel = NSSelectorFromString("set_variant:")
         guard view.responds(to: sel), let imp = view.method(for: sel) else { return }
         typealias Setter = @convention(c) (NSObject, Selector, Int64) -> Void
         unsafeBitCast(imp, to: Setter.self)(view, sel, Int64(variant))
+    }
+
+    private func applyNativeBackdropOverrides() {
+        for backdrop in backdropLayers {
+            if blurRadius > 0 {
+                backdrop.setValue(blurRadius, forKey: "gaussianRadius")
+            }
+            backdrop.setValue(saturation, forKey: "saturationFactor")
+        }
+    }
+
+    // MARK: - Synthetic blur underlay (variant 20)
+
+    /// Creates or tears down the blur underlay CABackdropLayer depending on
+    /// whether the current variant needs it.
+    private func syncBlurUnderlay() {
+        if isSyntheticVariant {
+            ensureBlurUnderlay()
+        } else {
+            removeBlurUnderlay()
+        }
+    }
+
+    private func ensureBlurUnderlay() {
+        guard blurUnderlayLayer == nil,
+              let containerLayer = layer,
+              let backdropClass = NSClassFromString("CABackdropLayer") as? CALayer.Type else { return }
+
+        let backdrop = backdropClass.init()
+        backdrop.setValue(true, forKey: "windowServerAware")
+        backdrop.setValue(1.0, forKey: "scale")
+        backdrop.frame = containerLayer.bounds
+        backdrop.autoresizingMask = [.layerWidthSizable, .layerHeightSizable]
+        containerLayer.insertSublayer(backdrop, at: 0)
+        blurUnderlayLayer = backdrop
+    }
+
+    private func removeBlurUnderlay() {
+        blurUnderlayLayer?.removeFromSuperlayer()
+        blurUnderlayLayer = nil
+    }
+
+    private func applyBlurUnderlayFilters() {
+        guard let backdrop = blurUnderlayLayer else { return }
+        var filters: [Any] = []
+        if blurRadius > 0, let blur = makeCAFilter("gaussianBlur") {
+            blur.setValue(blurRadius, forKey: "inputRadius")
+            blur.setValue(true, forKey: "inputNormalizeEdges")
+            filters.append(blur)
+        }
+        if saturation != 1.0, let saturate = makeCAFilter("colorSaturate") {
+            saturate.setValue(saturation, forKey: "inputAmount")
+            filters.append(saturate)
+        }
+        backdrop.filters = filters
+        backdrop.isHidden = filters.isEmpty
+    }
+
+    private func makeCAFilter(_ type: String) -> NSObject? {
+        guard let cls = NSClassFromString("CAFilter") as? NSObject.Type else { return nil }
+        let sel = NSSelectorFromString("filterWithType:")
+        guard cls.responds(to: sel) else { return nil }
+        return cls.perform(sel, with: type)?.takeUnretainedValue() as? NSObject
+    }
+
+    // MARK: - Layout & lifecycle
+
+    override func layout() {
+        super.layout()
+        if let containerLayer = layer {
+            blurUnderlayLayer?.frame = containerLayer.bounds
+        }
     }
 
     override func viewDidMoveToWindow() {
@@ -228,21 +343,36 @@ class LiquidGlassContainerView: NSView {
             backdrop.removeObserver(self, forKeyPath: "scale")
         }
         backdropLayers.removeAll()
+        removeBlurUnderlay()
         super.removeFromSuperview()
     }
+
+    // MARK: - Backdrop layer management
 
     private func configureBackdropLayers() {
         if let layer = glass?.layer {
             setBackdropProperties(in: layer)
             observeBackdropLayers(in: layer)
-            applyBackdropOverrides()
+        }
+        syncBlurUnderlay()
+        applyBackdropOverrides()
+    }
+
+    private func refreshBackdropLayers() {
+        for backdrop in backdropLayers {
+            backdrop.removeObserver(self, forKeyPath: "windowServerAware")
+            backdrop.removeObserver(self, forKeyPath: "scale")
+        }
+        backdropLayers.removeAll()
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { [weak self] in
+            self?.configureBackdropLayers()
         }
     }
 
-    // WindowServer resets `scale` to 0.5 for non-key windows, causing half-res blur.
-    // We observe `scale` via KVO and force it back to 1.0.
-    // We also observe `windowServerAware` — when false, the backdrop loses its
-    // connection to WindowServer state. Reconfigure to restore it.
+    /// WindowServer resets `scale` to 0.5 for non-key windows, causing half-res
+    /// blur. We observe both `scale` and `windowServerAware` via KVO so we can
+    /// force them back to the correct values.
     private func observeBackdropLayers(in layer: CALayer) {
         guard backdropLayers.isEmpty else { return }
         backdropLayers = collectBackdropLayers(in: layer)
@@ -288,6 +418,8 @@ class LiquidGlassContainerView: NSView {
         layer.sublayers?.forEach { setBackdropProperties(in: $0) }
     }
 
+    // MARK: - Appearance
+
     private func updateTintColor() {
         let isDark = effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
         tintLayer?.layer?.backgroundColor = (isDark ? NSColor.black : NSColor.white)
@@ -299,6 +431,8 @@ class LiquidGlassContainerView: NSView {
         updateTintColor()
     }
 }
+
+// MARK: - Material Blur View
 
 struct MaterialBlurView: NSViewRepresentable {
     var material: NSVisualEffectView.Material

--- a/DockDoor/Components/dockStyle.swift
+++ b/DockDoor/Components/dockStyle.swift
@@ -28,25 +28,49 @@ struct DockStyleModifier: ViewModifier {
     let backgroundOpacity: CGFloat
     let outerPadding: CGFloat
 
+    private var shape: RoundedRectangle {
+        RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+    }
+
     func body(content: Content) -> some View {
         content
             .background {
                 ZStack {
-                    BlurView(cornerRadius: cornerRadius, appearance: backgroundAppearance)
-                        .borderedBackground(
-                            glassBorderGradient(opacity: backgroundAppearance.borderOpacity),
-                            lineWidth: backgroundAppearance.borderWidth,
-                            shape: RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
-                        )
-                        .opacity(backgroundOpacity)
+                    glassBackground
                     if let hc = highlightColor {
                         FluidGradient(blobs: hc.generateShades(count: 3), highlights: hc.generateShades(count: 3), speed: 0.5, blur: 0.75)
                             .opacity(0.2 * backgroundOpacity)
                     }
                 }
-                .clipShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
+                .clipShape(shape)
             }
             .padding(outerPadding)
+    }
+
+    /// The synthetic blur variant relies on the glass shader's own edge
+    /// refraction as its border, so it skips `borderedBackground` (which
+    /// insets the content and leaves an un-blurred gap) and uses an overlay
+    /// stroke instead.
+    @ViewBuilder
+    private var glassBackground: some View {
+        if backgroundAppearance.usesSyntheticBlur {
+            BlurView(cornerRadius: cornerRadius, appearance: backgroundAppearance)
+                .overlay {
+                    shape.strokeBorder(
+                        glassBorderGradient(opacity: backgroundAppearance.borderOpacity),
+                        lineWidth: backgroundAppearance.borderWidth
+                    )
+                }
+                .opacity(backgroundOpacity)
+        } else {
+            BlurView(cornerRadius: cornerRadius, appearance: backgroundAppearance)
+                .borderedBackground(
+                    glassBorderGradient(opacity: backgroundAppearance.borderOpacity),
+                    lineWidth: backgroundAppearance.borderWidth,
+                    shape: shape
+                )
+                .opacity(backgroundOpacity)
+        }
     }
 }
 

--- a/DockDoor/Views/Settings/Appearance/BackgroundAppearanceSection.swift
+++ b/DockDoor/Views/Settings/Appearance/BackgroundAppearanceSection.swift
@@ -69,11 +69,11 @@ struct BackgroundAppearanceSection: View {
                                             get: { Double(glassVariant) },
                                             set: { glassVariant = Int($0.rounded()) }
                                         ),
-                                        in: 0 ... 19,
+                                        in: 0 ... 20,
                                         step: 1
                                     )
                                     .frame(maxWidth: 160)
-                                    Stepper(value: $glassVariant, in: 0 ... 19) {
+                                    Stepper(value: $glassVariant, in: 0 ... 20) {
                                         Text("\(glassVariant)")
                                             .font(.body.monospacedDigit())
                                             .frame(minWidth: 20, alignment: .trailing)


### PR DESCRIPTION
This adds a new variant aimed at getting closer to Apple's native liquid glass look — where you can see both the specular refraction and a soft blur of the content behind the window.

---
<img width="406" height="437" alt="2026-07-13_23-24-04" src="https://github.com/user-attachments/assets/8c166134-0e17-4014-a3aa-27c716177efc" />

---

The existing variants already cover a wide range of glass styles. Variant 20 makes it closer to how system UI panels feel by adding background Gaussion blur while keeping the refraction on top. This variant was built on top of variant 19's specular look by layering a separate CABackdropLayer underneath, which the blur and saturation sliders can drive via CAFilter.

The border rendering is also adjusted for this variant: the existing approach pads inward to draw the stroke, which can leave a thin un-blurred strip around the edges. Variant 20 uses an overlay stroke instead so the border sits directly on the glass surface. This is closer to Apple's recommended implementation.

Variants 0–19 are completely untouched. The only changes outside BlurView.swift are extending the slider range to 20 and a border-routing branch in DockStyleModifier.

> Since this variant takes a different approach from the existing ones, I've scoped the new setup (contentView, glass-level cornerRadius, masksToBounds) to variant 20 only, to keep the change low-risk. Some of these (particularly setting cornerRadius on the glass view itself for better edge refraction) could benefit all variants down the line if that's of interest.

## Describe your changes

- Added variant 20 as a new synthetic glass option. It uses variant 19's specular glass internally, but adds a manually-created `CABackdropLayer` underneath so the blur radius and saturation sliders actually work.
- The blur underlay is managed independently from the glass view's own layer tree — created when variant 20 is selected, removed when switching away. Gaussian blur and color saturation are applied via `CAFilter`.
- Changed the border rendering for variant 20 from `borderedBackground` (which pads inward) to an overlay stroke, so the border draws on top of the glass without leaving an un-blurred gap.
- Extended the variant slider/stepper range from 0–19 to 0–20.
- No changes to the behavior of variants 0–19.

## Related issue number(s) and link(s)

#1397

## Checklist before requesting a review

- [x] I have performed a self-review of my code and understand every line
- [x] If this change affects core functionality, I have added a description highlighting the changes
- [x] I have followed conventional commit guidelines
- [x] I have tested this PR on my own machine

## AI Assistance Disclosure

> **Policy**: AI-assisted contributions are welcome, but you must understand, test, and take full responsibility for your code. Pasting AI-generated code or PR descriptions without genuine human review and understanding will result in your PR being closed and may result in a ban from contributing.

**Did you use AI tools (ChatGPT, Claude, Copilot, Cursor, etc.) for this PR?**

- [ ] No AI tools were used
- [x] Yes - describe below how AI was used and confirm you reviewed/tested the output

I Used Claude Code to investigate the glass variant layer hierarchy (dumping the CALayer tree, identifying that variant 19 uses glassBackground/glassForeground CAFilters instead of exposing gaussianRadius), prototype the CABackdropLayer + CAFilter approach, and draft the implementation. I reviewed the output, tested each iteration on my machine, and directed the final structure (scoping changes to variant 20 only, border fix, comment clarity).

### What "genuine human review" means:

- You can explain any line of code if asked
- You tested the changes yourself and verified they work
- You understand how your changes interact with existing code
- Your PR description reflects your actual understanding, not AI-generated summaries

### Examples of acceptable AI use:

- "Used Copilot for autocomplete suggestions, reviewed each one"
- "Asked Claude to explain how ScreenCaptureKit works, wrote the implementation myself"
- "Used ChatGPT to help debug an issue, verified the fix myself"

### What will get your PR closed (and possibly banned):

- Pasting AI output directly without review or understanding
- PR descriptions that are clearly AI-generated (overly formal, generic explanations you can't elaborate on)
- Unable to explain your own code changes when asked
- Submitting large refactors with undocumented behavioral changes

## Core Functionality Changes

This PR adds a new glass variant (20) with its own backdrop blur pipeline. It does **not** modify the rendering path for existing variants 0–19. The new code paths (`syncBlurUnderlay`, `applyBlurUnderlayFilters`, overlay border in `DockStyleModifier`) are only reached when variant 20 is selected. The `CABackdropLayer` and `CAFilter` APIs used are private but fail silently if unavailable — variant 20 would degrade to variant 19 without blur.