### PR TITLE
fix: preserve focused native tab when switching apps - #1

### DIFF
--- a/DockDoor/Utilities/DockObserver+CmdTab.swift
+++ b/DockDoor/Utilities/DockObserver+CmdTab.swift
@@ -123,7 +123,7 @@ extension DockObserver {
 
         var cachedWindows: [WindowInfo] = []
         if let app = resolvedApp {
-            cachedWindows = WindowUtil.readCachedWindows(for: app.processIdentifier, sortedBy: .cmdTab)
+            cachedWindows = WindowUtil.readCachedWindowsForPresentation(for: app.processIdentifier, sortedBy: .cmdTab)
         }
 
         let shouldIgnoreSingleWindowApp = Defaults[.ignoreAppsWithSingleWindowInCmdTab] && cachedWindows.count == 1

--- a/DockDoor/Utilities/DockObserver.swift
+++ b/DockDoor/Utilities/DockObserver.swift
@@ -346,7 +346,7 @@ final class DockObserver {
 
         var cachedWindows: [WindowInfo] = []
         for appInstance in appsToFetchWindowsFrom {
-            cachedWindows.append(contentsOf: WindowUtil.readCachedWindows(for: appInstance.processIdentifier))
+            cachedWindows.append(contentsOf: WindowUtil.readCachedWindowsForPresentation(for: appInstance.processIdentifier))
         }
 
         lastHoveredPID = currentApp.processIdentifier

--- a/DockDoor/Utilities/Window Management/NativeTabGrouping.swift
+++ b/DockDoor/Utilities/Window Management/NativeTabGrouping.swift
@@ -20,12 +20,19 @@ enum NativeTabGrouping {
         let id: CGWindowID
         let pid: pid_t
         let frame: CGRect
-        /// Used to pick which member represents its group; the most recently accessed window
-        /// (typically the active tab) wins.
+        /// Used to pick which member represents its group when none is focused.
         let recency: Date
+        /// Whether the application currently reports this member through
+        /// `kAXFocusedWindowAttribute`.
+        let isFocused: Bool
         /// Whether this window may be collapsed into a group. Minimized, hidden, windowless,
         /// and zero-sized windows are never collapsed and are always kept as-is.
         let groupable: Bool
+    }
+
+    struct Group: Equatable {
+        let representativeID: CGWindowID
+        let memberIDs: Set<CGWindowID>
     }
 
     private struct GroupKey: Hashable {
@@ -36,18 +43,14 @@ enum NativeTabGrouping {
         let height: Int
     }
 
-    /// Returns the window IDs to keep: every non-groupable window, plus a single representative
-    /// per detected tab group.
-    ///
-    /// The representative is the most recently accessed window in the group; ties are broken by
-    /// the larger window ID so the result is deterministic regardless of input ordering.
-    static func representativeIDs(from candidates: [Candidate]) -> Set<CGWindowID> {
-        var keptIDs = Set<CGWindowID>()
-        var representativeByGroup: [GroupKey: Candidate] = [:]
+    /// Returns every detected group with its selected representative and complete membership.
+    static func groups(from candidates: [Candidate]) -> [Group] {
+        var standaloneGroups: [Group] = []
+        var membersByGroup: [GroupKey: [Candidate]] = [:]
 
         for candidate in candidates {
             guard candidate.groupable else {
-                keptIDs.insert(candidate.id)
+                standaloneGroups.append(Group(representativeID: candidate.id, memberIDs: [candidate.id]))
                 continue
             }
 
@@ -59,25 +62,45 @@ enum NativeTabGrouping {
                 height: Int(candidate.frame.size.height.rounded())
             )
 
-            if let current = representativeByGroup[key] {
-                if isBetterRepresentative(candidate, than: current) {
-                    representativeByGroup[key] = candidate
-                }
-            } else {
-                representativeByGroup[key] = candidate
+            membersByGroup[key, default: []].append(candidate)
+        }
+
+        let collapsedGroups = membersByGroup.values.map { members in
+            let representative = members.dropFirst().reduce(members[0]) { current, candidate in
+                isBetterRepresentative(candidate, than: current) ? candidate : current
             }
+            return Group(
+                representativeID: representative.id,
+                memberIDs: Set(members.map(\.id))
+            )
         }
 
-        for representative in representativeByGroup.values {
-            keptIDs.insert(representative.id)
+        return (standaloneGroups + collapsedGroups).sorted {
+            $0.representativeID < $1.representativeID
         }
+    }
 
-        return keptIDs
+    /// Returns the window IDs to keep: every non-groupable window, plus a single representative
+    /// per detected tab group.
+    static func representativeIDs(from candidates: [Candidate]) -> Set<CGWindowID> {
+        Set(groups(from: candidates).map(\.representativeID))
+    }
+
+    static func activationWindowID(
+        representativeID: CGWindowID,
+        memberIDs: Set<CGWindowID>,
+        focusedWindowID: CGWindowID?
+    ) -> CGWindowID {
+        guard let focusedWindowID, memberIDs.contains(focusedWindowID) else {
+            return representativeID
+        }
+        return focusedWindowID
     }
 
     private static func isBetterRepresentative(_ candidate: Candidate, than current: Candidate) -> Bool {
-        // Most recently accessed wins; the larger window ID breaks ties so the result is
-        // deterministic regardless of input ordering.
-        (candidate.recency, candidate.id) > (current.recency, current.id)
+        if candidate.isFocused != current.isFocused {
+            return candidate.isFocused
+        }
+        return (candidate.recency, candidate.id) > (current.recency, current.id)
     }
 }

--- a/DockDoor/Utilities/Window Management/WindowInfo.swift
+++ b/DockDoor/Utilities/Window Management/WindowInfo.swift
@@ -27,10 +27,11 @@ struct WindowInfo: Identifiable, Hashable {
     var isMinimized: Bool
     var isHidden: Bool
     private(set) var isWindowlessApp: Bool
+    var nativeTabGroupWindowIDs: Set<CGWindowID>
 
     private var _scWindow: SCWindow?
 
-    init(windowProvider: WindowPropertiesProviding, app: NSRunningApplication, ownerApp: NSRunningApplication? = nil, image: CGImage?, axElement: AXUIElement, appAxElement: AXUIElement, closeButton: AXUIElement?, lastAccessedTime: Date, creationTime: Date? = nil, imageCapturedTime: Date? = nil, spaceID: Int? = nil, screenIdentifier: String? = nil, isMinimized: Bool, isHidden: Bool) {
+    init(windowProvider: WindowPropertiesProviding, app: NSRunningApplication, ownerApp: NSRunningApplication? = nil, image: CGImage?, axElement: AXUIElement, appAxElement: AXUIElement, closeButton: AXUIElement?, lastAccessedTime: Date, creationTime: Date? = nil, imageCapturedTime: Date? = nil, spaceID: Int? = nil, screenIdentifier: String? = nil, isMinimized: Bool, isHidden: Bool, nativeTabGroupWindowIDs: Set<CGWindowID> = []) {
         id = windowProvider.windowID
         self.windowProvider = windowProvider
         self.app = app
@@ -48,6 +49,7 @@ struct WindowInfo: Identifiable, Hashable {
         self.isMinimized = isMinimized
         self.isHidden = isHidden
         isWindowlessApp = false
+        self.nativeTabGroupWindowIDs = nativeTabGroupWindowIDs
         _scWindow = windowProvider as? SCWindow
     }
 
@@ -71,6 +73,7 @@ struct WindowInfo: Identifiable, Hashable {
         let windowName: String?
         let isMinimized: Bool
         let isHidden: Bool
+        let nativeTabGroupWindowIDs: Set<CGWindowID>
         let imagePointer: UnsafeRawPointer?
     }
 
@@ -81,6 +84,7 @@ struct WindowInfo: Identifiable, Hashable {
             windowName: windowName,
             isMinimized: isMinimized,
             isHidden: isHidden,
+            nativeTabGroupWindowIDs: nativeTabGroupWindowIDs,
             imagePointer: image.map { Unmanaged.passUnretained($0).toOpaque() }
         )
     }
@@ -436,30 +440,46 @@ extension WindowInfo {
         let maxRetries = 3
         var retryCount = 0
 
-        func attemptActivation() -> Bool {
+        func activationTarget() -> (id: CGWindowID, element: AXUIElement) {
+            guard nativeTabGroupWindowIDs.count > 1,
+                  let focusedWindow = (try? AXUIElementCreateApplication(app.processIdentifier).focusedWindow()) ?? nil,
+                  let focusedWindowID = (try? focusedWindow.cgWindowId()) ?? nil,
+                  NativeTabGrouping.activationWindowID(
+                      representativeID: id,
+                      memberIDs: nativeTabGroupWindowIDs,
+                      focusedWindowID: focusedWindowID
+                  ) == focusedWindowID
+            else {
+                return (id, axElement)
+            }
+            return (focusedWindowID, focusedWindow)
+        }
+
+        func attemptActivation() -> CGWindowID? {
+            let target = activationTarget()
             do {
                 var psn = ProcessSerialNumber()
                 _ = GetProcessForPID(ownerApp.processIdentifier, &psn)
-                _ = _SLPSSetFrontProcessWithOptions(&psn, UInt32(id), SLPSMode.userGenerated.rawValue)
+                _ = _SLPSSetFrontProcessWithOptions(&psn, UInt32(target.id), SLPSMode.userGenerated.rawValue)
 
-                WindowUtil.makeKeyWindow(&psn, windowID: id)
+                WindowUtil.makeKeyWindow(&psn, windowID: target.id)
 
-                try axElement.performAction(kAXRaiseAction)
-                try axElement.setAttribute(kAXMainWindowAttribute, true)
+                try target.element.performAction(kAXRaiseAction)
+                try target.element.setAttribute(kAXMainWindowAttribute, true)
 
-                return true
+                return target.id
             } catch {
                 print("Attempt \(retryCount + 1) failed to bring window to front: \(error)")
                 if error is AxError {
-                    WindowUtil.removeWindowFromDesktopSpaceCache(with: id, in: app.processIdentifier)
+                    WindowUtil.removeWindowFromDesktopSpaceCache(with: target.id, in: app.processIdentifier)
                 }
-                return false
+                return nil
             }
         }
 
         while retryCount < maxRetries {
-            if attemptActivation() {
-                WindowUtil.updateTimestampOptimistically(for: self)
+            if let activatedWindowID = attemptActivation() {
+                WindowUtil.updateTimestampOptimistically(for: self, activatedWindowID: activatedWindowID)
                 return
             }
             retryCount += 1

--- a/DockDoor/Utilities/Window Management/WindowUtil.swift
+++ b/DockDoor/Utilities/Window Management/WindowUtil.swift
@@ -316,13 +316,13 @@ enum WindowUtil {
 // MARK: - Cache Management
 
 extension WindowUtil {
-    /// Reads cached windows for an app without triggering any SCK/AX fetches.
-    /// Returns immediately with whatever is in cache, sorted by the given context.
+    /// Reads cached windows without triggering SCK capture or AX window enumeration.
+    /// Native-tab collapsing may query the app's focused AX window.
     static func readCachedWindows(for pid: pid_t, sortedBy context: WindowFetchContext = .dockPreview) -> [WindowInfo] {
         let cached = deduplicatedByWindowID(desktopSpaceWindowCacheManager.readCache(pid: pid).filter {
             WindowOwnerResolver.ownerBelongsToDisplayApp($0.ownerApp, displayApp: $0.app)
         })
-        return sortWindows(cached, for: context)
+        return sortWindows(collapseNativeTabsIfNeeded(cached), for: context)
     }
 
     static func saveWindowOrderFromCache() {
@@ -372,10 +372,13 @@ extension WindowUtil {
     }
 
     /// Updates window timestamp optimistically and records breadcrumb for observer deduplication
-    static func updateTimestampOptimistically(for windowInfo: WindowInfo) {
+    static func updateTimestampOptimistically(for windowInfo: WindowInfo, activatedWindowID: CGWindowID? = nil) {
         let now = Date()
+        let windowID = activatedWindowID ?? windowInfo.id
         desktopSpaceWindowCacheManager.updateCache(pid: windowInfo.app.processIdentifier) { windowSet in
-            if let index = windowSet.firstIndex(where: { $0.axElement == windowInfo.axElement || $0.id == windowInfo.id }) {
+            if let index = windowSet.firstIndex(where: {
+                $0.id == windowID || (windowID == windowInfo.id && $0.axElement == windowInfo.axElement)
+            }) {
                 var updatedWindow = windowSet[index]
                 updatedWindow.lastAccessedTime = now
                 windowSet.remove(at: index)
@@ -750,12 +753,30 @@ extension WindowUtil {
     static func collapseNativeTabsIfNeeded(_ windows: [WindowInfo]) -> [WindowInfo] {
         guard Defaults[.collapseNativeTabsIntoSingleWindow] else { return windows }
 
+        var focusedWindowIDsByPID: [pid_t: CGWindowID] = [:]
+        for pid in Set(windows.map(\.app.processIdentifier)) {
+            let appElement = AXUIElementCreateApplication(pid)
+            if let focusedWindow = (try? appElement.focusedWindow()) ?? nil,
+               let focusedWindowID = (try? focusedWindow.cgWindowId()) ?? nil
+            {
+                focusedWindowIDsByPID[pid] = focusedWindowID
+            }
+        }
+
+        return collapseNativeTabs(windows, focusedWindowIDsByPID: focusedWindowIDsByPID)
+    }
+
+    static func collapseNativeTabs(
+        _ windows: [WindowInfo],
+        focusedWindowIDsByPID: [pid_t: CGWindowID]
+    ) -> [WindowInfo] {
         let candidates = windows.map { window in
             NativeTabGrouping.Candidate(
                 id: window.id,
                 pid: window.app.processIdentifier,
                 frame: window.frame,
                 recency: window.lastAccessedTime,
+                isFocused: focusedWindowIDsByPID[window.app.processIdentifier] == window.id,
                 groupable: !window.isMinimized
                     && !window.isHidden
                     && !window.isWindowlessApp
@@ -764,9 +785,18 @@ extension WindowUtil {
             )
         }
 
-        let keptIDs = NativeTabGrouping.representativeIDs(from: candidates)
-        guard keptIDs.count < windows.count else { return windows }
-        return windows.filter { keptIDs.contains($0.id) }
+        let groupsByRepresentative = Dictionary(
+            uniqueKeysWithValues: NativeTabGrouping.groups(from: candidates).map {
+                ($0.representativeID, $0.memberIDs)
+            }
+        )
+
+        return windows.compactMap { window in
+            guard let memberIDs = groupsByRepresentative[window.id] else { return nil }
+            var representative = window
+            representative.nativeTabGroupWindowIDs = memberIDs.count > 1 ? memberIDs : []
+            return representative
+        }
     }
 
     static func getActiveWindows(of app: NSRunningApplication, context: WindowFetchContext = .dockPreview, ignoreSingleWindowFilter: Bool = false) async throws -> [WindowInfo] {

--- a/DockDoor/Utilities/Window Management/WindowUtil.swift
+++ b/DockDoor/Utilities/Window Management/WindowUtil.swift
@@ -316,12 +316,18 @@ enum WindowUtil {
 // MARK: - Cache Management
 
 extension WindowUtil {
-    /// Reads cached windows without triggering SCK capture or AX window enumeration.
-    /// Native-tab collapsing may query the app's focused AX window.
+    /// Reads cached windows without triggering SCK/AX fetches.
     static func readCachedWindows(for pid: pid_t, sortedBy context: WindowFetchContext = .dockPreview) -> [WindowInfo] {
         let cached = deduplicatedByWindowID(desktopSpaceWindowCacheManager.readCache(pid: pid).filter {
             WindowOwnerResolver.ownerBelongsToDisplayApp($0.ownerApp, displayApp: $0.app)
         })
+        return sortWindows(cached, for: context)
+    }
+
+    /// Reads cached windows for preview and switcher presentation.
+    /// Native-tab collapsing may query the app's focused AX window.
+    static func readCachedWindowsForPresentation(for pid: pid_t, sortedBy context: WindowFetchContext = .dockPreview) -> [WindowInfo] {
+        let cached = readCachedWindows(for: pid, sortedBy: context)
         return sortWindows(collapseNativeTabsIfNeeded(cached), for: context)
     }
 

--- a/DockDoorTests/NativeTabGroupingTests.swift
+++ b/DockDoorTests/NativeTabGroupingTests.swift
@@ -1,3 +1,5 @@
+import AppKit
+import ApplicationServices
 import CoreGraphics
 @testable import DockDoor
 import Foundation
@@ -11,6 +13,7 @@ struct NativeTabGroupingTests {
         pid: pid_t = 100,
         frame: CGRect = CGRect(x: 0, y: 0, width: 800, height: 600),
         recency: TimeInterval = 0,
+        isFocused: Bool = false,
         groupable: Bool = true
     ) -> NativeTabGrouping.Candidate {
         NativeTabGrouping.Candidate(
@@ -18,7 +21,36 @@ struct NativeTabGroupingTests {
             pid: pid,
             frame: frame,
             recency: Date(timeIntervalSinceReferenceDate: recency),
+            isFocused: isFocused,
             groupable: groupable
+        )
+    }
+
+    private func window(
+        id: CGWindowID,
+        frame: CGRect,
+        recency: TimeInterval
+    ) -> WindowInfo {
+        let app = NSRunningApplication.current
+        let appElement = AXUIElementCreateApplication(app.processIdentifier)
+        return WindowInfo(
+            windowProvider: MockPreviewWindow(
+                windowID: id,
+                frame: frame,
+                title: "Terminal",
+                owningApplicationBundleIdentifier: app.bundleIdentifier,
+                owningApplicationProcessID: app.processIdentifier,
+                isOnScreen: true,
+                windowLayer: 0
+            ),
+            app: app,
+            image: nil,
+            axElement: appElement,
+            appAxElement: appElement,
+            closeButton: nil,
+            lastAccessedTime: Date(timeIntervalSinceReferenceDate: recency),
+            isMinimized: false,
+            isHidden: false
         )
     }
 
@@ -76,6 +108,93 @@ struct NativeTabGroupingTests {
             candidate(id: 42, frame: frame, recency: 3),
         ])
         #expect(kept == [42])
+    }
+
+    @Test func focusedMemberWinsWhenIdenticalTitlesHaveEqualRecency() {
+        let kept = NativeTabGrouping.representativeIDs(from: [
+            candidate(id: 7, recency: 3),
+            candidate(id: 42, recency: 3, isFocused: true),
+        ])
+        #expect(kept == [42])
+    }
+
+    @Test func focusedMemberWinsAfterRestartWithStaleRecency() {
+        let kept = NativeTabGrouping.representativeIDs(from: [
+            candidate(id: 7, recency: 100),
+            candidate(id: 42, recency: 0, isFocused: true),
+        ])
+        #expect(kept == [42])
+    }
+
+    @Test func focusedMemberWinsAfterRapidlySwitchingAway() {
+        let kept = NativeTabGrouping.representativeIDs(from: [
+            candidate(id: 7, recency: 50),
+            candidate(id: 42, recency: 49, isFocused: true),
+        ])
+        #expect(kept == [42])
+    }
+
+    @Test func collapsesMultipleTabbedWindowsIndependently() {
+        let firstFrame = CGRect(x: 0, y: 0, width: 800, height: 600)
+        let secondFrame = CGRect(x: 100, y: 100, width: 900, height: 700)
+        let groups = NativeTabGrouping.groups(from: [
+            candidate(id: 1, frame: firstFrame, recency: 10),
+            candidate(id: 2, frame: firstFrame, recency: 0, isFocused: true),
+            candidate(id: 3, frame: secondFrame, recency: 2),
+            candidate(id: 4, frame: secondFrame, recency: 8),
+        ])
+
+        #expect(groups == [
+            NativeTabGrouping.Group(representativeID: 2, memberIDs: [1, 2]),
+            NativeTabGrouping.Group(representativeID: 4, memberIDs: [3, 4]),
+        ])
+    }
+
+    @Test func refreshedSwitcherPathPreservesCollapsedMemberIDs() {
+        let frame = CGRect(x: 0, y: 0, width: 800, height: 600)
+        let pid = NSRunningApplication.current.processIdentifier
+        let collapsed = WindowUtil.collapseNativeTabs(
+            [
+                window(id: 1, frame: frame, recency: 10),
+                window(id: 2, frame: frame, recency: 0),
+            ],
+            focusedWindowIDsByPID: [pid: 2]
+        )
+
+        #expect(collapsed.map(\.id) == [2])
+        #expect(collapsed.first?.nativeTabGroupWindowIDs == [1, 2])
+    }
+
+    @Test func cachedSwitcherPathCollapsesBeforeRefresh() {
+        let frame = CGRect(x: 0, y: 0, width: 800, height: 600)
+        let pid = NSRunningApplication.current.processIdentifier
+        let collapsed = WindowUtil.collapseNativeTabs(
+            [
+                window(id: 1, frame: frame, recency: 100),
+                window(id: 2, frame: frame, recency: 0),
+            ],
+            focusedWindowIDsByPID: [pid: 2]
+        )
+
+        #expect(collapsed.map(\.id) == [2])
+    }
+
+    @Test func activationReResolvesCurrentFocusedGroupMember() {
+        let selectedID = NativeTabGrouping.activationWindowID(
+            representativeID: 2,
+            memberIDs: [1, 2],
+            focusedWindowID: 1
+        )
+        #expect(selectedID == 1)
+    }
+
+    @Test func activationKeepsRepresentativeWhenFocusBelongsToAnotherTabbedWindow() {
+        let selectedID = NativeTabGrouping.activationWindowID(
+            representativeID: 2,
+            memberIDs: [1, 2],
+            focusedWindowID: 4
+        )
+        #expect(selectedID == 2)
     }
 
     @Test func emptyInputYieldsEmpty() {


### PR DESCRIPTION
**NOTE:** This PR is 100% coded with AI. I don't know anything about swift, though I build and tested the app. I had a bug which I wanted to fix (see description). I do fully understand if you don't want that and reject this PR. In this case, I can open an issue instead.

## Describe your changes
Preserve Ghostty’s currently focused native tab when switching away and back through DockDoor’s Cmd+Tab integration.

Collapsed native-tab groups now retain their member window IDs, prefer the focused member as their representative, and re-resolve that focused member immediately before activation. Cached windows are collapsed only in Dock and Cmd+Tab presentation paths so close/auto-quit logic continues to count every real window.

## Related issue number(s) and link(s)
N/A

## Checklist before requesting a review
- [ ] I have performed a self-review of my code and understand every line
- [x] If this change affects core functionality, I have added a description highlighting the changes
- [x] I have followed conventional commit guidelines
- [ ] I have tested this PR on my own machine

## AI Assistance Disclosure

> **Policy**: AI-assisted contributions are welcome, but you must understand, test, and take full responsibility for your code. Pasting AI-generated code or PR descriptions without genuine human review and understanding will result in your PR being closed and may result in a ban from contributing.

**Did you use AI tools (ChatGPT, Claude, Copilot, Cursor, etc.) for this PR?**
- [ ] No AI tools were used
- [x] Yes - describe below how AI was used and confirm you reviewed/tested the output

Used OpenAI Codex to review the original fix, identify the cached-window-count regression, and implement the follow-up separation between raw and presentation cache reads. Manual testing was done (build and launch) to confirm the fix.

## Core Functionality Changes
DockDoor now preserves the focused native tab for collapsed tab groups during Cmd+Tab activation. Raw cached-window consumers remain uncollapsed, preventing tab groups from being mistaken for a single real window by close and auto-quit behavior.