### PR TITLE
fix: Activate app via public API before raising window

### DIFF
--- a/DockDoor/Utilities/Window Management/WindowInfo.swift
+++ b/DockDoor/Utilities/Window Management/WindowInfo.swift
@@ -433,6 +433,15 @@ extension WindowInfo {
             app.activate(options: [.activateIgnoringOtherApps])
             return
         }
+
+        // Also activate via the public API so third-party window/space managers
+        // (e.g. AeroSpace, yabai) that observe standard app-activation
+        // notifications learn about the focus change. The private SLPS/AX calls
+        // below raise the exact window but are invisible to those observers,
+        // which can leave a window that lives in a currently-hidden managed
+        // space activated at the process level yet never scrolled into view.
+        ownerApp.activate(options: [.activateIgnoringOtherApps])
+
         let maxRetries = 3
         var retryCount = 0
 


### PR DESCRIPTION
## Describe your changes

`WindowInfo.bringToFront()` now calls `ownerApp.activate(options: [.activateIgnoringOtherApps])` before the existing private SLPS/AX raise sequence.

With a tiling window manager like AeroSpace or yabai active, selecting a window via the window switcher when that window lives in a currently-hidden managed space doesn't bring it into view. `bringToFront()` only called `_SLPSSetFrontProcessWithOptions` and raised the `AXUIElement` directly, both private/low-level calls that these window managers don't observe. They rely on standard app-activation notifications (the same ones `NSRunningApplication.activate()` triggers) to know when to switch to the space/workspace containing the newly-focused window.

I traced this in AeroSpace's own source (`nikitabobko/AeroSpace`):
- `GlobalObserver.swift` observes `NSWorkspace.didActivateApplicationNotification`, which is exactly what `NSRunningApplication.activate()` posts.
- That triggers a refresh that reads the focused window via AX and calls `updateFocusCache`.
- `updateFocusCache` calls `focusWindow()` → `setFocus(to:)` → `workspaceMonitor.setActiveWorkspace(...)`, which is what actually switches AeroSpace's visible workspace.

So calling `activate()` first gives these window managers the signal they need to switch to the right workspace before the window is raised.

Caveat: `activate()`'s AX-focused-window read happens asynchronously off the notification. For a single-window app there's no ambiguity. For apps with multiple windows there's a theoretical race with the AX raise that follows in the same call stack, though in practice the raise happens before control returns to the run loop.

## Related issue number(s) and link(s)

None.

## Checklist before requesting a review
- [x] I have performed a self-review of my code and understand every line
- [ ] If this change affects core functionality, I have added a description highlighting the changes
- [x] I have followed conventional commit guidelines
- [ ] I have tested this PR on my own machine

## AI Assistance Disclosure

**Did you use AI tools (ChatGPT, Claude, Copilot, Cursor, etc.) for this PR?**
- [x] Yes - describe below how AI was used and confirm you reviewed/tested the output

Used Claude to help trace how AeroSpace responds to app activation notifications and to draft the code change and description. I reviewed the diff, verified the AeroSpace source references cited above, and understand how `bringToFront()` and `NSRunningApplication.activate()` interact.

## Core Functionality Changes

Not tested on a real machine yet, only verified via `swiftc -parse` against the macOS SDK and the repo's SwiftFormat lint. This is a change to window focus/raise behavior, so I'd appreciate confirmation from someone running AeroSpace or yabai before merge.
