### PR TITLE
feat: add per-app quit-on-close policies

### DIFF
--- a/DockDoor.xcodeproj/project.pbxproj
+++ b/DockDoor.xcodeproj/project.pbxproj
@@ -64,6 +64,7 @@
 		AA11001122334455AA110022 /* DockLocker.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA11001122334455AA110011 /* DockLocker.swift */; };
 		AA11001122334455AA110044 /* DockLockingSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA11001122334455AA110033 /* DockLockingSettingsView.swift */; };
 		AA11001122334455AA110066 /* DockLockerGeometryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA11001122334455AA110055 /* DockLockerGeometryTests.swift */; };
+		3D53691881BD41209B219129EF173A4B /* QuitAppOnLastWindowClosePolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB9C5D90DA6F4E4D8F9EE4AE691D6B1F /* QuitAppOnLastWindowClosePolicyTests.swift */; };
 		B376D66B467C4587915220BC80D3B9CB /* ScriptCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = F098F8107F464776B5C18294427CAECD /* ScriptCommands.swift */; };
 		B3C9F20484F14266B941AFB170B66530 /* MediaRemoteService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC298B81953848F481EE849906E0AE77 /* MediaRemoteService.swift */; };
 		B5247D12ACED4D439B680104EC99DB30 /* WindowlessAppPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 033B1F63CB464113ADA3868696F486CF /* WindowlessAppPreview.swift */; };
@@ -290,6 +291,7 @@
 		AA11001122334455AA110011 /* DockLocker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockLocker.swift; sourceTree = "<group>"; };
 		AA11001122334455AA110033 /* DockLockingSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockLockingSettingsView.swift; sourceTree = "<group>"; };
 		AA11001122334455AA110055 /* DockLockerGeometryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockLockerGeometryTests.swift; sourceTree = "<group>"; };
+		EB9C5D90DA6F4E4D8F9EE4AE691D6B1F /* QuitAppOnLastWindowClosePolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuitAppOnLastWindowClosePolicyTests.swift; sourceTree = "<group>"; };
 		AA11001122334455AA110100 /* DockDoorTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DockDoorTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		AC298B81953848F481EE849906E0AE77 /* MediaRemoteService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaRemoteService.swift; sourceTree = "<group>"; };
 		B056906A7ACD4903BD5E1627B359AE2C /* AdvancedSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvancedSettingsView.swift; sourceTree = "<group>"; };
@@ -610,6 +612,7 @@
 			children = (
 				AA11001122334455AA110055 /* DockLockerGeometryTests.swift */,
 				D00D4B366E3CF5338182E065 /* NativeTabGroupingTests.swift */,
+				EB9C5D90DA6F4E4D8F9EE4AE691D6B1F /* QuitAppOnLastWindowClosePolicyTests.swift */,
 			);
 			path = DockDoorTests;
 			sourceTree = "<group>";
