### PR TITLE
fix: proper handling of the case when the same app has multiple instances running and multiple dock icons

### DIFF
--- a/DockDoor.xcodeproj/project.pbxproj
+++ b/DockDoor.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		3BB072C8A800463CB09CC383 /* MouseActionsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C1919C22F1F48369D6FCCD1 /* MouseActionsSection.swift */; };
 		49327679B03B44DC8FC44058 /* WindowSwitcherGesturesSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8E0D699507444D3985957B6 /* WindowSwitcherGesturesSection.swift */; };
 		4E665A7B0E9F4D458307E40493674B2B /* DockPreviewsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 970D8CBC36D84F14B8E6E83487035CFB /* DockPreviewsSettingsView.swift */; };
+		400B743394004E7F96049F86 /* DockAppInstanceOrderingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEBCF6588F2B4DEBA4E9B33B /* DockAppInstanceOrderingTests.swift */; };
 		555110B7F7B99C7BD510DBC7 /* NativeTabGroupingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D00D4B366E3CF5338182E065 /* NativeTabGroupingTests.swift */; };
 		5BCC969779654E67A6386C12FC709616 /* Glow.wav in Resources */ = {isa = PBXBuildFile; fileRef = D924F5BAEF564CC1AF84527876E14356 /* Glow.wav */; };
 		5C1867B80C2F46948F5C6336 /* SupportLinksSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F2844BF18EB4D089A62A368 /* SupportLinksSection.swift */; };
@@ -208,6 +209,7 @@
 		D4B28EF578BC4053BF908A5A /* CmdKeyShortcutsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6AA4630D2D54CD7AB622B27 /* CmdKeyShortcutsSection.swift */; };
 		D840D9FEDA7F4F129CAC9C455104296F /* SettingsSearchResultsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E159457AD5CE4E54988FDAF2CB583AE3 /* SettingsSearchResultsView.swift */; };
 		D9F56880CB0E4365980B4DDD87BB20AC /* WindowSwitcherBehaviorSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2361530A12344D0090E22EC428DC77D0 /* WindowSwitcherBehaviorSettingsView.swift */; };
+		E8023EA0AC0540E5AF723494 /* DockAppInstanceOrdering.swift in Sources */ = {isa = PBXBuildFile; fileRef = 030F08EC10F943C9B64311B6 /* DockAppInstanceOrdering.swift */; };
 		EBE2166867324098AFE30B239FF83CE8 /* CmdTabSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99C808769D1048FF95FCDA50FA52116A /* CmdTabSettingsView.swift */; };
 		EE170699DAA44638A41F52048707488C /* SettingsSearchEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2C876FFD01A4267862BF125EA617987 /* SettingsSearchEngine.swift */; };
 		F0796B6D96ED42D58D75BB8A /* SettingsSliderRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0970FA03935B41E59919A618 /* SettingsSliderRow.swift */; };
@@ -437,6 +439,7 @@
 		CBBBAA129E24438589330D3B /* WindowSwitcherAppearanceSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowSwitcherAppearanceSection.swift; sourceTree = "<group>"; };
 		CC5D1784E68A4052A122B9019AA9C150 /* WidgetHoverContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetHoverContainer.swift; sourceTree = "<group>"; };
 		D00D4B366E3CF5338182E065 /* NativeTabGroupingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeTabGroupingTests.swift; sourceTree = "<group>"; };
+		DEBCF6588F2B4DEBA4E9B33B /* DockAppInstanceOrderingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockAppInstanceOrderingTests.swift; sourceTree = "<group>"; };
 		D4E5F6789012345678901234 /* ActiveAppIndicatorDockDetection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActiveAppIndicatorDockDetection.swift; sourceTree = "<group>"; };
 		D924F5BAEF564CC1AF84527876E14356 /* Glow.wav */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = Glow.wav; sourceTree = "<group>"; };
 		DBECBD93A13645B2A46E546AC58BD1A4 /* FolderWidgetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FolderWidgetView.swift; sourceTree = "<group>"; };
@@ -446,6 +449,7 @@
 		F4258675B29E4A22ACF92845 /* SettingsGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsGroup.swift; sourceTree = "<group>"; };
 		F6AA4630D2D54CD7AB622B27 /* CmdKeyShortcutsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmdKeyShortcutsSection.swift; sourceTree = "<group>"; };
 		FB59EE0D7419468CABBAD220 /* CmdTabAppearanceSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmdTabAppearanceSection.swift; sourceTree = "<group>"; };
+		030F08EC10F943C9B64311B6 /* DockAppInstanceOrdering.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockAppInstanceOrdering.swift; sourceTree = "<group>"; };
 		FCF95019606449008856E149 /* SettingsLinkRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsLinkRow.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -623,6 +627,7 @@
 			isa = PBXGroup;
 			children = (
 				AA11001122334455AA110055 /* DockLockerGeometryTests.swift */,
