### PR TITLE
fix: dismiss stale full-size hover previews

### DIFF
--- a/DockDoor/Utilities/KeybindHelper.swift
+++ b/DockDoor/Utilities/KeybindHelper.swift
@@ -980,17 +980,19 @@ class KeybindHelper {
             keyCode == $0.keyCode && modifierFlagsMatch($0.modifierFlags, flags: flags)
         } ?? false
 
-        if previewIsCurrentlyVisible {
-            if keyCode == kVK_Escape, !isExactSwitcherShortcutPressed, !isAlternateShortcutPressed {
-                switcherSessionActive = false
-                return (true, { @MainActor in
-                    self.windowSwitchingCoordinator.cancelSwitching(previewCoordinator: self.previewCoordinator)
-                    self.previewCoordinator.hideWindow()
-                    self.preventSwitcherHideOnRelease = false
-                    self.hasProcessedModifierRelease = true
-                })
-            }
+        if previewIsCurrentlyVisible || snapshot.fullPreviewFrame != nil,
+           keyCode == kVK_Escape, !isExactSwitcherShortcutPressed, !isAlternateShortcutPressed
+        {
+            switcherSessionActive = false
+            return (true, { @MainActor in
+                self.windowSwitchingCoordinator.cancelSwitching(previewCoordinator: self.previewCoordinator)
+                self.previewCoordinator.hideWindow()
+                self.preventSwitcherHideOnRelease = false
+                self.hasProcessedModifierRelease = true
+            })
+        }
 
+        if previewIsCurrentlyVisible {
             if flags.contains(.maskCommand), previewCoordinator.windowSwitcherCoordinator.currIndex >= 0 {
                 if let action = getActionForCmdShortcut(keyCode: keyCode) {
                     preventSwitcherHideOnRelease = true

--- a/DockDoor/Views/Hover Window/Shared Components/SharedPreviewWindowCoordinator.swift
+++ b/DockDoor/Views/Hover Window/Shared Components/SharedPreviewWindowCoordinator.swift
@@ -24,6 +24,7 @@ final class SharedPreviewWindowCoordinator: NSPanel {
     var mouseIsWithinPreviewWindow: Bool = false
     private var onWindowTap: (() -> Void)?
     private var fullPreviewWindow: NSPanel?
+    private var activeFullPreviewHoverID: UUID?
     private var pendingShowWorkItem: DispatchWorkItem?
 
     var windowSize: CGSize = getWindowSize()
@@ -190,11 +191,11 @@ final class SharedPreviewWindowCoordinator: NSPanel {
 
         // Always restore dock auto-hide state, even if the preview isn't visible.
         restoreDockAutoHideState()
+        hideFullPreviewWindow()
 
         guard isVisible else { return }
 
         DragPreviewCoordinator.shared.endDragging()
-        hideFullPreviewWindow()
 
         searchWindow?.hideSearch()
 
@@ -474,6 +475,23 @@ final class SharedPreviewWindowCoordinator: NSPanel {
         }
     }
 
+    func beginFullPreviewHover() -> UUID? {
+        guard isVisible, !windowSwitcherCoordinator.windowSwitcherActive else { return nil }
+        hideFullPreviewWindow()
+        let hoverID = UUID()
+        activeFullPreviewHoverID = hoverID
+        return hoverID
+    }
+
+    func cancelFullPreviewHover(_ hoverID: UUID) {
+        guard activeFullPreviewHoverID == hoverID else { return }
+        hideFullPreviewWindow()
+    }
+
+    func isFullPreviewHoverActive(_ hoverID: UUID?) -> Bool {
+        isVisible && hoverID != nil && activeFullPreviewHoverID == hoverID
+    }
+
     @MainActor
     private func showFullPreviewWindow(for windowInfo: WindowInfo, on screen: NSScreen) {
         if fullPreviewWindow == nil {
@@ -512,6 +530,7 @@ final class SharedPreviewWindowCoordinator: NSPanel {
 
     @MainActor
     func hideFullPreviewWindow() {
+        activeFullPreviewHoverID = nil
         fullPreviewWindow?.orderOut(nil)
         if let currentFullPreviewContent = fullPreviewWindow?.contentView {
             currentFullPreviewContent.removeFromSuperview()
@@ -828,15 +847,13 @@ final class SharedPreviewWindowCoordinator: NSPanel {
         let shouldCenterOnScreen = centeredHoverWindowState != .none
 
         let screen = mouseScreen ?? NSScreen.main!
-        hideFullPreviewWindow()
-
-        if centeredHoverWindowState == .fullWindowPreview,
-           let windowInfo = windows.first,
-           let windowPosition = try? windowInfo.axElement.position(),
-           let windowScreen = windowPosition.screen()
-        {
+        if centeredHoverWindowState == .fullWindowPreview {
+            guard let windowInfo = windows.first,
+                  let windowPosition = try? windowInfo.axElement.position(),
+                  let windowScreen = windowPosition.screen() else { return }
             showFullPreviewWindow(for: windowInfo, on: windowScreen)
         } else {
+            hideFullPreviewWindow()
             self.appName = appName
             let activeDockPosition = dockPositionOverride ?? DockUtils.getDockPosition()
             currentDockPosition = activeDockPosition
@@ -1059,10 +1076,14 @@ final class SharedPreviewWindowCoordinator: NSPanel {
                     onWindowTap: (() -> Void)? = nil, bundleIdentifier: String? = nil,
                     bypassDockMouseValidation: Bool = false,
                     dockPositionOverride: DockPosition? = nil, initialIndex: Int? = nil,
-                    dockItemFrameOverride: CGRect? = nil)
+                    dockItemFrameOverride: CGRect? = nil, fullPreviewHoverID: UUID? = nil)
     {
         let renderStartTime = CFAbsoluteTimeGetCurrent()
         DebugLogger.log("PreviewRender", details: "showWindow called: \(windows.count) windows for \(appName)")
+
+        if centeredHoverWindowState == .fullWindowPreview, !isFullPreviewHoverActive(fullPreviewHoverID) {
+            return
+        }
 
         let shouldSkipDelay = overrideDelay || (Defaults[.useDelayOnlyForInitialOpen] && isVisible)
         let delay = shouldSkipDelay ? 0 : Defaults[.hoverWindowOpenDelay]
@@ -1102,6 +1123,9 @@ final class SharedPreviewWindowCoordinator: NSPanel {
             }
 
             Task { @MainActor [weak self] in
+                if centeredHoverWindowState == .fullWindowPreview, self?.isFullPreviewHoverActive(fullPreviewHoverID) != true {
+                    return
+                }
                 self?.performDisplay(appName: appName, windows: windows, mouseLocation: mouseLocation, mouseScreen: mouseScreen, dockItemElement: dockItemElement, centeredHoverWindowState: centeredHoverWindowState, onWindowTap: onWindowTap, bundleIdentifier: bundleIdentifier, dockPositionOverride: dockPositionOverride, initialIndex: initialIndex, dockItemFrameOverride: dockItemFrameOverride, renderStartTime: renderStartTime)
             }
         }

--- a/DockDoor/Views/Hover Window/WindowPreview.swift
+++ b/DockDoor/Views/Hover Window/WindowPreview.swift
@@ -913,13 +913,18 @@ struct WindowPreview: View, Equatable {
             .fixedSize()
             .opacity(skeletonMode ? 0 : 1)
             .allowsHitTesting(!skeletonMode && !mockPreviewActive)
+            .onDisappear {
+                cancelFullPreviewHover()
+            }
     }
 
     private func cancelFullPreviewHover() {
         fullPreviewTimer?.invalidate()
         fullPreviewTimer = nil
+        if let hoverID = fullPreviewHoverID {
+            SharedPreviewWindowCoordinator.activeInstance?.cancelFullPreviewHover(hoverID)
+        }
         fullPreviewHoverID = nil
-        SharedPreviewWindowCoordinator.activeInstance?.hideFullPreviewWindow()
     }
 
     private func handleFullPreviewHover(isHovering: Bool, action: PreviewHoverAction) {
@@ -935,16 +940,18 @@ struct WindowPreview: View, Equatable {
                 }
 
             case .previewFullSize:
-                let hoverID = UUID()
+                guard let coordinator = SharedPreviewWindowCoordinator.activeInstance,
+                      let hoverID = coordinator.beginFullPreviewHover() else { return }
                 fullPreviewHoverID = hoverID
                 let showFullPreview = {
                     guard fullPreviewHoverID == hoverID else { return }
-                    SharedPreviewWindowCoordinator.activeInstance?.showWindow(
+                    coordinator.showWindow(
                         appName: windowInfo.app.localizedName ?? "Unknown",
                         windows: [windowInfo],
                         mouseScreen: bestGuessMonitor,
                         dockItemElement: nil, overrideDelay: true,
-                        centeredHoverWindowState: .fullWindowPreview
+                        centeredHoverWindowState: .fullWindowPreview,
+                        fullPreviewHoverID: hoverID
                     )
                 }
                 if appearance.tapEquivalentInterval == 0 {


### PR DESCRIPTION
## Describe your changes

I've run into this bug for a long time and kept hoping an update would fix it. It seemed random, but I finally reproduced it reliably with a debugging script.

To reproduce:

1. Select “Present a full size preview of the window” with a 0.3-second delay.
2. Hover over Calculator in the Dock, then move onto its thumbnail.
3. Press Escape within 0.1–0.25 seconds, keeping the pointer still.
4. The thumbnail closes, but the full-size preview appears and stays stuck—even after another Escape.

This fix cancels stale hover requests and lets Escape dismiss the full-size preview independently.

Validation: 38 tests passed, including six local regression tests. Native input replay passed 12 timing and dismissal scenarios, with additional visual checks. I haven't included the test script or local regression tests in this PR; let me know if you'd like them.

## Related issue number(s) and link(s)

None linked.

## Checklist before requesting a review

- [x] I have performed a self-review of my code and understand every line
- [x] If this change affects core functionality, I have added a description highlighting the changes
- [x] I have followed conventional commit guidelines
- [x] I have tested this PR on my own machine

## AI Assistance Disclosure

**Did you use AI tools (ChatGPT, Claude, Copilot, Cursor, etc.) for this PR?**
- [ ] No AI tools were used
- [x] Yes - describe below how AI was used and confirm you reviewed/tested the output

Codex helped reproduce the bug, implement the fix, run tests, and draft this description. I reviewed the code, understand the changes, and tested them on my own machine.

## Core Functionality Changes

Delayed full-size previews require an active hover on a visible thumbnail panel. Dismissal invalidates pending requests; Escape also closes a remaining full-size preview.
