### PR TITLE
fix: window flush with top of secondary monitor attributed to wrong screen

### DIFF
--- a/DockDoor/Extensions/NSScreen.swift
+++ b/DockDoor/Extensions/NSScreen.swift
@@ -2,12 +2,13 @@ import Cocoa
 
 extension NSScreen {
     static func screenFromQuartzPoint(_ point: CGPoint) -> NSScreen {
-        let screens = NSScreen.screens
         let pointInScreenCoordinates = CGPoint(x: point.x, y: NSScreen.screens.first!.frame.maxY - point.y)
 
-        return screens.first { screen in
-            NSPointInRect(pointInScreenCoordinates, screen.frame)
-        } ?? NSScreen.main!
+        // NSMouseInRect(_, _, false) is inclusive at a frame's top edge, so a window
+        // flush with the top of a screen still matches; NSPointInRect would exclude it.
+        return NSScreen.screens.first { NSMouseInRect(pointInScreenCoordinates, $0.frame, false) }
+            ?? pointInScreenCoordinates.screen()
+            ?? NSScreen.main!
     }
 
     func convertPoint(fromGlobal point: CGPoint) -> CGPoint {


### PR DESCRIPTION
## Describe your changes

Windows maximized (not fullscreen) on a secondary monitor showed up under the main monitor in the Window Switcher when "Show windows from current monitor only" was enabled.

Cause:

- `screenFromQuartzPoint` tested containment with `NSPointInRect`, which excludes a rect's max edges
- a maximized window touches the top of its screen, so its flipped top-left corner lands exactly on `frame.maxY` and matches no screen
- the function then fell back to `NSScreen.main` and tagged the window with the wrong monitor

Fix (`Extensions/NSScreen.swift`):

- use `NSMouseInRect(_, _, false)` for containment, inclusive at the top edge, which is the right semantics for a window's top-left corner
- if no screen contains the point at all, fall back to the existing `CGPoint.screen()` nearest-screen lookup instead of `NSScreen.main`

Repro: two monitors, current-monitor-only enabled, maximize (not fullscreen) a window on the secondary monitor and open the switcher. Before: listed under the main monitor. After: listed where it actually is.

## Related issue number(s) and link(s)

Possibly #1467

## Checklist before requesting a review
- [x] I have performed a self-review of my code and understand every line
- [x] If this change affects core functionality, I have added a description highlighting the changes
- [x] I have followed conventional commit guidelines
- [x] I have tested this PR on my own machine

## AI Assistance Disclosure

**Did you use AI tools (ChatGPT, Claude, Copilot, Cursor, etc.) for this PR?**
- ~[ ] No AI tools were used~
- [x] Yes - describe below how AI was used and confirm you reviewed/tested the output

Used Claude Code to trace the root cause and draft the fix. I reviewed the logic myself and tested the repro on my own dual-monitor setup.

## Core Functionality Changes

All "current monitor only" filtering (dock previews, Window Switcher, Cmd+Tab) goes through `screenFromQuartzPoint`. Windows flush with a screen edge now classify to the screen they are on. No change otherwise.