### PR TITLE
fix: restore auto-hidden dock state

### DIFF
--- a/DockDoor/Utilities/DockObserver.swift
+++ b/DockDoor/Utilities/DockObserver.swift
@@ -796,6 +796,10 @@ final class DockObserver {
             return nil
         }
 
+        if type == .leftMouseDown, appUnderMouse.dockItemElement != nil {
+            previewCoordinator.restoreDockAutoHideState()
+        }
+
         if case let .success(app) = appUnderMouse.status {
             if type == .rightMouseDown, event.flags.contains(.maskCommand), Defaults[.enableCmdRightClickQuit] {
                 handleCmdRightClickQuit(app: app, event: event)

--- a/DockDoor/Views/Hover Window/Shared Components/SharedPreviewWindowCoordinator.swift
+++ b/DockDoor/Views/Hover Window/Shared Components/SharedPreviewWindowCoordinator.swift
@@ -166,7 +166,7 @@ final class SharedPreviewWindowCoordinator: NSPanel {
         }
 
         // Always restore dock auto-hide state, even if the preview isn't visible.
-        dockManager.restoreDockState()
+        restoreDockAutoHideState()
 
         guard isVisible else { return }
 

--- a/DockDoor/Views/Hover Window/Shared Components/SharedPreviewWindowCoordinator.swift
+++ b/DockDoor/Views/Hover Window/Shared Components/SharedPreviewWindowCoordinator.swift
@@ -156,6 +156,10 @@ final class SharedPreviewWindowCoordinator: NSPanel {
         pendingShowWorkItem = nil
     }
 
+    func restoreDockAutoHideState() {
+        dockManager.restoreDockState()
+    }
+
     func hideWindow(cancelPendingShow shouldCancelPendingShow: Bool = true) {
         if shouldCancelPendingShow {
             cancelPendingShow()


### PR DESCRIPTION
## Describe your changes
Im using the auto-hide Option for my Dock, and want to use DockDoors Dock-Preview with the `Prevent dock from hiding during previews` option.
The problem with this is that if an App is fullscreen (as in windowed mode, but taking all screen space, not fullscreen mode) and then you click on the App in the Dock with these options, the App resizes and fits to the Dock.
Then when you hover away from the Dock and the Dock auto-hides, youre loosing some vertical space at the bottom.

This PR addresses this by restoring by restoring the Dock State in that scenario.

Let me know if youd rather have this as a feature implementation and/or if you need screenshots to understand what i mean, im aware my explanation of my problem isnt the best 😅 

## Related issue number(s) and link(s)

## Checklist before requesting a review
- [x] I have performed a self-review of my code and understand every line
- [x] If this change affects core functionality, I have added a description highlighting the changes
- [x] I have followed conventional commit guidelines
- [x] I have tested this PR on my own machine

## AI Assistance Disclosure

> **Policy**: AI-assisted contributions are welcome, but you must understand, test, and take full responsibility for your code. Pasting AI-generated code or PR descriptions without genuine human review and understanding will result in your PR being closed and may result in a ban from contributing.

**Did you use AI tools (ChatGPT, Claude, Copilot, Cursor, etc.) for this PR?**
- [ ] No AI tools were used
- [x] Yes - describe below how AI was used and confirm you reviewed/tested the output

GPT 5.6 Sol in the Codex Harness to implement this Fix. Tested, Reviewed and Checked Manually

### What "genuine human review" means:
- You can explain any line of code if asked
- You tested the changes yourself and verified they work
- You understand how your changes interact with existing code
- Your PR description reflects your actual understanding, not AI-generated summaries

### Examples of acceptable AI use:
- "Used Copilot for autocomplete suggestions, reviewed each one"
- "Asked Claude to explain how ScreenCaptureKit works, wrote the implementation myself"
- "Used ChatGPT to help debug an issue, verified the fix myself"

### What will get your PR closed (and possibly banned):
- Pasting AI output directly without review or understanding
- PR descriptions that are clearly AI-generated (overly formal, generic explanations you can't elaborate on)
- Unable to explain your own code changes when asked
- Submitting large refactors with undocumented behavioral changes

## Core Functionality Changes
If this PR modifies core functionality, please provide a brief description of the changes and their impact below:
