### PR TITLE
fix: exclude floating panels from AX window discovery

### DIFF
--- a/DockDoor/Utilities/Window Management/WindowDiscoveryShared.swift
+++ b/DockDoor/Utilities/Window Management/WindowDiscoveryShared.swift
@@ -191,7 +191,12 @@ enum WindowCandidateDiscriminator {
             (level.map { crossoverWindow(app, attributes.role, attributes.subrole, $0) } ?? false) ||
             (level.map { alwaysOnTopScrcpy(app, $0, attributes.role, attributes.subrole) } ?? false)
 
-        let standardSubrole = [kAXStandardWindowSubrole, kAXDialogSubrole].contains(attributes.subrole)
+        // Floating panels pass the subrole check but are not switchable app windows
+        // (e.g. Outlook's meeting-reminder toast is an AXDialog at floating level 3).
+        // The SC discovery path already enforces windowLayer == 0; this keeps the AX
+        // path consistent. Apps that legitimately float have explicit rules below.
+        let isNormalLevel = level == nil || level == normalLevel
+        let standardSubrole = isNormalLevel && [kAXStandardWindowSubrole, kAXDialogSubrole].contains(attributes.subrole)
         let appSpecificSubrole = openBoard(app) ||
             adobeAudition(app, attributes.subrole) ||
             adobeAfterEffects(app, attributes.subrole) ||
@@ -207,7 +212,7 @@ enum WindowCandidateDiscriminator {
             autocad(app, attributes.subrole)
 
         guard specialApp || standardSubrole || appSpecificSubrole else {
-            return "subrole is not standard/dialog and no app-specific rule matched"
+            return "subrole is not standard/dialog at normal level and no app-specific rule matched"
         }
 
         if !specialApp {


### PR DESCRIPTION
## Describe your changes

Floating panels were showing up as switchable windows in the dock previews and the window switcher. The most visible case is Outlook's meeting-reminder toast: it is an `AXDialog` at window level 3 (floating), so it passes the standard/dialog subrole check in `WindowCandidateDiscriminator` and gets treated like a regular app window. Selecting it does nothing useful, and it pollutes the switcher list while it is on screen.

The ScreenCaptureKit discovery path already enforces `windowLayer == 0`, so the two paths disagreed: SC filters these panels out, AX let them through. The fix requires normal window level for the generic standard/dialog subrole acceptance, making the AX path consistent with the SC path. Apps that legitimately float (e.g. scrcpy with `--always-on-top`) are unaffected - they are matched by the explicit app-specific rules, which are checked independently of this condition.

Tested on my machine:
- Outlook meeting-reminder toast no longer appears in the switcher or dock previews while regular Outlook windows still do
- scrcpy with `--always-on-top` still appears (app-specific rule path)
- Regular windows, dialogs, and minimized windows across Finder, Safari, Xcode unaffected

## Related issue number(s) and link(s)

None

## Checklist before requesting a review
- [x] I have performed a self-review of my code and understand every line
- [x] If this change affects core functionality, I have added a description highlighting the changes
- [x] I have followed conventional commit guidelines
- [x] I have tested this PR on my own machine

## AI Assistance Disclosure

> **Policy**: AI-assisted contributions are welcome, but you must understand, test, and take full responsibility for your code. Pasting AI-generated code or PR descriptions without genuine human review and understanding will result in your PR being closed and may result in a ban from contributing.

**Did you use AI tools (ChatGPT, Claude, Copilot, Cursor, etc.) for this PR?**
- [ ] No AI tools were used
- [x] Yes - describe below how AI was used and confirm you reviewed/tested the output

Used Claude Code to help implement the fix. I reviewed every line of the change and tested the scenarios listed above on my own machine, where I run this fix daily.

## Core Functionality Changes

Tightens AX window discovery: the generic `AXStandardWindow`/`AXDialog` acceptance now also requires normal window level, matching the filter the ScreenCaptureKit path already applies. App-specific inclusion rules (floating apps like scrcpy) are unchanged.
