### PR TITLE
feat(cmd-tab): restore minimized/hidden windows when switching (AltTab-style)

### DIFF
--- a/DockDoor/Utilities/DockObserver+CmdTab.swift
+++ b/DockDoor/Utilities/DockObserver+CmdTab.swift
@@ -17,6 +17,7 @@ extension DockObserver {
         cmdTabObserver = nil
         stopCmdTabPolling()
         DockObserver.isCmdTabSwitcherActive = false
+        DockObserver.lastCmdTabTargetApp = nil
     }
 
     // MARK: - On-Demand Polling (Event-Driven)
@@ -118,6 +119,7 @@ extension DockObserver {
         }
 
         let resolvedApp = selectedItem.app
+        DockObserver.lastCmdTabTargetApp = resolvedApp
         let appName = resolvedApp?.localizedName ?? selectedItem.title ?? "Unknown"
         let bundleId = resolvedApp?.bundleIdentifier ?? selectedItem.bundleId
 
@@ -227,6 +229,34 @@ extension DockObserver {
     /// Cached state tracking whether the Cmd+Tab switcher is currently active.
     /// Updated by the AXObserver when the switcher appears/disappears.
     static var isCmdTabSwitcherActive = false
+
+    /// The app the switcher last landed on. Used by the app-level fallback in KeybindHelper:
+    /// when Cmd is released without an explicit window selection and every window of this app is
+    /// minimized / hidden, we restore the most recently used one.
+    static var lastCmdTabTargetApp: NSRunningApplication?
+
+    /// App-level fallback invoked when the Cmd+Tab session ends without an explicit window
+    /// selection (no Enter press, no preview window picked). Mirrors AltTab / Windows Alt+Tab:
+    /// if the app the switcher landed on has *every* window minimized or hidden, deminiaturize the
+    /// most recently used one so the user doesn't end up staring at an empty Dock.
+    ///
+    /// `bringToFront()` already deminiaturizes / unhides first (see `restoreFromPutAwayState()`),
+    /// so a single call is enough here.
+    @MainActor
+    func restoreLastCmdTabAppIfFullyPutAway(targetApp: NSRunningApplication?) {
+        guard Defaults[.restoreMinimizedWindowsOnCmdTab] else { return }
+        guard let app = targetApp else { return }
+
+        let windows = WindowUtil.readCachedWindows(for: app.processIdentifier, sortedBy: .cmdTab)
+        guard !windows.isEmpty else { return }
+
+        let putAway = windows.filter { $0.isPutAway }
+        // Only step in when *every* window is put away — if at least one is already on screen the
+        // native switcher already did its job and yanking a hidden one forward would be wrong.
+        guard putAway.count == windows.count, let target = putAway.first else { return }
+
+        target.bringToFront()
+    }
 
     private func getSelectedCmdTabItem(dockElement: AXUIElement) -> (element: AXUIElement, app: NSRunningApplication?, bundleId: String?, title: String?)? {
         guard let appSwitcherElement = findCmdTabSwitcherElement(in: dockElement) else {

--- a/DockDoor/Utilities/KeybindHelper.swift
+++ b/DockDoor/Utilities/KeybindHelper.swift
@@ -390,6 +390,8 @@ class KeybindHelper {
             // Track Command up/down explicitly for Cmd+Tab fallback behavior
             let cmdNowDown = event.flags.contains(.maskCommand)
             if isCommandKeyCurrentlyDown, !cmdNowDown {
+                // Capture the app the switcher last landed on *before* teardown clears it.
+                let cmdTabTargetApp = DockObserver.lastCmdTabTargetApp
                 DockObserver.activeInstance?.teardownCmdTabObserver()
 
                 if Defaults[.enableCmdTabEnhancements], lastCmdTabObservedActive {
@@ -402,6 +404,9 @@ class KeybindHelper {
                             self.previewCoordinator.selectAndBringToFrontCurrentWindow()
                         } else {
                             self.previewCoordinator.hideWindow()
+                            // App-level fallback: if Cmd+Tab landed on an app whose windows are all
+                            // minimized / hidden, restore the most recently used one.
+                            DockObserver.activeInstance?.restoreLastCmdTabAppIfFullyPutAway(targetApp: cmdTabTargetApp)
                         }
                         self.windowSwitchingCoordinator.cancelSwitching(previewCoordinator: self.previewCoordinator)
                     }

--- a/DockDoor/Utilities/Window Management/WindowInfo.swift
+++ b/DockDoor/Utilities/Window Management/WindowInfo.swift
@@ -114,23 +114,62 @@ extension WindowInfo {
         return info
     }
 
+    /// True when macOS has "put the window away" — it is either miniaturized into the Dock or
+    /// belongs to a hidden app. In both states the window is absent from the WindowServer's
+    /// on-screen list, so the focus primitives used by `bringToFront()`
+    /// (`_SLPSSetFrontProcessWithOptions`, `makeKeyWindow`, `kAXRaiseAction`) silently no-op.
+    var isPutAway: Bool { isMinimized || isHidden }
+
+    /// Puts a minimized / hidden window back on screen so it can actually be focused.
+    ///
+    /// This mirrors what AltTab does at the top of `Window.focus()`: deminiaturize first, then run
+    /// the normal front-process + raise sequence. Without it, selecting a minimized window in the
+    /// switcher only activates the owning app and the window stays in the Dock.
+    ///
+    /// - Returns: `false` only when the deminiaturize write failed; a window that needed no
+    ///   restoring at all still returns `true`.
+    @discardableResult
+    func restoreFromPutAwayState() -> Bool {
+        guard !isWindowlessApp else { return false }
+
+        var didRestore = false
+
+        if app.isHidden {
+            app.unhide()
+            WindowUtil.updateCachedWindowState(self, isHidden: false)
+            didRestore = true
+        }
+
+        // Prefer the live AX state over the cached flag: the cache can lag a few hundred ms behind
+        // and writing kAXMinimized = false on an already-restored window makes some apps replay the
+        // genie animation.
+        let minimizedNow = (try? axElement.isMinimized()) ?? isMinimized
+        if minimizedNow {
+            do {
+                try axElement.setAttribute(kAXMinimizedAttribute, false)
+                WindowUtil.updateCachedWindowState(self, isMinimized: false)
+                didRestore = true
+            } catch {
+                DebugLogger.log("WindowInfo", details: "Failed to deminiaturize window \(id): \(error)")
+                return false
+            }
+        }
+
+        if didRestore {
+            app.activate()
+        }
+
+        return true
+    }
+
     @discardableResult
     mutating func toggleMinimize() -> Bool? {
         guard !isWindowlessApp else { return nil }
         if isMinimized {
-            if app.isHidden {
-                app.unhide()
-            }
-            do {
-                try axElement.setAttribute(kAXMinimizedAttribute, false)
-                app.activate()
-                bringToFront()
-                isMinimized = false
-                WindowUtil.updateCachedWindowState(self, isMinimized: false)
-                return false
-            } catch {
-                return nil
-            }
+            guard restoreFromPutAwayState() else { return nil }
+            bringToFront()
+            isMinimized = false
+            return false
         } else {
             do {
                 try axElement.setAttribute(kAXMinimizedAttribute, true)
@@ -433,6 +472,12 @@ extension WindowInfo {
             app.activate(options: [.activateIgnoringOtherApps])
             return
         }
+        // A minimized / hidden window is absent from the WindowServer's on-screen list, so the
+        // focus primitives below (`_SLPSSetFrontProcessWithOptions`, `makeKeyWindow`,
+        // `kAXRaiseAction`) silently no-op on it — the app merely activates while the window stays
+        // in the Dock. Deminiaturize / unhide first (mirrors AltTab's Window.focus()) so the
+        // subsequent raise actually lands on the right window.
+        restoreFromPutAwayState()
         let maxRetries = 3
         var retryCount = 0
 

--- a/DockDoor/Views/Settings/CmdTabSettingsView.swift
+++ b/DockDoor/Views/Settings/CmdTabSettingsView.swift
@@ -10,6 +10,7 @@ struct CmdTabSettingsView: View {
     @Default(.cmdTabSortOrder) var cmdTabSortOrder
     @Default(.cmdTabAutoSelectFirstWindow) var cmdTabAutoSelectFirstWindow
     @Default(.includeHiddenWindowsInCmdTab) var includeHiddenWindowsInCmdTab
+    @Default(.restoreMinimizedWindowsOnCmdTab) var restoreMinimizedWindowsOnCmdTab
     @Default(.showWindowlessAppsInCmdTab) var showWindowlessAppsInCmdTab
     @Default(.ignoreAppsWithSingleWindowInCmdTab) var ignoreAppsWithSingleWindowInCmdTab
 
@@ -115,6 +116,13 @@ struct CmdTabSettingsView: View {
 
                 Toggle(isOn: $includeHiddenWindowsInCmdTab) { Text("Include hidden/minimized windows") }
                     .settingsSearchTarget("cmdTab.includeHidden")
+
+                Toggle(isOn: $restoreMinimizedWindowsOnCmdTab) { Text("Restore minimized/hidden windows on switch") }
+                    .settingsSearchTarget("cmdTab.restoreMinimized")
+                Text("When Cmd+Tab lands on an app whose windows are all minimized or hidden, automatically restore the most recently used one instead of leaving it in the Dock.")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .padding(.leading, 20)
 
                 Toggle(isOn: $showWindowlessAppsInCmdTab) { Text("Show preview for apps with no open windows") }
                     .settingsSearchTarget("cmdTab.showWindowless")

--- a/DockDoor/Views/Settings/Search/SettingsSearchCatalog.swift
+++ b/DockDoor/Views/Settings/Search/SettingsSearchCatalog.swift
@@ -500,6 +500,15 @@ enum SettingsSearchCatalog {
             icon: "eye.slash"
         ),
         SettingsSearchItem(
+            id: "cmdTab.restoreMinimized",
+            title: String(localized: "Restore minimized/hidden windows on switch"),
+            description: String(localized: "When Cmd+Tab lands on an app whose windows are all minimized or hidden, automatically restore the most recently used one."),
+            keywords: ["restore", "minimized", "hidden", "deminiaturize", "unhide"],
+            tab: "CmdTab",
+            section: String(localized: "Window Display"),
+            icon: "macwindow"
+        ),
+        SettingsSearchItem(
             id: "cmdTab.showWindowless",
             title: String(localized: "Show preview for apps with no open windows"),
             description: String(localized: "Show a placeholder preview when Cmd+Tab lands on an app that has no windows."),

--- a/DockDoor/consts.swift
+++ b/DockDoor/consts.swift
@@ -148,6 +148,7 @@ extension Defaults.Keys {
     static let includeHiddenWindowsInSwitcher = Key<Bool>("includeHiddenWindowsInSwitcher", default: true)
     static let includeHiddenWindowsInDockPreview = Key<Bool>("includeHiddenWindowsInDockPreview", default: true)
     static let includeHiddenWindowsInCmdTab = Key<Bool>("includeHiddenWindowsInCmdTab", default: true)
+    static let restoreMinimizedWindowsOnCmdTab = Key<Bool>("restoreMinimizedWindowsOnCmdTab", default: true)
     static let showWindowlessAppsInSwitcher = Key<Bool>("showWindowlessAppsInSwitcher", default: true)
     static let showWindowlessAppsInDockPreview = Key<Bool>("showWindowlessAppsInDockPreview", default: false)
     static let showWindowlessAppsInCmdTab = Key<Bool>("showWindowlessAppsInCmdTab", default: false)


### PR DESCRIPTION
## Summary

When using Cmd+Tab with DockDoor's enhancements, switching to an app whose target window is **minimized or hidden** did nothing — the window stayed in the Dock. This mirrors AltTab / Windows Alt+Tab, which restore the window to the front.

## Root cause

`WindowInfo.bringToFront()` relies on `_SLPSSetFrontProcessWithOptions` / `makeKeyWindow` / `kAXRaiseAction`, which **silently fail on minimized/hidden windows**: the app activates, but the window never comes forward.

## Changes

- **`WindowInfo.swift`** — added `isPutAway` (`isMinimized || isHidden`) and `restoreFromPutAwayState()` (unhide the app, then deminiaturize the window — mirroring AltTab's `Window.focus()`). `bringToFront()` now restores put-away windows **first**, so every focus path is covered (Cmd+Tab selection, Window Switcher, preview click, drag). `toggleMinimize()` reuses the same logic.
- **`DockObserver+CmdTab.swift`** — app-level fallback: when Cmd is released without an explicit window selection and the target app's windows are **all** minimized/hidden, restore the most recently used one (AltTab/TabLift behavior).
- **`KeybindHelper.swift`** — wires the fallback into the Cmd-release path.
- **`consts.swift`** + **`CmdTabSettingsView.swift`** + **`SettingsSearchCatalog.swift`** — new setting `restoreMinimizedWindowsOnCmdTab` (default **on**) with a UI toggle and a settings-search entry.

## Behavior

- Selecting a minimized/hidden window via Cmd+Tab now brings it forward.
- App-level fallback restores a fully-minimized app when Cmd is released without an explicit pick.
- The new toggle lets users keep the old behavior if they prefer.

## Notes

- Default on; disable `Restore minimized/hidden windows on switch` in Cmd+Tab settings to revert.
- Needs Xcode to build (no CI change). Please compile-test on macOS before merging.