+				DEBCF6588F2B4DEBA4E9B33B /* DockAppInstanceOrderingTests.swift */,
 				D00D4B366E3CF5338182E065 /* NativeTabGroupingTests.swift */,
 			);
 			path = DockDoorTests;
@@ -737,6 +742,7 @@
 				BB2567C52C10C5F000C0C93E /* DockUtils.swift */,
 				BB157B7A2C0E343000997315 /* SystemPreferencesHelper.swift */,
 				BB157B7F2C0E8E6700997315 /* MessageUtil.swift */,
+				030F08EC10F943C9B64311B6 /* DockAppInstanceOrdering.swift */,
 				BB157B812C0EB29E00997315 /* DockObserver.swift */,
 				BBF6C6232C1B4B4400BF1D40 /* KeybindHelper.swift */,
 				BBF6C6262C1B4B4500BF1D40 /* StringMatchingUtil.swift */,
@@ -1119,6 +1125,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				AA11001122334455AA110066 /* DockLockerGeometryTests.swift in Sources */,
+				400B743394004E7F96049F86 /* DockAppInstanceOrderingTests.swift in Sources */,
 				555110B7F7B99C7BD510DBC7 /* NativeTabGroupingTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1210,6 +1217,7 @@
 				BB638F1E2E0218EC0010077D /* CalendarContentView.swift in Sources */,
 				81BFDF0D2EE815FD00D56F65 /* CompactModeWarningBanner.swift in Sources */,
 				BB157B822C0EB29E00997315 /* DockObserver.swift in Sources */,
+				E8023EA0AC0540E5AF723494 /* DockAppInstanceOrdering.swift in Sources */,
 				BB638F022E0216FE0010077D /* MediaControlButton.swift in Sources */,
 				BB638F0A2E02172B0010077D /* MediaLyricsButton.swift in Sources */,
 				BBA153FA2C11FFD500119C02 /* consts.swift in Sources */,

--- a/DockDoor/Utilities/ActiveAppIndicator/ActiveAppIndicatorCoordinator.swift
+++ b/DockDoor/Utilities/ActiveAppIndicator/ActiveAppIndicatorCoordinator.swift
@@ -284,8 +284,8 @@ final class ActiveAppIndicatorCoordinator {
 
         isDockCurrentlyVisible = DockObserver.isDockVisible()
 
-        let isNewApp = previousApp?.bundleIdentifier != app.bundleIdentifier
-        updateIndicatorPosition(for: app, widenFromCenter: isNewApp)
+        let isNewAppInstance = previousApp?.processIdentifier != app.processIdentifier
+        updateIndicatorPosition(for: app, widenFromCenter: isNewAppInstance)
         scheduleDelayedUpdate()
     }
 

--- a/DockDoor/Utilities/ActiveAppIndicator/ActiveAppIndicatorDockDetection.swift
+++ b/DockDoor/Utilities/ActiveAppIndicator/ActiveAppIndicatorDockDetection.swift
@@ -32,27 +32,54 @@ enum ActiveAppIndicatorDockDetection {
             return nil
         }
 
