### PR TITLE
fix: prevent window resizing during dock preview activation

### DIFF
--- a/DockDoor/Utilities/DockObserver.swift
+++ b/DockDoor/Utilities/DockObserver.swift
@@ -832,7 +832,10 @@ final class DockObserver {
         }
 
         if type == .leftMouseDown, appUnderMouse.dockItemElement != nil {
-            DispatchQueue.main.async { [weak self] in self?.previewCoordinator.restoreDockAutoHideState() }
+            DispatchQueue.main.async { [weak self] in
+                self?.previewCoordinator.cancelPendingShow()
+                self?.previewCoordinator.restoreDockAutoHideState()
+            }
         }
 
         if case let .success(app) = appUnderMouse.status {

--- a/DockDoor/Views/Hover Window/WindowPreviewInteractionModifier.swift
+++ b/DockDoor/Views/Hover Window/WindowPreviewInteractionModifier.swift
@@ -100,6 +100,9 @@ struct WindowPreviewInteractionModifier: ViewModifier {
     // MARK: - Tap Handling
 
     private func handleWindowTap() {
+        // Avoid activating the target while the temporarily pinned Dock reduces the usable screen area.
+        SharedPreviewWindowCoordinator.activeInstance?.restoreDockAutoHideState()
+
         if NSEvent.modifierFlags.contains(.shift) {
             WindowUtil.activateAndOpenNewWindow(app: windowInfo.app)
             onTap?()


### PR DESCRIPTION
## Describe your changes

When **Prevent dock from hiding during previews** is enabled, DockDoor temporarily disables Dock auto-hide. Two activation paths could still leave macOS seeing the reduced work area reserved for the visible Dock:

1. Clicking a native Dock icon before the configured preview delay expired restored the current Dock state, but left the pending preview scheduled. The preview could then appear after the click, pin the Dock, and resize the newly activated window.
2. Clicking a DockDoor window preview activated the selected app/window before dismissing the preview and restoring auto-hide.

This PR fixes both paths:

- Native Dock left-clicks now cancel any pending delayed preview before restoring auto-hide.
- The shared standard/compact preview-card tap handler restores auto-hide synchronously before shift-click, windowless-app activation, unminimize, unhide, or window raise.

The restore remains a no-op when DockDoor is not managing auto-hide. This extends the restore-before-activation behavior introduced in #1534 and closes its delayed-preview and preview-card gaps.

## Related issue number(s) and link(s)

Fixes #1222

## Validation

- `git diff --check`
- Confirmed native Dock left-click cancellation occurs before auto-hide restoration
- Confirmed restoration precedes every activation branch in the shared standard/compact preview-card tap handler
- Xcode build and hands-on macOS WindowServer reproduction were not available in this Linux environment

## Checklist before requesting a review
- [x] I have performed a self-review of the code changes and understand every line
- [x] If this change affects core functionality, I have added a description highlighting the changes
- [x] I have followed conventional commit guidelines
- [x] I have tested this PR on my own machine

## AI Assistance Disclosure

> **Policy**: AI-assisted contributions are welcome, but you must understand, test, and take full responsibility for your code. Pasting AI-generated code or PR descriptions without genuine human review and understanding will result in your PR being closed and may result in a ban from contributing.

**Did you use AI tools (ChatGPT, Claude, Copilot, Cursor, etc.) for this PR?**
- [ ] No AI tools were used
- [x] Yes - describe below how AI was used and confirm you reviewed/tested the output

OpenAI Codex traced both activation orderings, implemented the two targeted changes, and reviewed the diffs. Static validation was completed, but a human still needs to review and test the behavior on macOS.

### What "genuine human review" means:
- You can explain any line of code if asked
- You tested the changes yourself and verified they work
- You understand how the changes interact with existing code
- The PR description reflects your actual understanding, not AI-generated summaries

### Examples of acceptable AI use:
- "Used Copilot for autocomplete suggestions, reviewed each one"
- "Asked Claude to explain how ScreenCaptureKit works, wrote the implementation myself"
- "Used ChatGPT to help debug an issue, verified the fix myself"

### What will get your PR closed (and possibly banned):
- Pasting AI output directly without review or understanding
- PR descriptions that are clearly AI-generated (overly formal, generic explanations you can't elaborate on)
- Unable to explain your own code changes when asked
- Submitting large refactors with undocumented behavioral changes

## Core Functionality Changes

Native Dock clicks now discard delayed previews that would otherwise pin the Dock after activation. Preview-card selection restores the original Dock auto-hide state before activating its target. The Dock remains pinned while browsing an already-open preview, but macOS no longer sees that temporary reduced work area during either affected activation flow.