@@ -1099,6 +1102,7 @@
 			files = (
 				AA11001122334455AA110066 /* DockLockerGeometryTests.swift in Sources */,
 				555110B7F7B99C7BD510DBC7 /* NativeTabGroupingTests.swift in Sources */,
+				3D53691881BD41209B219129EF173A4B /* QuitAppOnLastWindowClosePolicyTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/DockDoor/Utilities/Window Management/WindowUtil.swift
+++ b/DockDoor/Utilities/Window Management/WindowUtil.swift
@@ -1409,7 +1409,12 @@ extension WindowUtil {
                                                  remainingWindowCount: Int) -> Bool
     {
         guard Defaults[.quitAppOnWindowClose],
-              app.bundleIdentifier != "com.apple.finder",
+              shouldQuitAppOnLastWindowClose(
+                  bundleIdentifier: app.bundleIdentifier,
+                  mode: Defaults[.quitAppOnWindowCloseMode],
+                  excludedApps: Defaults[.quitAppOnWindowCloseExcludedApps],
+                  allowedApps: Defaults[.quitAppOnWindowCloseAllowedApps]
+              ),
               previousWindowCount > 0,
               remainingWindowCount == 0
         else {
@@ -1432,6 +1437,23 @@ extension WindowUtil {
             }
         }
         return true
+    }
+
+    static func shouldQuitAppOnLastWindowClose(bundleIdentifier: String?,
+                                               mode: QuitAppOnWindowCloseMode,
+                                               excludedApps: [String],
+                                               allowedApps: [String]) -> Bool
+    {
+        guard bundleIdentifier != "com.apple.finder" else { return false }
+
+        switch mode {
+        case .allAppsExceptSelected:
+            guard let bundleIdentifier else { return true }
+            return !excludedApps.contains(bundleIdentifier)
+        case .selectedAppsOnly:
+            guard let bundleIdentifier else { return false }
+            return allowedApps.contains(bundleIdentifier)
+        }
     }
 
     /// Checks if the frontmost application is fullscreen and in the blacklist

--- a/DockDoor/Views/Settings/DockPreviewsSettingsView.swift
+++ b/DockDoor/Views/Settings/DockPreviewsSettingsView.swift
@@ -20,6 +20,9 @@ struct DockPreviewsSettingsView: View {
     @Default(.restoreAllMinimizedWindowsOnDockClick) var restoreAllMinimizedWindowsOnDockClick
     @Default(.enableCmdRightClickQuit) var enableCmdRightClickQuit
     @Default(.quitAppOnWindowClose) var quitAppOnWindowClose
+    @Default(.quitAppOnWindowCloseMode) var quitAppOnWindowCloseMode
+    @Default(.quitAppOnWindowCloseExcludedApps) var quitAppOnWindowCloseExcludedApps
+    @Default(.quitAppOnWindowCloseAllowedApps) var quitAppOnWindowCloseAllowedApps
     @Default(.bufferFromDock) var bufferFromDock
     @Default(.ignoreAppsWithSingleWindow) var ignoreAppsWithSingleWindow
     @Default(.enableFolderWidget) var enableFolderWidget
@@ -27,6 +30,8 @@ struct DockPreviewsSettingsView: View {
     @Default(.folderWidgetDefaultSortReversed) var folderWidgetDefaultSortReversed
     @Default(.folderWidgetRememberSortPerFolder) var folderWidgetRememberSortPerFolder
     @Default(.folderWidgetShowHiddenFiles) var folderWidgetShowHiddenFiles
+
+    @State private var showingQuitAppPickerSheet = false
 
     var body: some View {
         BaseSettingsView {
@@ -43,6 +48,14 @@ struct DockPreviewsSettingsView: View {
                     dockAppearanceSection
                 }
             }
+        }
+        .sheet(isPresented: $showingQuitAppPickerSheet) {
+            AppPickerSheet(
+                selectedApps: quitAppSelection,
+                title: quitAppPickerTitle,
+                description: quitAppPickerDescription,
+                selectionMode: .include
+            )
         }
     }
 
@@ -242,9 +255,80 @@ struct DockPreviewsSettingsView: View {
                     .foregroundColor(.secondary)
                     .padding(.leading, 20)
 
+                if quitAppOnWindowClose {
+                    Picker("Apply quit behavior to", selection: $quitAppOnWindowCloseMode) {
+                        ForEach(QuitAppOnWindowCloseMode.allCases, id: \.self) { mode in
+                            Text(mode.localizedName).tag(mode)
+                        }
+                    }
+                    .pickerStyle(.menu)
+                    .padding(.leading, 20)
+                    .settingsSearchTarget("dockPreviews.quitOnCloseMode")
+
+                    HStack {
+                        Button("Select Apps...") {
+                            showingQuitAppPickerSheet = true
+                        }
+                        .buttonStyle(AccentButtonStyle(color: .accentColor))
+                        .settingsSearchTarget("dockPreviews.quitOnCloseApps")
+
+                        if quitAppSelection.wrappedValue.isEmpty {
+                            Text("No apps selected")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        } else {
+                            Text("\(quitAppSelection.wrappedValue.count) app\(quitAppSelection.wrappedValue.count == 1 ? "" : "s") selected")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+                    }
+                    .padding(.leading, 20)
+
+                    Text(quitAppModeDescription)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .padding(.leading, 20)
+                }
+
                 sliderSetting(title: "Window Buffer from Dock (pixels)", value: $bufferFromDock, range: -100 ... 100, step: 5, unit: "px", formatter: { let f = NumberFormatter(); f.allowsFloats = false; f.minimumIntegerDigits = 1; f.maximumFractionDigits = 0; return f }())
                     .settingsSearchTarget("dockPreviews.buffer")
             }
+        }
+    }
+
+    private var quitAppSelection: Binding<[String]> {
+        switch quitAppOnWindowCloseMode {
+        case .allAppsExceptSelected:
+            $quitAppOnWindowCloseExcludedApps
+        case .selectedAppsOnly:
+            $quitAppOnWindowCloseAllowedApps
+        }
+    }
+
+    private var quitAppPickerTitle: String {
+        switch quitAppOnWindowCloseMode {
+        case .allAppsExceptSelected:
+            String(localized: "Apps to Keep Running")
+        case .selectedAppsOnly:
+            String(localized: "Apps to Quit")
+        }
+    }
+
+    private var quitAppPickerDescription: String {
+        switch quitAppOnWindowCloseMode {
+        case .allAppsExceptSelected:
+            String(localized: "Selected apps will stay running when their last window closes.")
+        case .selectedAppsOnly:
+            String(localized: "Selected apps will quit when their last window closes.")
+        }
+    }
+
+    private var quitAppModeDescription: String {
+        switch quitAppOnWindowCloseMode {
+        case .allAppsExceptSelected:
+            String(localized: "Selected apps stay running when their last window closes. Finder always stays running.")
+        case .selectedAppsOnly:
+            String(localized: "Only selected apps quit when their last window closes. Finder always stays running.")
         }
     }
 }

--- a/DockDoor/Views/Settings/Search/SettingsSearchCatalog.swift
+++ b/DockDoor/Views/Settings/Search/SettingsSearchCatalog.swift
@@ -269,10 +269,26 @@ enum SettingsSearchCatalog {
             id: "dockPreviews.quitOnClose",
             title: String(localized: "Quit app when closing its last window"),
             description: String(localized: "When an app has only one window left, closing it will quit the app. Useful as a replacement for Swift Quit."),
-            keywords: ["quit", "close", "last window"],
+            keywords: ["quit", "close", "last window", "allow list", "ignore list", "exclude"],
             tab: "DockPreviews",
             section: String(localized: "Dock Interaction"),
             icon: "xmark.app.fill"
+        ),
+        SettingsSearchItem(
+            id: "dockPreviews.quitOnCloseMode",
+            title: String(localized: "Apply quit behavior to"),
+            keywords: ["quit", "close", "scope", "mode", "allow list", "ignore list"],
+            tab: "DockPreviews",
+            section: String(localized: "Dock Interaction"),
+            icon: "checklist"
+        ),
+        SettingsSearchItem(
+            id: "dockPreviews.quitOnCloseApps",
+            title: String(localized: "Select Apps..."),
+            keywords: ["quit", "close", "apps", "allow list", "ignore list", "exclude"],
+            tab: "DockPreviews",
+            section: String(localized: "Dock Interaction"),
+            icon: "app.badge.checkmark"
         ),
         SettingsSearchItem(
             id: "dockPreviews.buffer",

--- a/DockDoor/consts.swift
+++ b/DockDoor/consts.swift
@@ -42,6 +42,9 @@ extension Defaults.Keys {
     static let restoreAllMinimizedWindowsOnDockClick = Key<Bool>("restoreAllMinimizedWindowsOnDockClick", default: true)
     static let enableCmdRightClickQuit = Key<Bool>("enableCmdRightClickQuit", default: true)
     static let quitAppOnWindowClose = Key<Bool>("quitAppOnWindowClose", default: false)
+    static let quitAppOnWindowCloseMode = Key<QuitAppOnWindowCloseMode>("quitAppOnWindowCloseMode", default: .allAppsExceptSelected)
+    static let quitAppOnWindowCloseExcludedApps = Key<[String]>("quitAppOnWindowCloseExcludedApps", default: [])
+    static let quitAppOnWindowCloseAllowedApps = Key<[String]>("quitAppOnWindowCloseAllowedApps", default: [])
     static let enableDockScrollGesture = Key<Bool>("enableDockScrollGesture", default: false)
     static let enableTitleBarScrollGesture = Key<Bool>("enableTitleBarScrollGesture", default: false)
     static let titleBarScrollCenteredWindowScale = Key<CGFloat>("titleBarScrollCenteredWindowScale", default: 0.8)
@@ -775,6 +778,20 @@ enum DockPreviewActivationModifier: String, CaseIterable, Defaults.Serializable 
             .maskShift
         case .command:
             .maskCommand
+        }
+    }
+}
+
+enum QuitAppOnWindowCloseMode: String, CaseIterable, Defaults.Serializable {
+    case allAppsExceptSelected
+    case selectedAppsOnly
+
+    var localizedName: String {
+        switch self {
+        case .allAppsExceptSelected:
+            String(localized: "All apps except selected", comment: "Quit on last window app scope option")
+        case .selectedAppsOnly:
+            String(localized: "Selected apps only", comment: "Quit on last window app scope option")
         }
     }
 }

--- a/DockDoorTests/QuitAppOnLastWindowClosePolicyTests.swift
+++ b/DockDoorTests/QuitAppOnLastWindowClosePolicyTests.swift
@@ -1,0 +1,85 @@
+@testable import DockDoor
+import Testing
+
+struct QuitAppOnLastWindowClosePolicyTests {
+    private let safari = "com.apple.Safari"
+    private let outlook = "com.microsoft.Outlook"
+
+    @Test func allAppsExceptSelectedQuitsUnlistedApp() {
+        let result = WindowUtil.shouldQuitAppOnLastWindowClose(
+            bundleIdentifier: safari,
+            mode: .allAppsExceptSelected,
+            excludedApps: [outlook],
+            allowedApps: []
+        )
+
+        #expect(result)
+    }
+
+    @Test func allAppsExceptSelectedKeepsExcludedAppRunning() {
+        let result = WindowUtil.shouldQuitAppOnLastWindowClose(
+            bundleIdentifier: outlook,
+            mode: .allAppsExceptSelected,
+            excludedApps: [outlook],
+            allowedApps: []
+        )
+
+        #expect(!result)
+    }
+
+    @Test func selectedAppsOnlyQuitsAllowedApp() {
+        let result = WindowUtil.shouldQuitAppOnLastWindowClose(
+            bundleIdentifier: safari,
+            mode: .selectedAppsOnly,
+            excludedApps: [],
+            allowedApps: [safari]
+        )
+
+        #expect(result)
+    }
+
+    @Test func selectedAppsOnlyKeepsUnlistedAppRunning() {
+        let result = WindowUtil.shouldQuitAppOnLastWindowClose(
+            bundleIdentifier: outlook,
+            mode: .selectedAppsOnly,
+            excludedApps: [],
+            allowedApps: [safari]
+        )
+
+        #expect(!result)
+    }
+
+    @Test(arguments: QuitAppOnWindowCloseMode.allCases)
+    func finderAlwaysStaysRunning(mode: QuitAppOnWindowCloseMode) {
+        let result = WindowUtil.shouldQuitAppOnLastWindowClose(
+            bundleIdentifier: "com.apple.finder",
+            mode: mode,
+            excludedApps: [],
+            allowedApps: ["com.apple.finder"]
+        )
+
+        #expect(!result)
+    }
+
+    @Test func unidentifiedAppPreservesAllAppsBehavior() {
+        let result = WindowUtil.shouldQuitAppOnLastWindowClose(
+            bundleIdentifier: nil,
+            mode: .allAppsExceptSelected,
+            excludedApps: [],
+            allowedApps: []
+        )
+
+        #expect(result)
+    }
+
+    @Test func unidentifiedAppDoesNotMatchSelectedAppsOnly() {
+        let result = WindowUtil.shouldQuitAppOnLastWindowClose(
+            bundleIdentifier: nil,
+            mode: .selectedAppsOnly,
+            excludedApps: [],
+            allowedApps: []
+        )
+
+        #expect(!result)
+    }
+}


### PR DESCRIPTION
## Describe your changes

Adds per-app scope controls to **Quit app when closing its last window** so users can choose either:

- **All apps except selected** — preserves the existing behavior by default, with an ignore list for apps that should stay running.
- **Selected apps only** — applies the behavior only to an allow list.

The settings reuse DockDoor's existing app picker, retain separate lists when switching modes, and are included in Settings search. Finder remains protected in both modes. Policy tests cover both modes, excluded/allowed apps, Finder, and apps without a bundle identifier.

## Related issue number(s) and link(s)

Related to #1480. The ignore-list mode gives users a way to keep incompatible apps running without disabling quit-on-last-window globally.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code and understand every line
- [x] If this change affects core functionality, I have added a description highlighting the changes
- [x] I have followed conventional commit guidelines
- [x] I have tested this PR on my own machine

## AI Assistance Disclosure

**Did you use AI tools (ChatGPT, Claude, Copilot, Cursor, etc.) for this PR?**

- [ ] No AI tools were used
- [x] Yes - describe below how AI was used and confirm you reviewed/tested the output

OpenAI Codex assisted with repository inspection, implementation, and tests. The resulting diff was checked against the existing centralized close/quit path and app-picker patterns, then verified with SwiftFormat lint, the full 31-test macOS test suite, and a manual UI pass in the built app. This PR is intentionally opened as a draft so a final human review can be completed before requesting maintainer review.

## Core Functionality Changes

The last-window close path now evaluates a small policy function before scheduling termination. The existing all-app behavior remains the default, while exact bundle-ID allow and ignore lists can narrow its scope. The existing delayed window re-check and Finder safeguard remain unchanged.

### Verification

- `swiftformat --lint`: passed
- `xcodebuild test`: 31 tests passed across 4 suites
- Manual macOS UI verification: mode picker, selected-app count, and app-selection sheet