-        // Find the dock item for this app
-        for item in dockItems {
-            guard let subrole = try? item.subrole(),
-                  subrole == "AXApplicationDockItem"
-            else { continue }
+        let applicationDockItems = dockItems.filter {
+            (try? $0.subrole()) == "AXApplicationDockItem"
+        }
 
-            // Check if this is our app by comparing bundle identifiers
-            if let itemURL = try? item.attribute(kAXURLAttribute, NSURL.self)?
+        // A Dock item does not expose the PID of the application instance it
+        // represents. Reconstruct that identity from launch order and whether
+        // the matching items are persistent or transient Dock tiles.
+        let bundleMatchingItems = applicationDockItems.filter { item in
+            guard let itemURL = try? item.attribute(kAXURLAttribute, NSURL.self)?
                 .absoluteURL,
-                let itemBundle = Bundle(url: itemURL),
-                itemBundle.bundleIdentifier == bundleIdentifier
-            {
-                return getFrameForDockItem(item)
+                let itemBundle = Bundle(url: itemURL)
+            else {
+                return false
             }
+            return itemBundle.bundleIdentifier == bundleIdentifier
+        }
 
-            // Check by running app if bundle ID check failed
-            if let itemTitle = try? item.title(),
-               itemTitle == app.localizedName
-            {
-                return getFrameForDockItem(item)
-            }
+        let runningApps = NSRunningApplication.runningApplications(
+            withBundleIdentifier: bundleIdentifier
+        )
+        let persistentDockItemCount = bundleMatchingItems.count > 1
+            ? DockAppInstanceOrdering.persistentDockItemCount(for: bundleIdentifier)
+            : 0
+        let dockOrderedProcessIdentifiers = DockAppInstanceOrdering.processIdentifiers(
+            for: runningApps.map {
+                (processIdentifier: $0.processIdentifier, launchDate: $0.launchDate)
+            },
+            persistentDockItemCount: persistentDockItemCount
+        )
+        if let matchingItemIndex = dockOrderedProcessIdentifiers.firstIndex(
+            of: app.processIdentifier
+        ),
+            bundleMatchingItems.indices.contains(matchingItemIndex),
+            let frame = getFrameForDockItem(bundleMatchingItems[matchingItemIndex])
+        {
+            return frame
+        }
+
+        if let item = bundleMatchingItems.first {
+            return getFrameForDockItem(item)
+        }
+
+        // Preserve the existing fallback for apps whose Dock URL cannot be
+        // resolved to a bundle, or while Launch Services is still settling.
+        if let title = app.localizedName,
+           let item = applicationDockItems.first(where: { (try? $0.title()) == title })
+        {
+            return getFrameForDockItem(item)
         }
 
         return nil

--- a/DockDoor/Utilities/ActiveAppIndicator/ActiveAppIndicatorDockDetection.swift
+++ b/DockDoor/Utilities/ActiveAppIndicator/ActiveAppIndicatorDockDetection.swift
@@ -36,9 +36,9 @@ enum ActiveAppIndicatorDockDetection {
             (try? $0.subrole()) == "AXApplicationDockItem"
         }
 
-        // A Dock item does not expose the PID of the application instance it
-        // represents. Reconstruct that identity from launch order and whether
-        // the matching items are persistent or transient Dock tiles.
+        // A Dock item exposes whether its application instance is running, but
+        // not its PID. Combine that occupancy with launch order to reconstruct
+        // the identity represented by each matching tile.
         let bundleMatchingItems = applicationDockItems.filter { item in
             guard let itemURL = try? item.attribute(kAXURLAttribute, NSURL.self)?
                 .absoluteURL,
@@ -55,13 +55,17 @@ enum ActiveAppIndicatorDockDetection {
         let persistentDockItemCount = bundleMatchingItems.count > 1
             ? DockAppInstanceOrdering.persistentDockItemCount(for: bundleIdentifier)
             : 0
-        let dockOrderedProcessIdentifiers = DockAppInstanceOrdering.processIdentifiers(
+        let dockItemRunningStates: [Bool?] = bundleMatchingItems.map {
+            try? $0.appIsRunning()
+        }
+        let processIdentifiersByDockItem = DockAppInstanceOrdering.processIdentifiersByDockItem(
             for: runningApps.map {
                 (processIdentifier: $0.processIdentifier, launchDate: $0.launchDate)
             },
-            persistentDockItemCount: persistentDockItemCount
+            persistentDockItemCount: persistentDockItemCount,
+            dockItemRunningStates: dockItemRunningStates
         )
-        if let matchingItemIndex = dockOrderedProcessIdentifiers.firstIndex(
+        if let matchingItemIndex = processIdentifiersByDockItem.firstIndex(
             of: app.processIdentifier
         ),
             bundleMatchingItems.indices.contains(matchingItemIndex),
@@ -70,7 +74,9 @@ enum ActiveAppIndicatorDockDetection {
             return frame
         }
 
-        if let item = bundleMatchingItems.first {
+        if let item = bundleMatchingItems.first(where: {
+            (try? $0.appIsRunning()) == true
+        }) ?? bundleMatchingItems.first {
             return getFrameForDockItem(item)
         }
 

--- a/DockDoor/Utilities/DockAppInstanceOrdering.swift
+++ b/DockDoor/Utilities/DockAppInstanceOrdering.swift
@@ -1,0 +1,57 @@
+import Cocoa
+
+/// Reconstructs the order macOS uses for separate Dock items that share a
+/// bundle identifier. Accessibility exposes each item's position, but not the
+/// PID it represents, so launch order provides the identity bridge.
+enum DockAppInstanceOrdering {
+    typealias RunningApplicationIdentity = (processIdentifier: pid_t, launchDate: Date?)
+
+    /// Returns how many persistent Dock tiles use a bundle identifier.
+    static func persistentDockItemCount(for bundleIdentifier: String) -> Int {
+        guard let persistentApps = UserDefaults(suiteName: "com.apple.dock")?
+            .array(forKey: "persistent-apps") as? [[String: Any]]
+        else {
+            return 0
+        }
+
+        return persistentApps.count { item in
+            guard let tileData = item["tile-data"] as? [String: Any] else {
+                return false
+            }
+            return tileData["bundle-identifier"] as? String == bundleIdentifier
+        }
+    }
+
+    /// Returns running application PIDs in the order represented by the Dock.
+    /// Duplicate persistent tiles are filled in reverse launch order, followed
+    /// by any additional transient tiles in launch order.
+    static func processIdentifiers(
+        for runningApplications: [RunningApplicationIdentity],
+        persistentDockItemCount: Int
+    ) -> [pid_t] {
+        let processIdentifiers = runningApplications
+            .sorted { lhs, rhs in
+                let lhsDate = lhs.launchDate ?? .distantPast
+                let rhsDate = rhs.launchDate ?? .distantPast
+
+                if lhsDate == rhsDate {
+                    return lhs.processIdentifier < rhs.processIdentifier
+                }
+
+                return lhsDate < rhsDate
+            }
+            .map(\.processIdentifier)
+
+        let persistentProcessCount = min(
+            persistentDockItemCount,
+            processIdentifiers.count
+        )
+        let persistentProcessIdentifiers = processIdentifiers
+            .prefix(persistentProcessCount)
+            .reversed()
+        let transientProcessIdentifiers = processIdentifiers
+            .dropFirst(persistentProcessCount)
+
+        return Array(persistentProcessIdentifiers) + Array(transientProcessIdentifiers)
+    }
+}

--- a/DockDoor/Utilities/DockAppInstanceOrdering.swift
+++ b/DockDoor/Utilities/DockAppInstanceOrdering.swift
@@ -54,4 +54,45 @@ enum DockAppInstanceOrdering {
 
         return Array(persistentProcessIdentifiers) + Array(transientProcessIdentifiers)
     }
+
+    /// Returns a PID assignment aligned with the matching Dock items. A nil
+    /// entry represents an unoccupied tile whose application instance exited.
+    static func processIdentifiersByDockItem(
+        for runningApplications: [RunningApplicationIdentity],
+        persistentDockItemCount: Int,
+        dockItemRunningStates: [Bool?]
+    ) -> [pid_t?] {
+        let runningDockItemIndices = dockItemRunningStates.indices.filter {
+            dockItemRunningStates[$0] == true
+        }
+
+        // Trust the Accessibility occupancy flags when they account for every
+        // process. Otherwise retain the previous prefix-based behavior while
+        // the Dock and NSWorkspace are between updates.
+        let occupiedDockItemIndices = if runningDockItemIndices.count == runningApplications.count {
+            runningDockItemIndices
+        } else {
+            Array(dockItemRunningStates.indices.prefix(runningApplications.count))
+        }
+        let occupiedPersistentDockItemCount = occupiedDockItemIndices.count {
+            $0 < persistentDockItemCount
+        }
+        let processIdentifiers = processIdentifiers(
+            for: runningApplications,
+            persistentDockItemCount: occupiedPersistentDockItemCount
+        )
+
+        var processIdentifiersByDockItem = [pid_t?](
+            repeating: nil,
+            count: dockItemRunningStates.count
+        )
+        for (dockItemIndex, processIdentifier) in zip(
+            occupiedDockItemIndices,
+            processIdentifiers
+        ) {
+            processIdentifiersByDockItem[dockItemIndex] = processIdentifier
+        }
+
+        return processIdentifiersByDockItem
+    }
 }

--- a/DockDoor/Utilities/DockObserver.swift
+++ b/DockDoor/Utilities/DockObserver.swift
@@ -593,27 +593,26 @@ final class DockObserver {
         return dockChildren
     }
 
-    /// Finds the instance index of a hovered dock item among all dock items with the same bundle identifier.
-    /// This is used to correctly identify which instance of a multi-instance app is being hovered.
-    private func findDockItemInstanceIndex(_ hoveredItem: AXUIElement, bundleIdentifier: String) -> Int? {
+    /// Returns Dock items that share a bundle identifier in their visual order.
+    private func findDockItems(bundleIdentifier: String) -> [AXUIElement] {
         guard let allDockItems = getAllDockItemChildren() else {
-            return nil
+            return []
         }
 
-        // Filter to only AXApplicationDockItems with the same bundle ID
-        var matchingItems: [AXUIElement] = []
-        for item in allDockItems {
+        return allDockItems.filter { item in
             guard (try? item.subrole()) == "AXApplicationDockItem",
                   let itemURL = try? item.attribute(kAXURLAttribute, NSURL.self)?.absoluteURL,
-                  let itemBundle = Bundle(url: itemURL),
-                  itemBundle.bundleIdentifier == bundleIdentifier
-            else {
-                continue
-            }
-            matchingItems.append(item)
+                  let itemBundle = Bundle(url: itemURL)
+            else { return false }
+            return itemBundle.bundleIdentifier == bundleIdentifier
         }
+    }
 
-        // Find the index of the hovered item among matching items
+    /// Finds the hovered item's index among matching Dock items.
+    private func findDockItemInstanceIndex(
+        _ hoveredItem: AXUIElement,
+        matchingItems: [AXUIElement]
+    ) -> Int? {
         for (index, item) in matchingItems.enumerated() {
             if CFEqual(item, hoveredItem) {
                 return index
@@ -648,29 +647,55 @@ final class DockObserver {
 
             let runningApps = NSRunningApplication.runningApplications(withBundleIdentifier: bundleIdentifier)
 
-            // For multiple instances, find the correct one based on dock position
+            // A duplicate persistent tile can be inactive while another tile
+            // for the same bundle still has the sole running process.
+            if runningApps.count == 1,
+               (try? hoveredDockItem.appIsRunning()) == false
+            {
+                return ApplicationReturnType(
+                    status: .notRunning(bundleIdentifier: bundleIdentifier),
+                    dockItemElement: hoveredDockItem
+                )
+            }
+
+            // Resolve separate running and inactive tiles for duplicate bundles.
             if runningApps.count > 1 {
                 let persistentDockItemCount = DockAppInstanceOrdering
                     .persistentDockItemCount(for: bundleIdentifier)
-                let dockOrderedProcessIdentifiers = DockAppInstanceOrdering.processIdentifiers(
+                let matchingItems = findDockItems(bundleIdentifier: bundleIdentifier)
+                let dockItemRunningStates: [Bool?] = matchingItems.map {
+                    try? $0.appIsRunning()
+                }
+                let processIdentifiersByDockItem = DockAppInstanceOrdering.processIdentifiersByDockItem(
                     for: runningApps.map {
                         (processIdentifier: $0.processIdentifier, launchDate: $0.launchDate)
                     },
-                    persistentDockItemCount: persistentDockItemCount
+                    persistentDockItemCount: persistentDockItemCount,
+                    dockItemRunningStates: dockItemRunningStates
                 )
                 if let instanceIndex = findDockItemInstanceIndex(
                     hoveredDockItem,
-                    bundleIdentifier: bundleIdentifier
+                    matchingItems: matchingItems
                 ),
-                    dockOrderedProcessIdentifiers.indices.contains(instanceIndex),
-                    let runningApp = runningApps.first(where: {
-                        $0.processIdentifier == dockOrderedProcessIdentifiers[instanceIndex]
-                    })
+                    processIdentifiersByDockItem.indices.contains(instanceIndex)
                 {
-                    return ApplicationReturnType(
-                        status: .success(runningApp),
-                        dockItemElement: hoveredDockItem
-                    )
+                    if let processIdentifier = processIdentifiersByDockItem[instanceIndex],
+                       let runningApp = runningApps.first(where: {
+                           $0.processIdentifier == processIdentifier
+                       })
+                    {
+                        return ApplicationReturnType(
+                            status: .success(runningApp),
+                            dockItemElement: hoveredDockItem
+                        )
+                    }
+
+                    if dockItemRunningStates[instanceIndex] == false {
+                        return ApplicationReturnType(
+                            status: .notRunning(bundleIdentifier: bundleIdentifier),
+                            dockItemElement: hoveredDockItem
+                        )
+                    }
                 }
             }
 

--- a/DockDoor/Utilities/DockObserver.swift
+++ b/DockDoor/Utilities/DockObserver.swift
@@ -595,9 +595,9 @@ final class DockObserver {
 
     /// Finds the instance index of a hovered dock item among all dock items with the same bundle identifier.
     /// This is used to correctly identify which instance of a multi-instance app is being hovered.
-    private func findDockItemInstanceIndex(_ hoveredItem: AXUIElement, bundleIdentifier: String) -> Int {
+    private func findDockItemInstanceIndex(_ hoveredItem: AXUIElement, bundleIdentifier: String) -> Int? {
         guard let allDockItems = getAllDockItemChildren() else {
-            return 0
+            return nil
         }
 
         // Filter to only AXApplicationDockItems with the same bundle ID
@@ -620,7 +620,7 @@ final class DockObserver {
             }
         }
 
-        return 0
+        return nil
     }
 
     func getDockItemAppStatusUnderMouse() -> ApplicationReturnType {
@@ -650,9 +650,27 @@ final class DockObserver {
 
             // For multiple instances, find the correct one based on dock position
             if runningApps.count > 1 {
-                let instanceIndex = findDockItemInstanceIndex(hoveredDockItem, bundleIdentifier: bundleIdentifier)
-                if instanceIndex < runningApps.count {
-                    return ApplicationReturnType(status: .success(runningApps[instanceIndex]), dockItemElement: hoveredDockItem)
+                let persistentDockItemCount = DockAppInstanceOrdering
+                    .persistentDockItemCount(for: bundleIdentifier)
+                let dockOrderedProcessIdentifiers = DockAppInstanceOrdering.processIdentifiers(
+                    for: runningApps.map {
+                        (processIdentifier: $0.processIdentifier, launchDate: $0.launchDate)
+                    },
+                    persistentDockItemCount: persistentDockItemCount
+                )
+                if let instanceIndex = findDockItemInstanceIndex(
+                    hoveredDockItem,
+                    bundleIdentifier: bundleIdentifier
+                ),
+                    dockOrderedProcessIdentifiers.indices.contains(instanceIndex),
+                    let runningApp = runningApps.first(where: {
+                        $0.processIdentifier == dockOrderedProcessIdentifiers[instanceIndex]
+                    })
+                {
+                    return ApplicationReturnType(
+                        status: .success(runningApp),
+                        dockItemElement: hoveredDockItem
+                    )
                 }
             }
 

--- a/DockDoorTests/DockAppInstanceOrderingTests.swift
+++ b/DockDoorTests/DockAppInstanceOrderingTests.swift
@@ -78,4 +78,67 @@ struct DockAppInstanceOrderingTests {
 
         #expect(processIdentifiers == [101, 202])
     }
+
+    @Test func closedFirstPersistentItemLeavesItsDockPositionEmpty() {
+        let processIdentifiers = DockAppInstanceOrdering.processIdentifiersByDockItem(
+            for: [
+                (processIdentifier: 101, launchDate: olderLaunchDate),
+            ],
+            persistentDockItemCount: 2,
+            dockItemRunningStates: [false, true]
+        )
+
+        #expect(processIdentifiers == [nil, 101])
+    }
+
+    @Test func closedSecondPersistentItemLeavesItsDockPositionEmpty() {
+        let processIdentifiers = DockAppInstanceOrdering.processIdentifiersByDockItem(
+            for: [
+                (processIdentifier: 202, launchDate: newerLaunchDate),
+            ],
+            persistentDockItemCount: 2,
+            dockItemRunningStates: [true, false]
+        )
+
+        #expect(processIdentifiers == [202, nil])
+    }
+
+    @Test func runningPersistentItemsStillUseReverseLaunchOrder() {
+        let processIdentifiers = DockAppInstanceOrdering.processIdentifiersByDockItem(
+            for: [
+                (processIdentifier: 101, launchDate: olderLaunchDate),
+                (processIdentifier: 202, launchDate: newerLaunchDate),
+            ],
+            persistentDockItemCount: 2,
+            dockItemRunningStates: [true, true]
+        )
+
+        #expect(processIdentifiers == [202, 101])
+    }
+
+    @Test func inactivePersistentItemBeforeTransientItemRemainsEmpty() {
+        let processIdentifiers = DockAppInstanceOrdering.processIdentifiersByDockItem(
+            for: [
+                (processIdentifier: 202, launchDate: newerLaunchDate),
+                (processIdentifier: 101, launchDate: olderLaunchDate),
+            ],
+            persistentDockItemCount: 2,
+            dockItemRunningStates: [true, false, true]
+        )
+
+        #expect(processIdentifiers == [101, nil, 202])
+    }
+
+    @Test func unavailableRunningStatesFallBackToDockPrefix() {
+        let processIdentifiers = DockAppInstanceOrdering.processIdentifiersByDockItem(
+            for: [
+                (processIdentifier: 202, launchDate: newerLaunchDate),
+                (processIdentifier: 101, launchDate: olderLaunchDate),
+            ],
+            persistentDockItemCount: 2,
+            dockItemRunningStates: [nil, nil]
+        )
+
+        #expect(processIdentifiers == [202, 101])
+    }
 }

--- a/DockDoorTests/DockAppInstanceOrderingTests.swift
+++ b/DockDoorTests/DockAppInstanceOrderingTests.swift
@@ -1,0 +1,81 @@
+@testable import DockDoor
+import Foundation
+import Testing
+
+struct DockAppInstanceOrderingTests {
+    private let olderLaunchDate = Date(timeIntervalSince1970: 100)
+    private let newerLaunchDate = Date(timeIntervalSince1970: 200)
+
+    @Test func duplicatePersistentItemsUseReverseLaunchOrder() {
+        let processIdentifiers = DockAppInstanceOrdering.processIdentifiers(
+            for: [
+                (processIdentifier: 101, launchDate: olderLaunchDate),
+                (processIdentifier: 202, launchDate: newerLaunchDate),
+            ],
+            persistentDockItemCount: 2
+        )
+
+        #expect(processIdentifiers == [202, 101])
+    }
+
+    @Test func inputOrderDoesNotAffectPersistentItemOrder() {
+        let processIdentifiers = DockAppInstanceOrdering.processIdentifiers(
+            for: [
+                (processIdentifier: 202, launchDate: newerLaunchDate),
+                (processIdentifier: 101, launchDate: olderLaunchDate),
+            ],
+            persistentDockItemCount: 2
+        )
+
+        #expect(processIdentifiers == [202, 101])
+    }
+
+    @Test func transientItemsUseLaunchOrder() {
+        let processIdentifiers = DockAppInstanceOrdering.processIdentifiers(
+            for: [
+                (processIdentifier: 202, launchDate: newerLaunchDate),
+                (processIdentifier: 101, launchDate: olderLaunchDate),
+            ],
+            persistentDockItemCount: 0
+        )
+
+        #expect(processIdentifiers == [101, 202])
+    }
+
+    @Test func onePersistentItemKeepsLaunchOrder() {
+        let processIdentifiers = DockAppInstanceOrdering.processIdentifiers(
+            for: [
+                (processIdentifier: 202, launchDate: newerLaunchDate),
+                (processIdentifier: 101, launchDate: olderLaunchDate),
+            ],
+            persistentDockItemCount: 1
+        )
+
+        #expect(processIdentifiers == [101, 202])
+    }
+
+    @Test func transientItemsFollowTheReversedPersistentPrefix() {
+        let processIdentifiers = DockAppInstanceOrdering.processIdentifiers(
+            for: [
+                (processIdentifier: 303, launchDate: Date(timeIntervalSince1970: 300)),
+                (processIdentifier: 101, launchDate: olderLaunchDate),
+                (processIdentifier: 202, launchDate: newerLaunchDate),
+            ],
+            persistentDockItemCount: 2
+        )
+
+        #expect(processIdentifiers == [202, 101, 303])
+    }
+
+    @Test func missingLaunchDatesUseProcessIdentifiersAsATieBreak() {
+        let processIdentifiers = DockAppInstanceOrdering.processIdentifiers(
+            for: [
+                (processIdentifier: 202, launchDate: nil),
+                (processIdentifier: 101, launchDate: nil),
+            ],
+            persistentDockItemCount: 0
+        )
+
+        #expect(processIdentifiers == [101, 202])
+    }
+}


### PR DESCRIPTION
## Describe your changes
When there's more than one instance of the same app running, and it's being shown as multiple icons in dock, there were multiple issues in the current handling of this case:
1. active app indicator didn't properly detect which instance was active, and it was always highlighting the first one
2. enabling "click to minimize" on dock icons was incorrectly treating switching between different instances as clicks on the same entity so it was hiding the previous one when clicked on the next one
3. active app indicator was showing slide animation when switching between app instances instead of moving indicator instantly to a newly activated entity and showing proper animation (like it does when switching between any other apps).

My changes map duplicate Accessibility Dock items to running applications using launch order and persistent Dock item count instead of relying on NSRunningApplication array order, also I'm using the process identity for active indicator transitions. Added tests for persistent and transient instance ordering.

## Checklist before requesting a review
- [+] I have performed a self-review of my code and understand every line
- [+] If this change affects core functionality, I have added a description highlighting the changes
- [+] I have followed conventional commit guidelines
- [+] I have tested this PR on my own machine

## AI Assistance Disclosure
**Did you use AI tools (ChatGPT, Claude, Copilot, Cursor, etc.) for this PR?**
- [+] Yes - describe below how AI was used and confirm you reviewed/tested the output
Yes, I used Codex with GPT 5.6 Luna Max, it helped me find the exact code to fix the bug I found, I did tested thoroughly on my machine and it works fine
