### PR TITLE
fix: keep selection highlight visible when preview card background is hidden

### DIFF
--- a/DockDoor/Views/Hover Window/WindowPreview.swift
+++ b/DockDoor/Views/Hover Window/WindowPreview.swift
@@ -815,6 +815,15 @@ struct WindowPreview: View, Equatable {
                             }
                         }
                 }
+
+                // Selection border drawn outside the card-background branch so the
+                // selected item stays visible when hidePreviewCardBackground is on.
+                if finalIsSelected {
+                    let highlightColor = appearance.hoverHighlightColor ?? Color(nsColor: .controlAccentColor)
+                    RoundedRectangle(cornerRadius: cornerRadius)
+                        .strokeBorder(highlightColor, lineWidth: 2.5)
+                        .padding(-CardRadius.innerPadding)
+                }
             }
         }
         .overlay {

--- a/DockDoor/Views/Hover Window/WindowPreviewCompact.swift
+++ b/DockDoor/Views/Hover Window/WindowPreviewCompact.swift
@@ -172,6 +172,15 @@ struct WindowPreviewCompact: View, Equatable {
                         }
                     }
             }
+
+            // Selection border drawn outside the card-background branch so the
+            // selected item stays visible when hidePreviewCardBackground is on.
+            if isHighlighted {
+                let highlightColor = appearance.hoverHighlightColor ?? Color(nsColor: .controlAccentColor)
+                RoundedRectangle(cornerRadius: cornerRadius)
+                    .strokeBorder(highlightColor, lineWidth: 2.5)
+                    .padding(.horizontal, -CardRadius.innerPadding)
+            }
         }
         .opacity(isHighlighted ? 1.0 : appearance.unselectedContentOpacity)
         .padding(.horizontal, CardRadius.innerPadding)


### PR DESCRIPTION
## Describe your changes

With **Hide preview card background** enabled, the selected window in the previews and the window switcher had no visual indicator at all. The selection highlight is drawn as part of the card background branch, so hiding the background also hid the highlight - keyboard navigation through the switcher became blind guessing.

The fix draws the selection border independently of the card-background branch in both `WindowPreview` and `WindowPreviewCompact`. When an item is selected, a `strokeBorder` in the configured hover highlight color (falling back to the system accent color) is drawn around the card regardless of whether the background is shown. Behavior with the card background enabled is unchanged - the border simply reinforces the existing highlight.

Tested on my machine:
- `hidePreviewCardBackground` on: cycling with the switcher keybind now shows a clear accent-colored border around the selected item, in both regular and compact previews
- `hidePreviewCardBackground` off: no visual change apart from the added border on selection
- Custom `hoverHighlightColor` is respected; without one the system accent color is used

## Related issue number(s) and link(s)

None

## Checklist before requesting a review
- [x] I have performed a self-review of my code and understand every line
- [x] If this change affects core functionality, I have added a description highlighting the changes
- [x] I have followed conventional commit guidelines
- [x] I have tested this PR on my own machine

## AI Assistance Disclosure

> **Policy**: AI-assisted contributions are welcome, but you must understand, test, and take full responsibility for your code. Pasting AI-generated code or PR descriptions without genuine human review and understanding will result in your PR being closed and may result in a ban from contributing.

**Did you use AI tools (ChatGPT, Claude, Copilot, Cursor, etc.) for this PR?**
- [ ] No AI tools were used
- [x] Yes - describe below how AI was used and confirm you reviewed/tested the output

Used Claude Code to help implement the fix. I reviewed every line of the change and tested the scenarios listed above on my own machine, where I run this fix daily.

## Core Functionality Changes

Selection border rendering in `WindowPreview` / `WindowPreviewCompact` no longer depends on the card background being visible. With the background setting left at its default (shown), rendering is unchanged apart from the selection border.
