### PR TITLE
fix: resolve previews for Parall app shortcuts

### DIFF
--- a/DockDoor.xcodeproj/project.pbxproj
+++ b/DockDoor.xcodeproj/project.pbxproj
@@ -61,6 +61,7 @@
 		AA11001122334455AA110044 /* DockLockingSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA11001122334455AA110033 /* DockLockingSettingsView.swift */; };
 		AA11001122334455AA110066 /* DockLockerGeometryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA11001122334455AA110055 /* DockLockerGeometryTests.swift */; };
 		555110B7F7B99C7BD510DBC7 /* NativeTabGroupingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D00D4B366E3CF5338182E065 /* NativeTabGroupingTests.swift */; };
+		B39D72A40F154A60B56D59833FA84307 /* ParallShortcutResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D16E857F87064806B362CB6AF2D7014F /* ParallShortcutResolverTests.swift */; };
 		B376D66B467C4587915220BC80D3B9CB /* ScriptCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = F098F8107F464776B5C18294427CAECD /* ScriptCommands.swift */; };
 		B3C9F20484F14266B941AFB170B66530 /* MediaRemoteService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC298B81953848F481EE849906E0AE77 /* MediaRemoteService.swift */; };
 		B84941090B484695B105D967 /* SettingsGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4258675B29E4A22ACF92845 /* SettingsGroup.swift */; };
@@ -286,6 +287,7 @@
 		AA11001122334455AA110033 /* DockLockingSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockLockingSettingsView.swift; sourceTree = "<group>"; };
 		AA11001122334455AA110055 /* DockLockerGeometryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockLockerGeometryTests.swift; sourceTree = "<group>"; };
 		D00D4B366E3CF5338182E065 /* NativeTabGroupingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeTabGroupingTests.swift; sourceTree = "<group>"; };
+		D16E857F87064806B362CB6AF2D7014F /* ParallShortcutResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParallShortcutResolverTests.swift; sourceTree = "<group>"; };
 		AA11001122334455AA110100 /* DockDoorTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DockDoorTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		AC298B81953848F481EE849906E0AE77 /* MediaRemoteService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaRemoteService.swift; sourceTree = "<group>"; };
 		B056906A7ACD4903BD5E1627B359AE2C /* AdvancedSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvancedSettingsView.swift; sourceTree = "<group>"; };
@@ -589,6 +591,7 @@
 			children = (
 				AA11001122334455AA110055 /* DockLockerGeometryTests.swift */,
 				D00D4B366E3CF5338182E065 /* NativeTabGroupingTests.swift */,
+				D16E857F87064806B362CB6AF2D7014F /* ParallShortcutResolverTests.swift */,
 			);
 			path = DockDoorTests;
 			sourceTree = "<group>";
