### PR TITLE
fix: gate media listener on enableMediaWidget setting

### DIFF
--- a/DockDoor/Utilities/Media/MediaRemoteService.swift
+++ b/DockDoor/Utilities/Media/MediaRemoteService.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Combine
+import Defaults
 import Foundation
 import MediaRemoteAdapter
 
@@ -39,6 +40,8 @@ final class MediaRemoteService: ObservableObject {
     private var playbackIntent: (isPlaying: Bool, date: Date)?
 
     private var resyncWork: DispatchWorkItem?
+
+    private var mediaWidgetObserver: Defaults.Observation?
 
     var interpolatedElapsedTime: TimeInterval {
         if let seek = seekBase, seek.rate == 0 || isWithinSeekWindow {
@@ -80,6 +83,7 @@ final class MediaRemoteService: ObservableObject {
 
     private init() {
         setupController()
+        observeMediaWidgetSetting()
     }
 
     private func setupController() {
@@ -90,7 +94,29 @@ final class MediaRemoteService: ObservableObject {
         }
     }
 
+    /// Starts and stops the listener as the media widget is toggled, so turning the widget off
+    /// takes effect immediately rather than only at the next launch.
+    private func observeMediaWidgetSetting() {
+        mediaWidgetObserver = Defaults.observe(.enableMediaWidget) { [weak self] change in
+            DispatchQueue.main.async {
+                guard let self else { return }
+                if change.newValue {
+                    self.activate()
+                } else {
+                    self.deactivate()
+                }
+            }
+        }
+    }
+
+    /// `startListening()` spawns a helper process that lives for the rest of the session, so the
+    /// listener must not start while the media widget is disabled — otherwise the helper runs, and
+    /// accumulates memory, for a feature the user has turned off.
+    ///
+    /// The check lives here rather than at the call site so the precondition travels with the
+    /// service instead of relying on every caller to remember it.
     func activate() {
+        guard Defaults[.enableMediaWidget] else { return }
         guard !isActive else { return }
         isActive = true
         controller.startListening()


### PR DESCRIPTION
Addresses the second half of #1524 — the part that lives in DockDoor rather than in the vendored adapter.

## Problem

`MediaRemoteService.activate()` was called unconditionally from `AppDelegate.swift:62` and had no `Defaults[.enableMediaWidget]` check of its own, so `controller.startListening()` always ran. That spawns a `run.pl` helper which lives for the rest of the session, so a user who had turned the media widget off still paid its full memory cost with no way to opt out short of quitting DockDoor.

`deactivate()` already existed but had no callers, so toggling the setting at runtime did nothing either.

## Change

Two small things in `MediaRemoteService`:

- `activate()` now returns early when `enableMediaWidget` is off.
- A `Defaults` observer starts/stops the listener when the setting is toggled, so turning the widget off takes effect immediately rather than at the next launch.

The guard sits in `activate()` rather than at the `AppDelegate` call site so the precondition travels with the service — `activate()` is the only thing that can spawn the helper, so it seemed like the right place for it to enforce its own precondition.

## Verification

macOS 26.5 (Apple Silicon), Xcode 26.6, counting `perl` children of the running app with the setting written to the debug domain:

| build | `enableMediaWidget` | perl helpers |
|---|---|---|
| before | `false` | **1** ← the bug |
| after | `false` | **0** |
| after | `true` | 1 (unchanged) |

I also confirmed the before/after by stashing the change and rebuilding, rather than reasoning about it — the helper genuinely spawns on `main` today and genuinely does not with this applied.

- `xcodebuild` Debug and Release both succeed, no new warnings (the two existing `SpaceWindowCacheManager.swift` lock/unlock warnings are untouched)
- `swift run -c release --package-path BuildTools swiftformat --lint` reports `0/1 files require formatting`

## Scope

This does **not** address the leak itself, which is the more interesting half of #1524. The reporter's comparison against boringNotch — same library, `stream` vs `loop` mode, framework directory vs binary path, 11 MB over 3 days vs 3.3 GB over 3 hours — points at the invocation path rather than at DockDoor's Swift code, and that's a separate change I didn't want to bundle in here.

What this does mean is that users who don't want the media widget can now actually avoid the helper entirely, which is a complete workaround for them in the meantime.

Happy to adjust the placement of the guard if you'd rather it sat in `AppDelegate` alongside the other `Defaults` checks there.