@@ -1099,6 +1102,7 @@
 			files = (
 				AA11001122334455AA110066 /* DockLockerGeometryTests.swift in Sources */,
 				555110B7F7B99C7BD510DBC7 /* NativeTabGroupingTests.swift in Sources */,
+				B39D72A40F154A60B56D59833FA84307 /* ParallShortcutResolverTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/DockDoor/Utilities/DockObserver.swift
+++ b/DockDoor/Utilities/DockObserver.swift
@@ -1,6 +1,7 @@
 import ApplicationServices
 import Carbon.HIToolbox.Events
 import Cocoa
+import Darwin
 import Defaults
 
 struct ApplicationInfo: Sendable {
@@ -22,6 +23,97 @@ struct ApplicationReturnType {
 
     let status: Status
     let dockItemElement: AXUIElement?
+    let allowsBundleInstanceGrouping: Bool
+    let displayNameOverride: String?
+    let appIconOverride: NSImage?
+
+    init(
+        status: Status,
+        dockItemElement: AXUIElement?,
+        allowsBundleInstanceGrouping: Bool = true,
+        displayNameOverride: String? = nil,
+        appIconOverride: NSImage? = nil
+    ) {
+        self.status = status
+        self.dockItemElement = dockItemElement
+        self.allowsBundleInstanceGrouping = allowsBundleInstanceGrouping
+        self.displayNameOverride = displayNameOverride
+        self.appIconOverride = appIconOverride
+    }
+}
+
+enum ParallShortcutResolver {
+    private static let targetBundleIdentifierKey = "ParallAppBundleId"
+
+    static func targetApplication(for shortcutBundle: Bundle) -> NSRunningApplication? {
+        guard let targetBundleIdentifier = shortcutBundle.object(forInfoDictionaryKey: targetBundleIdentifierKey) as? String,
+              let shortcutExecutablePath = shortcutBundle.executableURL?.standardizedFileURL.path
+        else {
+            return nil
+        }
+
+        let targetApps = NSRunningApplication.runningApplications(withBundleIdentifier: targetBundleIdentifier)
+        guard let targetPID = matchingTargetProcessIdentifier(
+            shortcutExecutablePath: shortcutExecutablePath,
+            targetProcessIdentifiers: targetApps.map(\.processIdentifier),
+            parentExecutablePath: parentExecutablePath
+        ) else {
+            return nil
+        }
+
+        return targetApps.first { $0.processIdentifier == targetPID }
+    }
+
+    static func isLaunchedByShortcut(_ app: NSRunningApplication) -> Bool {
+        guard let parentExecutablePath = parentExecutablePath(of: app.processIdentifier),
+              let parentBundle = containingAppBundle(forExecutablePath: parentExecutablePath)
+        else {
+            return false
+        }
+
+        return parentBundle.object(forInfoDictionaryKey: targetBundleIdentifierKey) != nil
+    }
+
+    static func matchingTargetProcessIdentifier(
+        shortcutExecutablePath: String,
+        targetProcessIdentifiers: [pid_t],
+        parentExecutablePath: (pid_t) -> String?
+    ) -> pid_t? {
+        targetProcessIdentifiers.first { targetPID in
+            guard let parentPath = parentExecutablePath(targetPID) else { return false }
+            return URL(fileURLWithPath: parentPath).standardizedFileURL.path == shortcutExecutablePath
+        }
+    }
+
+    private static func parentExecutablePath(of pid: pid_t) -> String? {
+        guard let parentPID = parentProcessIdentifier(of: pid) else { return nil }
+
+        var pathBuffer = [UInt8](repeating: 0, count: Int(MAXPATHLEN) * 4)
+        let pathLength = pathBuffer.withUnsafeMutableBytes {
+            proc_pidpath(parentPID, $0.baseAddress, UInt32($0.count))
+        }
+        guard pathLength > 0 else { return nil }
+        return String(cString: pathBuffer)
+    }
+
+    private static func parentProcessIdentifier(of pid: pid_t) -> pid_t? {
+        var info = proc_bsdinfo()
+        let expectedSize = Int32(MemoryLayout<proc_bsdinfo>.stride)
+        let actualSize = proc_pidinfo(pid, PROC_PIDTBSDINFO, 0, &info, expectedSize)
+        guard actualSize == expectedSize else { return nil }
+        return pid_t(info.pbi_ppid)
+    }
+
+    private static func containingAppBundle(forExecutablePath path: String) -> Bundle? {
+        var candidateURL = URL(fileURLWithPath: path).deletingLastPathComponent()
+        while candidateURL.path != "/" {
+            if candidateURL.pathExtension == "app" {
+                return Bundle(url: candidateURL)
+            }
+            candidateURL.deleteLastPathComponent()
+        }
+        return nil
+    }
 }
 
 struct FolderDockItemInfo {
@@ -324,12 +416,14 @@ final class DockObserver {
         let currentAppInfo = ApplicationInfo(
             processIdentifier: currentApp.processIdentifier,
             bundleIdentifier: currentApp.bundleIdentifier,
-            localizedName: currentApp.localizedName
+            localizedName: appUnderMouseElement.displayNameOverride ?? currentApp.localizedName
         )
+        let appIconOverride = appUnderMouseElement.appIconOverride
 
         // Build list of apps to fetch windows from
         var appsToFetchWindowsFrom: [NSRunningApplication] = []
-        if Defaults[.groupAppInstancesInDock],
+        if appUnderMouseElement.allowsBundleInstanceGrouping,
+           Defaults[.groupAppInstancesInDock],
            let bundleId = currentApp.bundleIdentifier, !bundleId.isEmpty
         {
             let potentialApps = NSRunningApplication.runningApplications(withBundleIdentifier: bundleId)
@@ -397,7 +491,8 @@ final class DockObserver {
                 onWindowTap: { [weak self] in
                     self?.hideWindowAndResetLastApp()
                 },
-                bundleIdentifier: currentAppInfo.bundleIdentifier
+                bundleIdentifier: currentAppInfo.bundleIdentifier,
+                appIconOverride: appIconOverride
             )
             previousStatus = .success(currentApp)
         }
@@ -618,7 +713,18 @@ final class DockObserver {
                 }
             }
 
+            if let bundle, let targetApp = ParallShortcutResolver.targetApplication(for: bundle) {
+                return ApplicationReturnType(
+                    status: .success(targetApp),
+                    dockItemElement: hoveredDockItem,
+                    allowsBundleInstanceGrouping: false,
+                    displayNameOverride: appURL.deletingPathExtension().lastPathComponent,
+                    appIconOverride: NSWorkspace.shared.icon(forFile: appURL.path)
+                )
+            }
+
             let runningApps = NSRunningApplication.runningApplications(withBundleIdentifier: bundleIdentifier)
+                .filter { !ParallShortcutResolver.isLaunchedByShortcut($0) }
 
             // For multiple instances, find the correct one based on dock position
             if runningApps.count > 1 {

--- a/DockDoor/Views/Hover Window/Shared Components/SharedPreviewWindowCoordinator.swift
+++ b/DockDoor/Views/Hover Window/Shared Components/SharedPreviewWindowCoordinator.swift
@@ -275,6 +275,7 @@ final class SharedPreviewWindowCoordinator: NSPanel {
                                                   embeddedContentType: EmbeddedContentType = .none,
                                                   dockPositionOverride: DockPosition? = nil,
                                                   dockItemFrameOverride: CGRect? = nil,
+                                                  appIconOverride: NSImage? = nil,
                                                   renderStartTime: CFAbsoluteTime? = nil)
     {
         var elapsed = renderStartTime.map { (CFAbsoluteTimeGetCurrent() - $0) * 1000 } ?? 0
@@ -299,7 +300,8 @@ final class SharedPreviewWindowCoordinator: NSPanel {
                                                     mockPreviewActive: false,
                                                     updateAvailable: updateAvailable,
                                                     embeddedContentType: embeddedContentType,
-                                                    hasScreenRecordingPermission: hasScreenRecordingPermission)
+                                                    hasScreenRecordingPermission: hasScreenRecordingPermission,
+                                                    appIconOverride: appIconOverride)
         let newHostingView = NSHostingView(rootView: hoverView)
 
         if let oldContentView = contentView {
@@ -596,6 +598,7 @@ final class SharedPreviewWindowCoordinator: NSPanel {
         centeredHoverWindowState: PreviewStateCoordinator.WindowState?,
         onWindowTap: (() -> Void)?,
         bundleIdentifier: String?,
+        appIconOverride: NSImage?,
         dockPositionOverride: DockPosition? = nil,
         initialIndex: Int? = nil,
         dockItemFrameOverride: CGRect? = nil,
@@ -700,6 +703,7 @@ final class SharedPreviewWindowCoordinator: NSPanel {
                 centeredHoverWindowState: centeredHoverWindowState,
                 onWindowTap: onWindowTap,
                 embeddedContentType: finalEmbeddedContentType,
+                appIconOverride: appIconOverride,
                 dockPositionOverride: dockPositionOverride,
                 initialIndex: initialIndex,
                 dockItemFrameOverride: dockItemFrameOverride,
@@ -717,6 +721,7 @@ final class SharedPreviewWindowCoordinator: NSPanel {
                                    centeredHoverWindowState: PreviewStateCoordinator.WindowState? = nil,
                                    onWindowTap: (() -> Void)?,
                                    embeddedContentType: EmbeddedContentType = .none,
+                                   appIconOverride: NSImage? = nil,
                                    dockPositionOverride: DockPosition? = nil, initialIndex: Int? = nil,
                                    dockItemFrameOverride: CGRect? = nil,
                                    renderStartTime: CFAbsoluteTime? = nil)
@@ -753,7 +758,8 @@ final class SharedPreviewWindowCoordinator: NSPanel {
             updateContentViewSizeAndPosition(mouseLocation: mouseLocation, mouseScreen: screen, dockItemElement: dockItemElement, dockIconRect: dockIconRect, animated: !shouldCenterOnScreen,
                                              centerOnScreen: shouldCenterOnScreen, centeredHoverWindowState: centeredHoverWindowState,
                                              embeddedContentType: embeddedContentType, dockPositionOverride: dockPositionOverride,
-                                             dockItemFrameOverride: dockItemFrameOverride, renderStartTime: renderStartTime)
+                                             dockItemFrameOverride: dockItemFrameOverride, appIconOverride: appIconOverride,
+                                             renderStartTime: renderStartTime)
         }
     }
 
@@ -952,6 +958,7 @@ final class SharedPreviewWindowCoordinator: NSPanel {
                     dockItemElement: AXUIElement?,
                     overrideDelay: Bool = false, centeredHoverWindowState: PreviewStateCoordinator.WindowState? = nil,
                     onWindowTap: (() -> Void)? = nil, bundleIdentifier: String? = nil,
+                    appIconOverride: NSImage? = nil,
                     bypassDockMouseValidation: Bool = false,
                     dockPositionOverride: DockPosition? = nil, initialIndex: Int? = nil,
                     dockItemFrameOverride: CGRect? = nil)
@@ -997,7 +1004,7 @@ final class SharedPreviewWindowCoordinator: NSPanel {
             }
 
             Task { @MainActor [weak self] in
-                self?.performDisplay(appName: appName, windows: windows, mouseLocation: mouseLocation, mouseScreen: mouseScreen, dockItemElement: dockItemElement, centeredHoverWindowState: centeredHoverWindowState, onWindowTap: onWindowTap, bundleIdentifier: bundleIdentifier, dockPositionOverride: dockPositionOverride, initialIndex: initialIndex, dockItemFrameOverride: dockItemFrameOverride, renderStartTime: renderStartTime)
+                self?.performDisplay(appName: appName, windows: windows, mouseLocation: mouseLocation, mouseScreen: mouseScreen, dockItemElement: dockItemElement, centeredHoverWindowState: centeredHoverWindowState, onWindowTap: onWindowTap, bundleIdentifier: bundleIdentifier, appIconOverride: appIconOverride, dockPositionOverride: dockPositionOverride, initialIndex: initialIndex, dockItemFrameOverride: dockItemFrameOverride, renderStartTime: renderStartTime)
             }
         }
         pendingShowWorkItem = workItem

--- a/DockDoor/Views/Hover Window/WindowPreviewHoverContainer.swift
+++ b/DockDoor/Views/Hover Window/WindowPreviewHoverContainer.swift
@@ -50,6 +50,7 @@ struct WindowPreviewHoverContainer: View {
     let embeddedContentType: EmbeddedContentType
     let hasScreenRecordingPermission: Bool
     let appearanceOverride: PreviewAppearanceSettings?
+    let appIconOverride: NSImage?
 
     @ObservedObject var previewStateCoordinator: PreviewStateCoordinator
 
@@ -124,7 +125,8 @@ struct WindowPreviewHoverContainer: View {
          updateAvailable: Bool,
          embeddedContentType: EmbeddedContentType = .none,
          hasScreenRecordingPermission: Bool,
-         appearanceOverride: PreviewAppearanceSettings? = nil)
+         appearanceOverride: PreviewAppearanceSettings? = nil,
+         appIconOverride: NSImage? = nil)
     {
         self.appName = appName
         self.onWindowTap = onWindowTap
@@ -139,6 +141,8 @@ struct WindowPreviewHoverContainer: View {
         self.embeddedContentType = embeddedContentType
         self.hasScreenRecordingPermission = hasScreenRecordingPermission
         self.appearanceOverride = appearanceOverride
+        self.appIconOverride = appIconOverride
+        _appIcon = State(initialValue: appIconOverride)
     }
 
     private var minimumEmbeddedWidth: CGFloat {
@@ -889,6 +893,13 @@ struct WindowPreviewHoverContainer: View {
     }
 
     private func loadAppIcon() {
+        if let appIconOverride {
+            if appIcon != appIconOverride {
+                DispatchQueue.main.async { appIcon = appIconOverride }
+            }
+            return
+        }
+
         guard let app = previewStateCoordinator.windows.first?.app, let bundleID = app.bundleIdentifier else { return }
         if let icon = SharedHoverUtils.loadAppIcon(for: bundleID) {
             DispatchQueue.main.async {

--- a/DockDoorTests/ParallShortcutResolverTests.swift
+++ b/DockDoorTests/ParallShortcutResolverTests.swift
@@ -1,0 +1,50 @@
+@testable import DockDoor
+import Foundation
+import Testing
+
+struct ParallShortcutResolverTests {
+    @Test func parallShortcutResultCanDisableBundleInstanceGrouping() {
+        let result = ApplicationReturnType(
+            status: .notFound,
+            dockItemElement: nil,
+            allowsBundleInstanceGrouping: false
+        )
+
+        #expect(!result.allowsBundleInstanceGrouping)
+    }
+
+    @Test func matchesTargetWhoseParentIsShortcut() {
+        let parentPaths: [pid_t: String] = [
+            200: "/Applications/Other.app/Contents/MacOS/Other",
+            201: "/Applications/Claude Personal.app/Contents/MacOS/Claude Personal",
+        ]
+
+        let result = ParallShortcutResolver.matchingTargetProcessIdentifier(
+            shortcutExecutablePath: "/Applications/Claude Personal.app/Contents/MacOS/Claude Personal",
+            targetProcessIdentifiers: [200, 201],
+            parentExecutablePath: { parentPaths[$0] }
+        )
+
+        #expect(result == 201)
+    }
+
+    @Test func ignoresTargetsLaunchedOutsideShortcut() {
+        let result = ParallShortcutResolver.matchingTargetProcessIdentifier(
+            shortcutExecutablePath: "/Applications/Claude Personal.app/Contents/MacOS/Claude Personal",
+            targetProcessIdentifiers: [200],
+            parentExecutablePath: { _ in "/Applications/Other.app/Contents/MacOS/Other" }
+        )
+
+        #expect(result == nil)
+    }
+
+    @Test func ignoresTargetWhenParentCannotBeRead() {
+        let result = ParallShortcutResolver.matchingTargetProcessIdentifier(
+            shortcutExecutablePath: "/Applications/Claude Personal.app/Contents/MacOS/Claude Personal",
+            targetProcessIdentifiers: [200],
+            parentExecutablePath: { _ in nil }
+        )
+
+        #expect(result == nil)
+    }
+}


### PR DESCRIPTION
## Describe your changes

This fixes incorrect Dock previews when an app is launched through a [Parall](https://parall.app/) shortcut.

Parall gives the shortcut a distinct Dock identity, then launches the original app executable as its child. The child owns the windows and keeps the original bundle identifier; the shortcut process owns the Dock identity but has no windows. DockDoor consequently showed a Parall-launched window under the original app icon and found no windows for the Parall icon.

The change:

- detects Parall shortcut bundles through their `ParallAppBundleId` metadata
- matches a hovered shortcut to the target process whose parent executable is that exact shortcut
- excludes Parall-launched target processes when resolving the original app's Dock icon
- prevents the general same-bundle grouping option from expanding a resolved Parall shortcut back to every target-app instance
- preserves the hovered shortcut's display name and icon in the preview header
- adds four focused tests for process matching and shortcut-specific grouping behavior

This is generic and does not hard-code Claude, shortcut names, or individual bundle identifiers.

Validation performed:

- Xcode test plan on macOS 26.5.1: 28 tests passed, including all 4 `ParallShortcutResolverTests`
- reproduced with two live Parall Claude profiles and verified that each child PID resolves to its exact shortcut parent executable
- verified the patched build with Screen Recording and Accessibility permissions using both live profiles
- `plutil -lint DockDoor.xcodeproj/project.pbxproj`
- `git diff --check`

## Related issue number(s) and link(s)

No matching issue found after searching open and closed issues for Parall and same-app multi-instance preview behavior.

## Checklist before requesting a review
- [x] I have performed a self-review of my code and understand every line
- [x] If this change affects core functionality, I have added a description highlighting the changes
- [x] I have followed conventional commit guidelines
- [x] I have tested this PR on my own machine

## AI Assistance Disclosure

> **Policy**: AI-assisted contributions are welcome, but you must understand, test, and take full responsibility for your code. Pasting AI-generated code or PR descriptions without genuine human review and understanding will result in your PR being closed and may result in a ban from contributing.

**Did you use AI tools (ChatGPT, Claude, Copilot, Cursor, etc.) for this PR?**
- [ ] No AI tools were used
- [x] Yes - describe below how AI was used and confirm you reviewed/tested the output

OpenAI Codex was used to inspect the live process hierarchy, implement the resolver and tests, run the Xcode test plan, and draft this description. The PR remains a draft, and the human self-review checkbox is intentionally left unchecked until the contributor has reviewed the change and can explain every line.

### What "genuine human review" means:
- You can explain any line of code if asked
- You tested the changes yourself and verified they work
- You understand how your changes interact with existing code
- Your PR description reflects your actual understanding, not AI-generated summaries

### Examples of acceptable AI use:
- "Used Copilot for autocomplete suggestions, reviewed each one"
- "Asked Claude to explain how ScreenCaptureKit works, wrote the implementation myself"
- "Used ChatGPT to help debug an issue, verified the fix myself"

### What will get your PR closed (and possibly banned):
- Pasting AI output directly without review or understanding
- PR descriptions that are clearly AI-generated (overly formal, generic explanations you can't elaborate on)
- Unable to explain your own code changes when asked
- Submitting large refactors with undocumented behavioral changes

## Core Functionality Changes

Dock hover resolution now has a Parall-specific path:

- For a Parall Dock item, DockDoor reads the target bundle identifier from the shortcut and selects only the target process whose parent executable matches that shortcut.
- The resolved shortcut bypasses generic same-bundle instance grouping, so other Parall profiles are not added back to its preview.
- The preview uses the shortcut bundle's name and icon while window actions continue to target the child process that owns the windows.
- For an original app Dock item, DockDoor filters out target processes launched by Parall shortcuts, preventing those windows from appearing under the original icon.
- Apps without Parall metadata continue through the existing resolution path. If process-parent information cannot be read, DockDoor retains the existing behavior.
